### PR TITLE
fix(@dpc-sdp/ripple-ui-core): allow a single timeline element

### DIFF
--- a/packages/ripple-ui-core/src/components/timeline/RplTimeline.css
+++ b/packages/ripple-ui-core/src/components/timeline/RplTimeline.css
@@ -66,6 +66,16 @@
       }
     }
 
+    &:only-child {
+      padding-left: 0;
+      border-left-width: 0;
+
+      &::before,
+      &::after {
+        display: none;
+      }
+    }
+
     &-image {
       display: block;
       height: var(--local-img-height);

--- a/packages/ripple-ui-core/src/components/timeline/RplTimeline.vue
+++ b/packages/ripple-ui-core/src/components/timeline/RplTimeline.vue
@@ -56,7 +56,7 @@ const classes = (item: IRplTimelineItem, index: number) => {
     <h2 v-if="title" class="rpl-type-h2-fixed rpl-timeline__heading">
       {{ title }}
     </h2>
-    <ul v-if="items.length > 1" class="rpl-timeline__items rpl-type-p">
+    <ul v-if="items.length > 0" class="rpl-timeline__items rpl-type-p">
       <li
         v-for="(item, index) of items"
         :key="index"


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-566

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Allow for a single timeline element to be displayed 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

