### PR TITLE
[R20-737] Use same namespace for theme vars

### DIFF
--- a/examples/nuxt-app/app.config.ts
+++ b/examples/nuxt-app/app.config.ts
@@ -16,9 +16,7 @@ export default defineAppConfig({
       'rpl-clr-gradient-horizontal':
         'linear-gradient(90deg, #382484 0%, #5A0099 20%, #7623B0 35%, #2E7478 50%, #2FA26F 70%, #2FCE6A 80%)',
       'rpl-clr-gradient-vertical':
-        'linear-gradient(180deg, #382484 0%, #5A0099 20%, #7623B0 35%, #2E7478 50%, #2FA26F 70%, #2FCE6A 80%)',
-      'rpl-clr-footer-alt': '#6B19A3',
-      'rpl-clr-footer': '#3F006B'
+        'linear-gradient(180deg, #382484 0%, #5A0099 20%, #7623B0 35%, #2E7478 50%, #2FA26F 70%, #2FCE6A 80%)'
     }
   }
 })

--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -144,7 +144,7 @@ useHead({
   title: props.pageTitle,
   style: style && [
     {
-      children: `body { ${style} }`
+      children: `:root, body { ${style} }`
     }
   ],
   link: [


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-737

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Theme vars were using `body` but token vars are on `:root`
- It actually needs to be on both, or there's a visible flash on "un-themed" content while the page loads

### How to test
<!-- Summary of how to test  -->
- nuxt-app
- Will need to update the app config on reference to confirm

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

