### PR TITLE
fix(nuxt-ripple): moved alert script to base layout and fixed regex issue

### DIFF
--- a/packages/nuxt-ripple/app.vue
+++ b/packages/nuxt-ripple/app.vue
@@ -3,16 +3,3 @@
     <NuxtPage />
   </NuxtLayout>
 </template>
-
-<script setup lang="ts">
-import { useHead } from '#imports'
-import hideAlertsOnLoadScript from './utils/hideAlertsOnLoadScript.js'
-
-useHead({
-  script: [
-    {
-      innerHTML: hideAlertsOnLoadScript
-    }
-  ]
-})
-</script>

--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -86,6 +86,7 @@ import { deepmerge } from 'deepmerge-ts'
 import { TideSiteData } from '../types'
 import { TideTopicTag } from '../mapping/base/topic-tags/topic-tags-mapping'
 import { TideSiteSection } from '@dpc-sdp/ripple-tide-api/types'
+import hideAlertsOnLoadScript from '../utils/hideAlertsOnLoadScript.js'
 
 interface Props {
   site: TideSiteData
@@ -150,6 +151,11 @@ useHead({
     {
       name: 'description',
       content: props.pageDescription
+    }
+  ],
+  script: [
+    {
+      innerHTML: hideAlertsOnLoadScript
     }
   ]
 })

--- a/packages/nuxt-ripple/utils/hideAlertsOnLoadScript.ts
+++ b/packages/nuxt-ripple/utils/hideAlertsOnLoadScript.ts
@@ -20,7 +20,7 @@ const hideAlertsOnLoadScript = `function getCookie(name) {
 }
 
 const DISMISSED_ALERTS_COOKIE = 'dismissedAlerts'
-const guidRegex = new RegExp('^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$', 'g')
+const guidRegex = new RegExp('^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
 
 try {
   const cookieValue = getCookie(DISMISSED_ALERTS_COOKIE)


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- The script wasn't getting included in the reference site because it was providing its own `app.vue`
- Moved to TideBaseLayout
- Removed global flag from guid regex causing every second alert not to be hidden

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

