### PR TITLE
Add to content type templates

### DIFF
--- a/_templates/content-type/new/cy.feature.t
+++ b/_templates/content-type/new/cy.feature.t
@@ -1,0 +1,14 @@
+---
+to: examples/nuxt-app/test/features/<%= h.changeCase.paramCase(name) %>/<%= h.changeCase.paramCase(name) %>.feature
+---
+
+Feature: <%= h.changeCase.sentenceCase(name) %> page
+
+  Example of mocked page
+
+  Example: On load
+    Given the mock server has started
+    And the endpoint "/api/tide/page" with query "?path=/sample-<%= h.changeCase.paramCase(name) %>&site=8888" returns fixture "/<%= h.changeCase.paramCase(name) %>/sample-<%= h.changeCase.paramCase(name) %>" with status 200
+    And the endpoint "/api/tide/site" with query "?id=8888" returns fixture "/site/reference" with status 200
+    Given I visit the page "/sample-<%= h.changeCase.paramCase(name) %>"
+    Then the title should be "Sample <%= h.changeCase.sentenceCase(name) %>"

--- a/_templates/content-type/new/cy.ts.t
+++ b/_templates/content-type/new/cy.ts.t
@@ -1,0 +1,9 @@
+---
+to: examples/nuxt-app/test/features/<%= h.changeCase.paramCase(name) %>/<%= h.changeCase.paramCase(name) %>.ts
+---
+
+import { Then } from '@badeball/cypress-cucumber-preprocessor'
+
+Then('the title should be {string}', (title: string) => {
+  cy.get('[data-cy="title"]').should('have.text', title)
+})

--- a/_templates/content-type/new/fixture.json.t
+++ b/_templates/content-type/new/fixture.json.t
@@ -1,0 +1,15 @@
+---
+to: examples/nuxt-app/test/fixtures/<%= h.changeCase.paramCase(name) %>/sample-<%= h.changeCase.paramCase(name) %>.json
+---
+{
+  "title": "Sample <%= h.changeCase.sentenceCase(name) %>",
+  "changed": "2022-09-15T15:14:30+10:00",
+  "created": "2022-09-15T15:14:30+10:00",
+  "type": "<%= h.changeCase.paramCase(name) %>",
+  "nid": "2526ba4a-e12b-4fbd-a15a-38ac2528b922",
+  "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus.",
+  "header": {
+    "title": "Sample <%= h.changeCase.sentenceCase(name) %>",
+    "summary": "news intro test"
+  }
+}

--- a/_templates/content-type/new/index.ts.t
+++ b/_templates/content-type/new/index.ts.t
@@ -16,6 +16,10 @@ const tide<%= h.changeCase.pascalCase(name) %>Module: RplTideMapping = {
       withSidebarContacts: true,
       withSidebarRelatedLinks: true
     }),
+    header: {
+      title: 'title',
+      summary: 'field_landing_page_intro_text'
+    },
     summary: 'field_landing_page_summary',
   },
   includes: [

--- a/_templates/content-type/new/index.ts.t
+++ b/_templates/content-type/new/index.ts.t
@@ -13,8 +13,8 @@ const tide<%= h.changeCase.pascalCase(name) %>Module: RplTideMapping = {
   schema: '@dpc-sdp/ripple-tide-<%= h.changeCase.paramCase(name) %>/types',
   mapping: {
     ...tidePageBaseMapping({
-      withSidebarContacts: true,
-      withSidebarRelatedLinks: true
+      withSidebarContacts: false,
+      withSidebarRelatedLinks: false
     }),
     header: {
       title: 'title',
@@ -24,8 +24,8 @@ const tide<%= h.changeCase.pascalCase(name) %>Module: RplTideMapping = {
   },
   includes: [
     ...tidePageBaseIncludes({
-      withSidebarContacts: true,
-      withSidebarRelatedLinks: true
+      withSidebarContacts: false,
+      withSidebarRelatedLinks: false
     }),
   ]
 }

--- a/_templates/content-type/new/index.vue.t
+++ b/_templates/content-type/new/index.vue.t
@@ -35,6 +35,7 @@ export default { name: 'Tide<%= h.changeCase.pascalCase(name) %>Page' }
 <script setup lang="ts">
 import type Tide<%= h.changeCase.pascalCase(name) %>Page from './../types'
 import { RplLayout } from '@dpc-sdp/ripple-ui-core'
+import Tide<%= h.changeCase.pascalCase(name) %>Header from './components/tide-<%= h.changeCase.paramCase(name) %>-header.vue'
 
 interface Props {
   page: Tide<%= h.changeCase.pascalCase(name) %>Page

--- a/_templates/content-type/new/index.vue.t
+++ b/_templates/content-type/new/index.vue.t
@@ -2,16 +2,43 @@
 to: packages/ripple-tide-<%= h.changeCase.paramCase(name) %>/src/index.vue
 ---
 
+<script lang="ts">
+export default { name: 'Tide<%= h.changeCase.pascalCase(name) %>Page' }
+</script>
+
 <template>
-  <div>
-    <h1>{{ page.title }}</h1>
-  </div>
+  <RplLayout :background="page.background">
+    <template #aboveHeader>
+      <slot name="aboveHeader"></slot>
+    </template>
+    <template #primaryNav>
+      <slot name="primaryNav"></slot>
+    </template>
+    <template #breadcrumbs>
+      <slot name="breadcrumbs"></slot>
+    </template>
+    <template #aboveBody>
+      <Tide<%= h.changeCase.pascalCase(name) %>Header :header="page.header"></Tide<%= h.changeCase.pascalCase(name) %>Header>
+    </template>
+    <template #body>
+
+    </template>
+    <template #sidebar>
+      <slot name="sidebar"></slot>
+    </template>
+    <template #footer>
+      <slot name="footer"></slot>
+    </template>
+  </RplLayout>
 </template>
 
 <script setup lang="ts">
 import type Tide<%= h.changeCase.pascalCase(name) %>Page from './../types'
+import { RplLayout } from '@dpc-sdp/ripple-ui-core'
 
-defineProps<{
+interface Props {
   page: Tide<%= h.changeCase.pascalCase(name) %>Page
-}>()
+}
+
+defineProps<Props>()
 </script>

--- a/_templates/content-type/new/nuxt.ts.t
+++ b/_templates/content-type/new/nuxt.ts.t
@@ -1,0 +1,20 @@
+---
+to: packages/ripple-tide-<%= h.changeCase.paramCase(name) %>/src/nuxt.ts
+---
+
+import { join } from 'pathe'
+import { defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  hooks: {
+    'components:dirs'(dirs) {
+      console.log('Added Tide <%= h.changeCase.pascalCase(name) %> UI components')
+      dirs.push({
+        extensions: ['vue'],
+        path: join(__dirname, './components'),
+        prefix: 'Tide<%= h.changeCase.pascalCase(name) %>',
+        global: true
+      })
+    }
+  }
+})

--- a/_templates/content-type/new/package.json.t
+++ b/_templates/content-type/new/package.json.t
@@ -12,7 +12,8 @@ to: packages/ripple-tide-<%= h.changeCase.paramCase(name) %>/package.json
   "exports": {
     ".": "./dist/index.js",
     "./component": "./src/index.vue",
-    "./types": "./types.d.ts"
+    "./types": "./types.d.ts",
+    "./nuxt": "./src/nuxt.ts"
   },
   "license": "MIT",
   "keywords": [],

--- a/_templates/content-type/new/stories.mdx.t
+++ b/_templates/content-type/new/stories.mdx.t
@@ -8,7 +8,7 @@ import {
   Story
 } from '@storybook/addon-docs'
 
-// import fixture from '../../../examples/nuxt-app/test/fixtures/<%= h.changeCase.paramCase(name) %>/url-of-reference-node.json'
+import fixture from '../../../examples/nuxt-app/test/fixtures/<%= h.changeCase.paramCase(name) %>/sample-<%= h.changeCase.paramCase(name) %>.json'
 import MockPage from '../../ripple-ui-core/stories/components/mock-page.vue'
 import Tide<%= h.changeCase.pascalCase(name) %>Page from './index.vue'
 

--- a/_templates/content-type/new/stories.mdx.t
+++ b/_templates/content-type/new/stories.mdx.t
@@ -1,0 +1,61 @@
+---
+to: packages/ripple-tide-<%= h.changeCase.paramCase(name) %>/src/<%= h.changeCase.paramCase(name) %>.stories.mdx
+---
+
+import {
+  Canvas,
+  Meta,
+  Story
+} from '@storybook/addon-docs'
+
+// import fixture from '../../../examples/nuxt-app/test/fixtures/<%= h.changeCase.paramCase(name) %>/url-of-reference-node.json'
+import MockPage from '../../ripple-ui-core/stories/components/mock-page.vue'
+import Tide<%= h.changeCase.pascalCase(name) %>Page from './index.vue'
+
+export const <%= h.changeCase.pascalCase(name) %>Template = (args) => ({
+  components: {
+    MockPage
+  },
+  setup() {
+    return { args }
+  },
+  template: `<MockPage v-bind="args"></MockPage>`
+})
+
+<Meta
+  title='<%= h.changeCase.sentenceCase(name) %>/Template'
+  component={Tide<%= h.changeCase.pascalCase(name) %>Page}
+  argTypes={{
+    componentName: { table: { disable: true } },
+    pageComponent: { table: { disable: true } },
+    aboveHeader: { table: { disable: true } },
+    primaryNav: { table: { disable: true } },
+    sidebar: { table: { disable: true } },
+    footer: { table: { disable: true } },
+    default: { table: { disable: true } }
+  }}
+  args={{
+    componentName: 'Tide<%= h.changeCase.pascalCase(name) %>',
+    pageComponent: Tide<%= h.changeCase.pascalCase(name) %>Page,
+    url: 'https://www.vic.gov.au',
+    breadcrumbs: {
+      items: [
+        { label: 'Home', url: '/' },
+        { label: '<%= h.changeCase.sentenceCase(name) %>', url: '/<%= h.changeCase.paramCase(name) %>' }
+      ]
+    },
+    site: {},
+    page: fixture
+  }}
+  parameters={{
+    layout: 'fullscreen'
+  }}
+/>
+
+# <%= h.changeCase.sentenceCase(name) %>
+
+<Canvas>
+  <Story name='Template'>
+    {<%= h.changeCase.pascalCase(name) %>Template.bind()}
+  </Story>
+</Canvas>

--- a/_templates/content-type/new/tide-header.vue.t
+++ b/_templates/content-type/new/tide-header.vue.t
@@ -1,0 +1,28 @@
+---
+to: packages/ripple-tide-<%= h.changeCase.paramCase(name) %>/src/components/tide-<%= h.changeCase.paramCase(name) %>-header.vue
+---
+
+<script lang="ts">
+export default { name: 'Tide<%= h.changeCase.pascalCase(name) %>Header' }
+</script>
+
+<template>
+  <RplHeroHeader
+    :corner-top="true"
+    :corner-bottom="true"
+    :behind-nav="true"
+    :breadcrumbs="true"
+    :title="header.title"
+  >
+    <p class="rpl-type-p-large">{{ header.summary }}</p>
+  </RplHeroHeader>
+</template>
+
+<script setup lang="ts">
+import type { Tide<%= h.changeCase.pascalCase(name) %>Header } from '../../types'
+import { RplHeroHeader } from '@dpc-sdp/ripple-ui-core'
+
+defineProps<{
+  header: Tide<%= h.changeCase.pascalCase(name) %>Header
+}>()
+</script>

--- a/_templates/content-type/new/types.d.ts.t
+++ b/_templates/content-type/new/types.d.ts.t
@@ -4,10 +4,15 @@ to: packages/ripple-tide-<%= h.changeCase.paramCase(name) %>/types.d.ts
 
 import type { TidePageBase } from '@dpc-sdp/ripple-tide-api/types'
 
+export type Tide<%= h.changeCase.pascalCase(name) %>Header = {
+  title: string
+  summary: string
+}
+
 export default interface Tide<%= h.changeCase.pascalCase(name) %>Page extends TidePageBase {
   /**
    * @description Example field - change this to your own!
    * @example 'Hello world from Tide<%= h.changeCase.pascalCase(name) %>Page'
    */
-  example: String
+  header: Tide<%= h.changeCase.pascalCase(name) %>Header
 }

--- a/examples/nuxt-app/test/features/site/theme.feature
+++ b/examples/nuxt-app/test/features/site/theme.feature
@@ -8,7 +8,7 @@ Feature: Site theme
     Given the endpoint "/api/tide/site" with query "?id=8888" returns fixture "/site/reference" with status 200
     And the endpoint "/api/tide/page" with query "?path=/&site=8888" returns fixture "/landingpage/home" with status 200
     Given I visit the page "/"
-    Then the site header background color should be "rgb(175, 39, 46)"
+    Then the site header background color should be "rgb(128, 0, 128)"
 
   @mockserver
   Scenario: Alternate Theme

--- a/examples/nuxt-app/test/features/site/theme.feature
+++ b/examples/nuxt-app/test/features/site/theme.feature
@@ -2,7 +2,7 @@ Feature: Site theme
 
   As a site admin I can change the theme colours in the backend and they will populate to the site.
 
-  @mockserverwithproxy
+  @mockserver
   Scenario: Default Theme
     Given the mock server has started with proxy
     Given the endpoint "/api/tide/site" with query "?id=8888" returns fixture "/site/reference" with status 200


### PR DESCRIPTION
### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add storybook, layout, sample wrapper component to hygen templates for creating a new content type

These updates build out a working SFC in the content type module, and demonstrate the patterns for:
- Mapping fields to props
- Defining prop interfaces
- Wrapping components

And you get a nice shiny page to start with, the only manual step is adding the module in config on the nuxt app.

**UPDATE**

- Sidebar components default to `false` in mapping (can't be guaranteed that the data exists)
- Scaffold for cypress tests, cucumber and fixture added to hygen templates

![Screen Shot 2022-10-20 at 4 11 43 pm](https://user-images.githubusercontent.com/863542/196861636-10206902-72a7-478d-a2be-d8ce4244287a.png)

