### PR TITLE
[R20-811] make sure expanded content is visible

### DIFF
--- a/packages/ripple-ui-core/src/components/expandable/RplExpandable.vue
+++ b/packages/ripple-ui-core/src/components/expandable/RplExpandable.vue
@@ -14,7 +14,6 @@ const DEFAULT_DURATION = 420
 
 const containerRef = ref(null)
 const duration = ref(DEFAULT_DURATION)
-const transitionComplete = ref(false)
 
 onMounted(() => {
   duration.value =
@@ -40,12 +39,12 @@ function onEnter(el, done) {
 
 function onAfterEnter(el) {
   el.style.height = 'auto'
-  transitionComplete.value = true
+  el.style.overflow = 'initial'
 }
 
 function onBeforeLeave(el) {
   el.style.height = `${el.getBoundingClientRect().height}px`
-  transitionComplete.value = false
+  el.style.overflow = 'hidden'
 }
 
 // called when the leave transition starts.
@@ -60,7 +59,6 @@ function onLeave(el, done) {
 const classes = computed(() => ({
   'rpl-expandable': true,
   [`rpl-expandable--open`]: props.expanded,
-  [`rpl-expandable--expanded`]: transitionComplete.value
 }))
 </script>
 
@@ -85,11 +83,8 @@ const classes = computed(() => ({
 
 <style>
 .rpl-expandable {
+  overflow: hidden;
   transition: height var(--rpl-motion-speed-9) ease-out;
-
-  &:not(.rpl-expandable--expanded) {
-    overflow: hidden;
-  }
 
   @media print {
     /* Needs to override inline styles */


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-811

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Make sure expanded content is always visible, i.e. when screen size changes or device is rotated and when inner elements break outside of the expanded container.

### Screenshots
<img width="1859" alt="Screenshot 2023-03-31 at 1 48 15 pm" src="https://user-images.githubusercontent.com/287178/229013606-2c4b5bc4-6245-4e88-b89e-6cbb46834b60.png">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

