### PR TITLE
fix(@dpc-sdp/ripple-ui-core): fix aside cta link to display focus sta…

### DIFF
--- a/packages/ripple-ui-core/src/components/header/RplHeader.css
+++ b/packages/ripple-ui-core/src/components/header/RplHeader.css
@@ -58,6 +58,10 @@
     transform: translateX(var(--rpl-sp-1));
   }
 
+  &:focus-visible .rpl-icon {
+    color: inherit;
+  }
+
   &:active {
     text-decoration: underline;
   }

--- a/packages/ripple-ui-core/src/components/header/RplHeaderActions.css
+++ b/packages/ripple-ui-core/src/components/header/RplHeaderActions.css
@@ -43,10 +43,6 @@
     letter-spacing: var(--rpl-type-ls-2);
   }
 
-  &:focus-visible .rpl-icon {
-    color: inherit;
-  }
-
   .rpl-icon--size-xs {
     @media (--rpl-bp-l) {
       --rpl-icon-size: var(--rpl-sp-4);

--- a/packages/ripple-ui-core/src/components/header/RplHeaderLinks.css
+++ b/packages/ripple-ui-core/src/components/header/RplHeaderLinks.css
@@ -7,6 +7,7 @@
 
     color: var(--local-clr-link, var(--rpl-clr-link));
     white-space: nowrap;
+    display: inline;
   }
 
   .rpl-list__label,

--- a/packages/ripple-ui-core/src/components/header/RplHeaderLinks.vue
+++ b/packages/ripple-ui-core/src/components/header/RplHeaderLinks.vue
@@ -28,14 +28,15 @@ withDefaults(defineProps<Props>(), {
       item-class="rpl-header-links__item rpl-header__text-large-fixed rpl-type-p"
       icon-placement="after"
     />
-    <RplTextLink
-      v-if="moreLink"
-      :url="moreLink.url"
-      class="rpl-header__text-large-fixed rpl-header__icon-link rpl-header-links__more rpl-type-p rpl-type-weight-bold"
-    >
-      <span>{{ moreLink.text }}</span
-      ><RplIcon name="icon-arrow-right" size="xs" />
-    </RplTextLink>
+    <div v-if="moreLink" class="rpl-header-links__more">
+      <RplTextLink
+        :url="moreLink.url"
+        class="rpl-header__text-large-fixed rpl-header__icon-link rpl-type-p rpl-type-weight-bold"
+      >
+        <span>{{ moreLink.text }}</span
+        ><RplIcon name="icon-arrow-right" size="xs" />
+      </RplTextLink>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-330

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Updated the CTA journey link so it's focus state is inline like the other journey links

### How to test
<!-- Summary of how to test  -->
-  See storybook

### Screenshot
<img width="1388" alt="Screenshot 2023-02-21 at 11 26 35 am" src="https://user-images.githubusercontent.com/287178/220217310-71b76183-ec08-4e92-acee-ee94498095f0.png">



<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

