### PR TITLE
[R20-706] don't set background when higher contra…

### DIFF
--- a/packages/ripple-ui-core/src/components/layout/RplLayout.css
+++ b/packages/ripple-ui-core/src/components/layout/RplLayout.css
@@ -34,10 +34,12 @@
   }
 }
 
-@media not (prefers-contrast: more) {
-  .rpl-layout--alt .rpl-layout__body-wrap {
+.rpl-layout--alt .rpl-layout__body-wrap {
     background-color: var(--rpl-clr-neutral-100);
-  }
+
+    @media (prefers-contrast: more) {
+      background-color: var(--rpl-clr-neutral-0);
+    }
 }
 
 .rpl-layout__header {

--- a/packages/ripple-ui-core/src/components/layout/RplLayout.css
+++ b/packages/ripple-ui-core/src/components/layout/RplLayout.css
@@ -34,8 +34,8 @@
   }
 }
 
-.rpl-layout--alt {
-  .rpl-layout__body-wrap {
+@media not (prefers-contrast: more) {
+  .rpl-layout--alt .rpl-layout__body-wrap {
     background-color: var(--rpl-clr-neutral-100);
   }
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-706

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Don't set background when higher contrast is requested


### How to test
<!-- Summary of how to test  -->
- Add the alt background to a page and enable high contrast mode

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

