### PR TITLE
feat(docs): added DocsImageExample to docs site

### DIFF
--- a/docs/components/content/DocsImageExample.vue
+++ b/docs/components/content/DocsImageExample.vue
@@ -1,0 +1,44 @@
+<template>
+  <figure class="docs-example">
+    <div class="docs-example-body">
+      <img :src="src" :alt="alt" />
+    </div>
+    <div class="docs-example-footer" v-if="$slots.default">
+      <figcaption>
+        <ContentSlot :use="$slots.default" unwrap="p" />
+      </figcaption>
+    </div>
+  </figure>
+</template>
+
+<script lang="ts" setup>
+interface Props {
+  src: string
+  alt: string
+}
+
+withDefaults(defineProps<Props>(), {})
+</script>
+
+<style scoped>
+@import '@dpc-sdp/ripple-ui-core/style/breakpoints';
+.docs-example {
+  border: var(--rpl-border-1) solid var(--rpl-clr-neutral-300);
+  background: white;
+
+  margin: var(--rpl-sp-3) 0;
+
+  @media (--rpl-bp-l) {
+    margin: var(--rpl-sp-4) 0;
+  }
+}
+
+.docs-example-body {
+  padding: var(--rpl-sp-5);
+}
+
+.docs-example-footer {
+  border-top: var(--rpl-border-1) solid var(--rpl-clr-neutral-300);
+  padding: var(--rpl-sp-3) var(--rpl-sp-5);
+}
+</style>

--- a/docs/content/design-system/Kitchen sink.md
+++ b/docs/content/design-system/Kitchen sink.md
@@ -417,6 +417,46 @@ You can wrap `DocsExample` components with a `DocsThemeChooser` component. This 
   ::
 ::
 
+### DocsImageExample
+
+The `DocsImageExample` will display an image in a way this is visually similar to the component examples, you will need to give it the url (src) of the image, the alt text (alt) and an optional caption.
+
+```md
+::DocsImageExample
+---
+src: /assets/img/InlineLink-Focus.png
+alt: An example of focus state colour contrast
+---
+Here's the **rich** text `caption`
+::
+```
+
+::DocsImageExample
+---
+src: /assets/img/InlineLink-Focus.png
+alt: An example of focus state colour contrast
+---
+Here's the **rich** text `caption`
+::
+
+Example without caption:
+
+```md
+::DocsImageExample
+---
+src: /assets/img/InlineLink-Focus.png
+alt: An example of focus state colour contrast
+---
+::
+```
+
+::DocsImageExample
+---
+src: /assets/img/InlineLink-Focus.png
+alt: An example of focus state colour contrast
+---
+::
+
 ### DocsCard && DocsCardGrid
 
 Cards can also be added. Ensure that you wrap them with DocsCardGrid so that they are layout out correctly. DocsCard use the 'promo' type card under the hood.


### PR DESCRIPTION
used for making static images look like component examples

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

