### PR TITLE
[R20-776] fix(@dpc-sdp/ripple-ui-core): changed 'view transcript' to open in same window

### DIFF
--- a/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
+++ b/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
@@ -112,7 +112,7 @@ const pluginEmbededVideo = function (this: any) {
 
       const transcriptMarkup = link
         ? `<div class="rpl-media-embed__actions-list">
-        <a class="rpl-text-link rpl-u-focusable-inline rpl-media-embed__transcript-link rpl-media-embed__action rpl-u-focusable-inline rpl-type-p" href="${link}" target="_blank">
+        <a class="rpl-text-link rpl-u-focusable-inline rpl-media-embed__transcript-link rpl-media-embed__action rpl-u-focusable-inline rpl-type-p" href="${link}">
           <span class="rpl-icon rpl-icon--size-s rpl-icon--icon-view">
             <svg role="presentation"><use xlink:href="#icon-view"></use></svg>
           </span>View transcript

--- a/packages/ripple-ui-core/src/components/media-embed/RplMediaEmbed.vue
+++ b/packages/ripple-ui-core/src/components/media-embed/RplMediaEmbed.vue
@@ -151,7 +151,6 @@ const isActionsListEmpty = computed(() => {
       <li v-if="transcriptUrl">
         <RplTextLink
           class="rpl-media-embed__transcript-link rpl-media-embed__action rpl-u-focusable-inline rpl-type-p"
-          target="_blank"
           :url="transcriptUrl"
         >
           <RplIcon name="icon-view" />View transcript


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

