### PR TITLE
fix(@dpc-sdp/ripple-ui-core): allow click through on overflowing camp…

### DIFF
--- a/packages/ripple-ui-core/src/components/campaign-banner/RplCampaignBanner.css
+++ b/packages/ripple-ui-core/src/components/campaign-banner/RplCampaignBanner.css
@@ -25,6 +25,8 @@
 }
 
 .rpl-campaign-banner__media {
+  pointer-events: none;
+
   .rpl-image {
     width: 100%;
     height: auto;


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Allow click through on overflowing campaign images

<img width="1097" alt="Screenshot 2023-03-16 at 10 52 07 am" src="https://user-images.githubusercontent.com/287178/225469698-000f1650-8233-4f01-bc6c-4978796b2b37.png">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

