### PR TITLE
build: :wrench: ignore storybook build in build-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "storybook": "pnpm -F ripple-storybook start",
     "dev": "pnpm build && concurrently \"pnpm storybook\" \"pnpm -F nuxt-app dev\"",
     "clean": "git clean -dfx && git reset --hard && pnpm",
-    "build": "lerna run build --ignore docs",
+    "build": "lerna run build --ignore '{docs,ripple-storybook}'",
     "build:ripple": "lerna run build --scope '{@dpc-sdp/ripple-ui-*,@dpc-sdp/ripple-tide-api}'",
     "build:examples": "lerna run build --scope '{nuxt-app,vue-app,webcomponents}'",
     "build:docs": "lerna run build --scope docs",


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What happened
<!-- Summary of changes made in the Pull Request  -->
- lerna clears out all `dist` before building, but seems like it was trying to build `ripple-storybook` before `ripple-ui-core` was built. It doesn't need to happen here anyway, the static build is only needed for testing and chromatic, and is included in those steps.

### How to test
<!-- Summary of how to test  -->
- `pnpm build`
