### PR TITLE
[R20-142] add margin to topic tags

### DIFF
--- a/packages/ripple-tide-api/src/nuxt/components/BaseLayout.vue
+++ b/packages/ripple-tide-api/src/nuxt/components/BaseLayout.vue
@@ -34,7 +34,7 @@
     </template>
     <template #body="{ hasSidebar }">
       <slot name="body" :hasSidebar="hasSidebar"></slot>
-      <div data-cy="topic-tags">
+      <div data-cy="topic-tags" class="rpl-u-margin-t-6">
         <RplChip
           v-for="tag in topicTags"
           :key="tag.url"


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-142

### What I did
<!-- Summary of changes made in the Pull Request  -->
- add margin to topic tags (same margin as updated date)

### Screenshots
<img width="541" alt="Screenshot 2022-12-06 at 3 37 14 pm" src="https://user-images.githubusercontent.com/287178/205816624-bae2ebd3-a889-40bd-9ca3-f44d58b427ee.png">

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

