### PR TITLE
[R20-759] Stopped all links are forcing a full refresh instead of using client side navigation

### DIFF
--- a/docs/components/app/AppNavbar.vue
+++ b/docs/components/app/AppNavbar.vue
@@ -47,6 +47,8 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('keydown', escapeKeyHandler, false)
+  deactivateFocusTrap()
+  document.body.classList.remove('rpl-u-viewport-locked')
 })
 </script>
 

--- a/examples/nuxt-app/test/features/landingpage/forms.feature
+++ b/examples/nuxt-app/test/features/landingpage/forms.feature
@@ -46,11 +46,11 @@ Feature: Forms
     Then the error summary should not display
     When I submit the form with ID "full_form"
     Then the error summary should display with the following errors
-      | text                           | url                 |
-      | You must enter your first name | #first_name         |
-      | The message field is required  | #message            |
-      | Must choose a favourite colour | #favourite_colour   |
-      | You must accept the terms      | #i_accept_the_terms |
+      | text                           | url                              |
+      | You must enter your first name | /kitchen-sink#first_name         |
+      | The message field is required  | /kitchen-sink#message            |
+      | Must choose a favourite colour | /kitchen-sink#favourite_colour   |
+      | You must accept the terms      | /kitchen-sink#i_accept_the_terms |
     Then clicking on an error summary link with text "Must choose a favourite colour" should focus on the input with ID "favourite_colour"
 
   @mockserver

--- a/examples/nuxt-app/test/features/landingpage/home.feature
+++ b/examples/nuxt-app/test/features/landingpage/home.feature
@@ -45,11 +45,11 @@ Feature: Home page
   @mockserver
   Scenario: In page nav
     Then the in page nav should have the following items
-      | text                 | url                 |
-      | Content Anchor 1     | #content-anchor-1   |
-      | Content Anchor 2     | #content-anchor-2   |
-      | Test accordion title | #page-component-972 |
-      | Test timeline title  | #page-component-992 |
+      | text                 | url                  |
+      | Content Anchor 1     | /#content-anchor-1   |
+      | Content Anchor 2     | /#content-anchor-2   |
+      | Test accordion title | /#page-component-972 |
+      | Test timeline title  | /#page-component-992 |
 
   @mockserver
   Scenario: Header component - Intro banner

--- a/packages/nuxt-ripple/components/TideContentPage.vue
+++ b/packages/nuxt-ripple/components/TideContentPage.vue
@@ -79,7 +79,9 @@ if (pageError.value || !page.value) {
         <p>Have a look at the web address to make sure it was typed correctly. We may also have deleted this page.</p>
         <p>If none of our suggestions help you find the information you were looking for, please <a href="/connect-with-us" class="rpl-text-link rpl-u-focusable-inline">contact us</a>.</p>
       `,
-    data: JSON.stringify({ site: unref(site) })
+    data: JSON.stringify({ site: unref(site) }),
+    // Needs to be a fatal error in order to trigger a proper 404 page when this error occurs client side
+    fatal: true
   })
 }
 

--- a/packages/nuxt-ripple/components/TideContentRating.vue
+++ b/packages/nuxt-ripple/components/TideContentRating.vue
@@ -73,7 +73,7 @@ onMounted(() => {
                   <RplContent>
                     <p>
                       If you need a response, please use our
-                      <a href="/contact-us">contact us form</a>.
+                      <RplLink href="/contact-us">contact us form</RplLink>.
                     </p>
                   </RplContent>
                   <FormKit type="RplFormActions" />

--- a/packages/nuxt-ripple/components/global/RplLink.vue
+++ b/packages/nuxt-ripple/components/global/RplLink.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+interface IRplLinkProps {
+  url: string
+  analytics?: {
+    eventName: string
+  }
+}
+
+withDefaults(defineProps<IRplLinkProps>(), {})
+</script>
+
+<template>
+  <NuxtLink ref="link" :href="url">
+    <slot />
+  </NuxtLink>
+</template>

--- a/packages/nuxt-ripple/components/global/RplLink.vue
+++ b/packages/nuxt-ripple/components/global/RplLink.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
 interface IRplLinkProps {
   url: string
-  analytics?: {
-    eventName: string
-  }
 }
 
 withDefaults(defineProps<IRplLinkProps>(), {})

--- a/packages/ripple-storybook/.storybook/preview.js
+++ b/packages/ripple-storybook/.storybook/preview.js
@@ -2,7 +2,7 @@ import { withCssResources } from '@storybook/addon-cssresources'
 import { withDesign } from 'storybook-addon-designs'
 import { app } from '@storybook/vue3'
 import { registerRplFormPlugin } from '@dpc-sdp/ripple-ui-forms'
-import { RplIconSprite } from '@dpc-sdp/ripple-ui-core/vue'
+import { RplIconSprite, RplLink } from '@dpc-sdp/ripple-ui-core/vue'
 import '@dpc-sdp/ripple-ui-core/style'
 import themes from './themes.js'
 import withBackground from './utils/withBackground'
@@ -17,6 +17,8 @@ window.svgPlaceholder = svgPlaceholder
 
 // Ripple vue plugins
 registerRplFormPlugin(app)
+
+app.component('RplLink', RplLink)
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/packages/ripple-ui-core/src/components.ts
+++ b/packages/ripple-ui-core/src/components.ts
@@ -48,6 +48,8 @@ export { default as RplCardGrid } from './components/layout/RplCardGrid.vue'
 
 export { default as RplList } from './components/list/RplList.vue'
 
+export { default as RplLink } from './components/link/RplLink.vue'
+
 export { default as RplPageAction } from './components/page-action/RplPageAction.vue'
 export { default as RplPageLinks } from './components/page-links/RplPageLinks.vue'
 export { default as RplPrimaryNav } from './components/primary-nav/RplPrimaryNav.vue'

--- a/packages/ripple-ui-core/src/components/card/RplPromoCard.vue
+++ b/packages/ripple-ui-core/src/components/card/RplPromoCard.vue
@@ -15,7 +15,7 @@ interface Props {
   url?: string
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   el: 'div',
   highlight: false,
   image: undefined,

--- a/packages/ripple-ui-core/src/components/chip/RplChip.vue
+++ b/packages/ripple-ui-core/src/components/chip/RplChip.vue
@@ -22,12 +22,13 @@ const onClick = (payload?: any) => {
 </script>
 
 <template>
-  <a
+  <RplLink
     :class="`rpl-chip rpl-chip--${variant} rpl-type-label rpl-u-focusable-block rpl-u-screen-only`"
-    :href="url"
+    :url="url"
     @click="onClick()"
-    >{{ label }}</a
   >
+    {{ label }}
+  </RplLink>
 </template>
 
 <style src="./RplChip.css" />

--- a/packages/ripple-ui-core/src/components/footer/RplFooter.vue
+++ b/packages/ripple-ui-core/src/components/footer/RplFooter.vue
@@ -186,25 +186,25 @@ const columns = computed(() => {
           </div>
         </div>
         <div class="rpl-footer-bottom__branding">
-          <a
+          <RplLink
             v-for="(logoLink, index) in logos"
             :key="index"
             class="rpl-footer-logo-link rpl-u-focusable-outline rpl-u-focusable--alt-colour"
-            :href="logoLink.url"
+            :url="logoLink.url"
           >
             <RplImage
               class="rpl-footer-logo-link__img"
               :src="logoLink.src"
               :alt="logoLink.alt"
             />
-          </a>
-          <a
+          </RplLink>
+          <RplLink
             class="rpl-footer-logo-link rpl-u-focusable-outline rpl-u-focusable-outline--no-border rpl-u-focusable--alt-colour"
-            :href="vicGovHomeUrl"
+            :url="vicGovHomeUrl"
           >
             <span class="rpl-u-visually-hidden">{{ vicGovHomeLabel }}</span>
             <VicGovLogo class="rpl-footer-vic-gov-logo" />
-          </a>
+          </RplLink>
         </div>
       </div>
     </div>

--- a/packages/ripple-ui-core/src/components/link/RplLink.vue
+++ b/packages/ripple-ui-core/src/components/link/RplLink.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+interface IRplLinkProps {
+  url: string
+}
+
+withDefaults(defineProps<IRplLinkProps>(), {})
+</script>
+
+<template>
+  <a :href="url">
+    <slot />
+  </a>
+</template>

--- a/packages/ripple-ui-core/src/components/modal/RplModal.vue
+++ b/packages/ripple-ui-core/src/components/modal/RplModal.vue
@@ -50,6 +50,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('keydown', escapeKeyHandler, false)
+  document.body.classList.remove('rpl-u-viewport-locked', 'rpl-modal-open')
 })
 </script>
 

--- a/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.vue
@@ -75,6 +75,9 @@ onUnmounted(() => {
   window.removeEventListener('scroll', handleScroll)
 
   window.removeEventListener('keydown', handleEscapeKey, false)
+
+  document.body.classList.remove('rpl-u-viewport-locked')
+  deactivateFocusTrap()
 })
 
 const toggleNavItem = (level: 1 | 2 | 3, item: IRplPrimaryNavItem) => {

--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuAction.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuAction.vue
@@ -38,7 +38,7 @@ const isActive = computed(() => {
 
 <template>
   <component
-    :is="type === 'toggle' ? 'button' : 'a'"
+    :is="type === 'toggle' ? 'button' : 'RplLink'"
     :class="{
       'rpl-primary-nav__mega-menu-action': true,
       'rpl-primary-nav__mega-menu-action--toggle': type === 'toggle',
@@ -47,7 +47,7 @@ const isActive = computed(() => {
       'rpl-u-focusable-block': true,
       'rpl-type-p-small': true
     }"
-    :href="type == 'link' ? item.url : undefined"
+    :url="type == 'link' ? item.url : undefined"
     @click="clickHandler(item)"
   >
     <span class="rpl-primary-nav__mega-menu-action-text">{{ item.text }}</span>

--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuList.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuList.vue
@@ -26,15 +26,15 @@ withDefaults(defineProps<Props>(), {
   >
     <!-- 'Home' link - Only visible on mobile -->
     <li v-if="level == 1">
-      <a
+      <RplLink
         class="rpl-primary-nav__mega-menu-action rpl-primary-nav__mega-menu-action--home rpl-u-focusable-block rpl-type-p-small"
-        href="/"
+        url="/"
       >
         <span class="rpl-primary-nav__mega-menu-action-icon rpl-u-margin-r-2">
           <RplIcon name="icon-home" size="s" />
         </span>
         <span class="rpl-primary-nav__mega-menu-action-text">Home</span>
-      </a>
+      </RplLink>
     </li>
 
     <!-- Repeat of parent as a clickable link -->

--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
@@ -39,9 +39,9 @@ defineProps<Props>()
       }"
     >
       <!-- Primary logo -->
-      <a
+      <RplLink
         class="rpl-primary-nav__primary-logo-link rpl-u-focusable-outline rpl-u-focusable-outline--no-border"
-        :href="primaryLogo.href"
+        :url="primaryLogo.href"
       >
         <img
           class="rpl-primary-nav__primary-logo-image rpl-u-screen-only"
@@ -54,16 +54,16 @@ defineProps<Props>()
           :src="primaryLogo.printSrc"
           :alt="primaryLogo.altText"
         />
-      </a>
+      </RplLink>
 
       <!-- Logo divider -->
       <div v-if="secondaryLogo" class="rpl-primary-nav__logo-divider"></div>
 
       <!-- Secondary logo -->
-      <a
+      <RplLink
         v-if="secondaryLogo"
         class="rpl-primary-nav__secondary-logo-link rpl-u-focusable-outline rpl-u-focusable-outline--no-border"
-        :href="secondaryLogo.href"
+        :url="secondaryLogo.href"
       >
         <img
           class="rpl-primary-nav__secondary-logo-image rpl-u-screen-only"
@@ -76,7 +76,7 @@ defineProps<Props>()
           :src="secondaryLogo.printSrc"
           :alt="secondaryLogo.altText"
         />
-      </a>
+      </RplLink>
     </div>
 
     <ul class="rpl-primary-nav__nav-bar-actions-list">

--- a/packages/ripple-ui-core/src/components/text-link/RplTextLink.vue
+++ b/packages/ripple-ui-core/src/components/text-link/RplTextLink.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ref, Ref } from 'vue'
 import { rplEventBus } from '../../index'
 
 rplEventBus.register('rpl-text-link/click')
@@ -9,26 +8,22 @@ interface Props {
   text?: string
 }
 
-const props = defineProps<Props>()
+defineProps<Props>()
 
 const onClick = (payload?: any) => {
   rplEventBus.emit('rpl-text-link/click', payload)
 }
-
-const link: Ref = ref(null)
-
-defineExpose({ link })
 </script>
 
 <template>
-  <a
+  <RplLink
     ref="link"
     class="rpl-text-link rpl-u-focusable-inline"
-    :href="url"
+    :url="url"
     @click="onClick"
   >
     <slot>{{ text }}</slot>
-  </a>
+  </RplLink>
 </template>
 
 <style src="./RplTextLink.css" />

--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavLink.vue
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavLink.vue
@@ -13,8 +13,8 @@ withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
-  <a
-    :href="href"
+  <RplLink
+    :url="href"
     :class="{
       'rpl-vertical-nav__item': true,
       'rpl-vertical-nav__item--active': active,
@@ -24,5 +24,5 @@ withDefaults(defineProps<Props>(), {
   >
     <span v-if="showChildIcon" class="rpl-icon--child"></span>
     <span>{{ text }}</span>
-  </a>
+  </RplLink>
 </template>

--- a/packages/ripple-ui-core/src/composables/useAccessibleContainer.ts
+++ b/packages/ripple-ui-core/src/composables/useAccessibleContainer.ts
@@ -33,8 +33,7 @@ export function useAccessibleContainer() {
       // Add 200ms delay to allow text selection
       if (up - down < 200) {
         // Only fire a click if the target is not the trigger el
-        // Note, the link can also be nested, so we need to check so said 'nested' ref
-        const clickedElement = trigger.value?.link || trigger.value
+        const clickedElement = container.value.$el.querySelector('a')
 
         if (clickedElement !== e.target) {
           clickedElement.click()


### PR DESCRIPTION


<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: R20-759

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Added RplLink as a placeholder that can be replaced with NuxtLink etc.
- Used RplLink wherever a plain anchor tag was used
- Fixed 404 page not appearing on client side navigation
- Fixed some event listeners and classes not being cleaned up properly on client side navigation

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

