### PR TITLE
fix(@dpc-sdp/nuxt-ripple): fixed intermittent crash caused by nuxt cache reactivity set to null

### DIFF
--- a/packages/nuxt-ripple/composables/use-tide-page.ts
+++ b/packages/nuxt-ripple/composables/use-tide-page.ts
@@ -36,9 +36,7 @@ export const useTidePage = async (
       if (process.dev) {
         console.log('Cache reset for page', `page-${path}`)
       }
-      refreshNuxtData(`page-${path}`)
-      // unset this so we refetch
-      pageData.value = null
+      await clearNuxtData(`page-${path}`)
     }
   }
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Setting `pageData.value = null` was actually updating the cache, which meant that when we called `useFetch` again, nuxt was not calling the API again, but instead served up what it thought was the cached value (which was null, which caused the page to be blank
- This happened intermittently because it was only happening when the nuxt cache was older than 5 minutes
- The crashes will stop happening once you get a cache miss in section, and therefore a new _fetched timestamp in the nuxt cache. After 5 minutes the crashes start again.

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

