### PR TITLE
fix: remove nuxt.js export from ripple-tide-api

### DIFF
--- a/packages/ripple-tide-api/package.json
+++ b/packages/ripple-tide-api/package.json
@@ -8,7 +8,6 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
-    "./nuxt": "./dist/nuxt.js",
     "./types": "./types.d.ts",
     "./errors": "./dist/errors/errors.js",
     "./components": "./dist/nuxt/components",


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

