### PR TITLE
[R20-519] use alwaysSearchOnInitialLoad instead of mounted

### DIFF
--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -89,7 +89,7 @@
 import { useHead, useSiteTheme, useAppConfig, useRoute } from '#imports'
 import { RplChip } from '#components'
 import { computed, onMounted, provide, ref } from 'vue'
-import deepmerge from 'deepmerge'
+import { deepmerge } from 'deepmerge-ts'
 import { TideSiteData } from '../types'
 import { TideTopicTag } from '../mapping/topic-tags/topic-tags-mapping'
 import { TideSiteSection } from '@dpc-sdp/ripple-tide-api/types'

--- a/packages/nuxt-ripple/package.json
+++ b/packages/nuxt-ripple/package.json
@@ -10,6 +10,6 @@
     "@dpc-sdp/ripple-ui-forms": "workspace:*",
     "@vueuse/core": "^9.12.0",
     "change-case": "^4.1.2",
-    "deepmerge": "^4.3.0"
+    "deepmerge-ts": "^4.3.0"
   }
 }

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -41,7 +41,7 @@
 
 <script setup lang="ts">
 import { formatDate, useTideSearch, useRuntimeConfig } from '#imports'
-import { computed, inject, onMounted } from 'vue'
+import { computed, inject } from 'vue'
 import {
   IContentCollectionDisplay,
   IContentCollectionFilter,
@@ -107,6 +107,7 @@ const searchResultsMappingFn = (item): any => {
 
 const searchDriverOptions = {
   trackUrlState: false,
+  alwaysSearchOnInitialLoad: true,
   initialState: {
     resultsPerPage: props.perPage,
     sortList: [
@@ -146,12 +147,10 @@ const searchDriverOptions = {
   }
 }
 
-const { doSearch, results } = await useTideSearch(
+const { results } = await useTideSearch(
   apiConnectorOptions,
   searchDriverOptions,
   [],
   searchResultsMappingFn
 )
-
-onMounted(() => doSearch())
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,14 +249,14 @@ importers:
       '@dpc-sdp/ripple-ui-forms': workspace:*
       '@vueuse/core': ^9.12.0
       change-case: ^4.1.2
-      deepmerge: ^4.3.0
+      deepmerge-ts: ^4.3.0
     dependencies:
       '@dpc-sdp/ripple-tide-api': link:../ripple-tide-api
       '@dpc-sdp/ripple-ui-core': link:../ripple-ui-core
       '@dpc-sdp/ripple-ui-forms': link:../ripple-ui-forms
       '@vueuse/core': 9.12.0_vue@3.2.47
       change-case: 4.1.2
-      deepmerge: 4.3.0
+      deepmerge-ts: 4.3.0
 
   packages/nuxt-ripple-cli:
     specifiers:
@@ -9609,7 +9609,7 @@ packages:
       '@babel/core': 7.20.12
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.75.0
+      webpack: 5.75.0_esbuild@0.16.17
     dev: true
 
   /babel-messages/6.23.0:
@@ -12223,6 +12223,11 @@ packages:
   /deep-object-diff/1.1.9:
     resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
     dev: true
+
+  /deepmerge-ts/4.3.0:
+    resolution: {integrity: sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==}
+    engines: {node: '>=12.4.0'}
+    dev: false
 
   /deepmerge/4.3.0:
     resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-357

### What I did
<!-- Summary of changes made in the Pull Request  -->
- use alwaysSearchOnInitialLoad instead of mounted for consistency with search
- drop-in more modern ts version of deepmerge

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

