### PR TITLE
ci: add step to update reference site after publish to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,22 @@ jobs:
             npm config set access public
             npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
             yarn release:publish
+
+  update-reference:
+    steps:
+      - run:
+        name: Kick off new pipeline
+        command: |
+          curl --location --request POST 'https://circleci.com/api/v2/project/github/dpc-sdp/reference-sdp-vic-gov-au/pipeline' \
+          --header 'Content-Type: application/json' \
+          -u "${CIRCLECI_API_TOKEN}:"
+          --data-raw '{
+                  "branch": "'v2'",
+                  "parameters": {
+                      "update": true,
+                  }
+              }'
+
 workflows:
   commit:
     jobs:
@@ -203,6 +219,9 @@ workflows:
             branches:
               only:
                 - develop
+      - update-reference:
+          requires:
+            - publish-alpha
       - publish:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,19 +170,20 @@ jobs:
             yarn release:publish
 
   update-reference:
+    <<: *defaults
     steps:
       - run:
-        name: Kick off new pipeline
-        command: |
-          curl --location --request POST 'https://circleci.com/api/v2/project/github/dpc-sdp/reference-sdp-vic-gov-au/pipeline' \
-          --header 'Content-Type: application/json' \
-          -u "${CIRCLECI_API_TOKEN}:"
-          --data-raw '{
-                  "branch": "'v2'",
-                  "parameters": {
-                      "update": true,
-                  }
-              }'
+          name: Kick off new pipeline
+          command: |
+            curl --location --request POST 'https://circleci.com/api/v2/project/github/dpc-sdp/reference-sdp-vic-gov-au/pipeline' \
+            --header 'Content-Type: application/json' \
+            -u "${CIRCLECI_API_TOKEN}:"
+            --data-raw '{
+                    "branch": "'v2'",
+                    "parameters": {
+                        "update": true,
+                    }
+                }'
 
 workflows:
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
             --data-raw '{
                     "branch": "'v2'",
                     "parameters": {
-                        "update": true,
+                        "update": true
                     }
                 }'
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Adds step in CI to update reference site after successful publish to NPM
- 

### How to test
<!-- Summary of how to test  -->
- Can't be tested in PR
- On merge to develop - update-v2 pipeline should kick off https://app.circleci.com/pipelines/github/dpc-sdp/reference-sdp-vic-gov-au/119/workflows/8a0484bc-4f11-49a9-a7b5-1e8020fe1618

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

