### PR TITLE
[R20-846] use highlight for promo cards

### DIFF
--- a/packages/ripple-tide-api/src/utils/mapping-utils.ts
+++ b/packages/ripple-tide-api/src/utils/mapping-utils.ts
@@ -56,7 +56,7 @@ export const getCardImageFromField = (
   path: string | string[]
 ): TideImageField | null => {
   const image = get(field, path)
-  return image ? getCardImage(image) : null
+  return image && !Array.isArray(image) ? getCardImage(image) : null
 }
 
 export const getMediaImage = (

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/PromoCard.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/PromoCard.vue
@@ -4,7 +4,7 @@
     :title="title"
     :image="displayStyle !== 'noImage' ? image : null"
     :url="url"
-    :highlight="displayStyle === 'noImage'"
+    :highlight="displayStyle === 'noImage' || !image"
   >
     <p>{{ summary }}</p>
     <template v-if="showMetadata" #meta>


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-846

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Use highlight for promo cards when no image is supplied


### How to test
<img width="306" alt="Screenshot 2023-04-05 at 4 18 38 pm" src="https://user-images.githubusercontent.com/287178/230004178-504cced9-b75b-4a1d-a44d-1276294aa470.png">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

