### PR TITLE
[R20-855] add tab support for primary nav

### DIFF
--- a/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.vue
@@ -1,16 +1,25 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, useSlots } from 'vue'
+import {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  onUnmounted,
+  useSlots,
+  provide
+} from 'vue'
 import type { Ref } from 'vue'
-import { useElementBounding } from '@vueuse/core'
+import { useBreakpoints, useElementBounding } from '@vueuse/core'
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 import RplPrimaryNavBar from './components/nav-bar/RplPrimaryNavBar.vue'
 import RplPrimaryNavMegaMenu from './components/mega-menu/RplPrimaryNavMegaMenu.vue'
 import RplPrimaryNavSearchForm from './components/search-form/RplPrimaryNavSearchForm.vue'
-
+import { bpMin } from '../../lib/breakpoints'
 import {
   IRplPrimaryNavLogo,
   IRplPrimaryNavItem,
-  IRplPrimaryNavActiveItems
+  IRplPrimaryNavActiveItems,
+  IRplPrimaryNavFocusOptions
 } from './constants'
 
 interface Props {
@@ -33,7 +42,12 @@ const navContainer = ref()
 const { activate: activateFocusTrap, deactivate: deactivateFocusTrap } =
   useFocusTrap(navContainer)
 const { top: navOffest } = useElementBounding(navContainer)
+const bp = useBreakpoints(bpMin)
 
+const isLargeScreen = bp.greaterOrEqual('l')
+const isXLargeScreen = bp.greaterOrEqual('xl')
+
+const focus: Ref<string> = ref('')
 const isHidden: Ref<boolean> = ref(false)
 const isFixed: Ref<boolean> = ref(false)
 const scrollPosition: Ref<number> = ref(0)
@@ -96,11 +110,14 @@ const toggleNavItem = (
   }
 
   if (level == 1) {
+    const keepNavOpen = open || (navCollapse.value.collapsed && level === 1)
+
     // Make search inactive
     isSearchActive.value = false
 
     // If the target item is now active, make sure the mega nav is also active
-    isMegaNavActive.value = open || activeNavItems.value.level1?.id == item.id
+    isMegaNavActive.value =
+      keepNavOpen || activeNavItems.value.level1?.id == item.id
 
     // Clear any active sub menus
     activeNavItems.value.level2 = undefined
@@ -155,6 +172,30 @@ watch(isExpanded, (newValue) => {
   }
 })
 
+// Determine when the collapsed version of the nav bar appears
+// supplementary elements are counted in nav bar total, i.e. search, userActions and secondaryLogo
+const navCollapse = computed(() => {
+  let collapsed = true
+  let breakpoint = 'default'
+  let count = props?.items?.length || 0
+
+  if (props.showSearch) count++
+  if (slots.userAction) count++
+  if (props.secondaryLogo) count++
+
+  if (count <= 6) {
+    breakpoint = 'l'
+    collapsed = !isLargeScreen.value
+  } else if (count === 7) {
+    breakpoint = 'xl'
+    collapsed = !isXLargeScreen.value
+  } else if (count > 7) {
+    breakpoint = 'always'
+  }
+
+  return { breakpoint, collapsed }
+})
+
 const classList = computed(() => {
   const classes = ['rpl-primary-nav']
 
@@ -170,24 +211,21 @@ const classList = computed(() => {
     classes.push('rpl-primary-nav--expanded')
   }
 
-  let itemCount = props?.items?.length || 0
-
-  if (props.showSearch) itemCount++
-  if (slots.userAction) itemCount++
-  if (props.secondaryLogo) itemCount++
-
-  // Add classes to control when the desktop version of the nav bar appears
-  // supplementary elements are counted too, i.e. search, userActions and secondaryLogo
-  if (itemCount <= 6) {
-    classes.push('rpl-primary-nav--collapse-until-l')
-  } else if (itemCount === 7) {
-    classes.push('rpl-primary-nav--collapse-until-xl')
-  } else if (itemCount > 7) {
-    classes.push('rpl-primary-nav--collapse-always')
-  }
+  classes.push(
+    `rpl-primary-nav--collapse-until-${navCollapse.value.breakpoint}`
+  )
 
   return classes.join(' ')
 })
+
+const navFocus: IRplPrimaryNavFocusOptions = {
+  focus,
+  setFocus: (target: string) => (focus.value = target),
+  navCollapsed: navCollapse.value.collapsed,
+  hasQuickExit: props.showQuickExit,
+  hasUserActions: Boolean(slots.userAction)
+}
+provide('navFocus', navFocus)
 </script>
 
 <template>

--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenu.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenu.vue
@@ -6,14 +6,14 @@ import RplPrimaryNavQuickExit from '../quick-exit/RplPrimaryNavQuickExit.vue'
 import {
   IRplPrimaryNavItem,
   IRplPrimaryNavActiveItems,
-  IRplPrimaryNavToggleItemOptions
+  RplPrimaryNavToggleItemOptions
 } from '../../constants'
 
 interface Props {
   items: IRplPrimaryNavItem[]
   showQuickExit: boolean
   activeNavItems: IRplPrimaryNavActiveItems
-  toggleItem: (...args: IRplPrimaryNavToggleItemOptions) => void
+  toggleItem: (...args: RplPrimaryNavToggleItemOptions) => void
 }
 
 const props = withDefaults(defineProps<Props>(), {})
@@ -70,7 +70,9 @@ const backButtonHandler = () => {
       v-if="showQuickExit || hasUserActions"
       class="rpl-primary-nav__mega-menu-quick-links"
     >
-      <li v-if="showQuickExit"><RplPrimaryNavQuickExit /></li>
+      <li v-if="showQuickExit">
+        <RplPrimaryNavQuickExit :parent="activeNavItems.level1?.id" />
+      </li>
       <li v-if="hasUserActions" class="rpl-primary-nav__mega-menu-user-action">
         <slot name="userAction"></slot>
       </li>

--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuAction.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuAction.vue
@@ -1,29 +1,62 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import {
   IRplPrimaryNavItem,
   IRplPrimaryNavActiveItems,
-  IRplPrimaryNavToggleItemOptions
+  RplPrimaryNavToggleItemOptions
 } from '../../constants'
 import RplIcon from '../../../icon/RplIcon.vue'
+import { usePrimaryNavFocus } from '../../../../composables/usePrimaryNavFocus'
 
 interface Props {
   item: IRplPrimaryNavItem
+  parent?: string
   type: 'toggle' | 'link'
-  level?: 1 | 2 | 3 | 4
+  level: 1 | 2 | 3 | 4
+  position?: 'first' | 'last'
   activeNavItems?: IRplPrimaryNavActiveItems
-  toggleItem?: (...args: IRplPrimaryNavToggleItemOptions) => void
+  toggleItem?: (...args: RplPrimaryNavToggleItemOptions) => void
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  level: undefined,
+  parent: undefined,
+  position: undefined,
   activeNavItems: undefined,
   toggleItem: undefined
 })
 
+const action = ref(null)
+
+const { setFocus, navCollapsed } = usePrimaryNavFocus(
+  action,
+  `list:${props.level}:${props.item.id}`
+)
+
 const clickHandler = (item: IRplPrimaryNavItem) => {
   if (props.type == 'toggle' && props.level != 4) {
     props.toggleItem(props.level, item)
+  }
+}
+
+const focusHandler = (event) => {
+  const next = props.level + 1
+  const previous = props.level - 1
+
+  if (event.shiftKey && props.position === 'first') {
+    event.preventDefault()
+    props.toggleItem(previous, props.item)
+    setFocus(`list:${previous}:${props.item.id}`)
+  } else if (!event.shiftKey && isActive.value && props.item?.items) {
+    event.preventDefault()
+    setFocus(`list:${next}:${props.item.id}`)
+  } else if (!event.shiftKey && props.position === 'last') {
+    event.preventDefault()
+    props.toggleItem(previous, props.activeNavItems?.['level' + previous])
+    setFocus(
+      navCollapsed && props.level === 1
+        ? 'menu:toggle'
+        : `list:${previous}:${props?.parent}`
+    )
   }
 }
 
@@ -43,6 +76,7 @@ const isActive = computed(() => {
 <template>
   <component
     :is="type === 'toggle' ? 'button' : 'RplLink'"
+    ref="action"
     :class="{
       'rpl-primary-nav__mega-menu-action': true,
       'rpl-primary-nav__mega-menu-action--toggle': type === 'toggle',
@@ -53,6 +87,7 @@ const isActive = computed(() => {
     }"
     :url="type == 'link' ? item.url : undefined"
     @click="clickHandler(item)"
+    @keydown.tab="focusHandler"
   >
     <span class="rpl-primary-nav__mega-menu-action-text">{{ item.text }}</span>
     <span class="rpl-primary-nav__mega-menu-action-icon rpl-u-margin-l-5">

--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuHomeButton.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuHomeButton.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import RplIcon from '../../../icon/RplIcon.vue'
+import { usePrimaryNavFocus } from '../../../../composables/usePrimaryNavFocus'
+import { ref } from 'vue'
+
+const home = ref(null)
+
+const { setFocus } = usePrimaryNavFocus(home, 'list:home')
+
+const handleFocus = () => setFocus('menu:toggle')
+</script>
+
+<template>
+  <RplLink
+    ref="home"
+    class="rpl-primary-nav__mega-menu-action rpl-primary-nav__mega-menu-action--home rpl-u-focusable-block rpl-type-p-small"
+    url="/"
+    @keydown.shift.tab.exact.prevent="handleFocus"
+  >
+    <span class="rpl-primary-nav__mega-menu-action-icon rpl-u-margin-r-2">
+      <RplIcon name="icon-home" size="s" />
+    </span>
+    <span class="rpl-primary-nav__mega-menu-action-text">Home</span>
+  </RplLink>
+</template>

--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuList.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuList.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import RplIcon from '../../../icon/RplIcon.vue'
 import RplPrimaryNavMegaMenuAction from './RplPrimaryNavMegaMenuAction.vue'
 import {
   IRplPrimaryNavItem,
   IRplPrimaryNavActiveItems,
-  IRplPrimaryNavToggleItemOptions
+  RplPrimaryNavToggleItemOptions
 } from '../../constants'
+import RplPrimaryNavMegaMenuHomeButton from './RplPrimaryNavMegaMenuHomeButton.vue'
 
 interface Props {
   parent?: IRplPrimaryNavItem
   items: IRplPrimaryNavItem[]
   level: 1 | 2 | 3 | 4
   activeNavItems: IRplPrimaryNavActiveItems
-  toggleItem?: (...args: IRplPrimaryNavToggleItemOptions) => void
+  toggleItem?: (...args: RplPrimaryNavToggleItemOptions) => void
 }
 
 withDefaults(defineProps<Props>(), {
@@ -30,28 +30,28 @@ withDefaults(defineProps<Props>(), {
   >
     <!-- 'Home' link - Only visible on mobile -->
     <li v-if="level == 1">
-      <RplLink
-        class="rpl-primary-nav__mega-menu-action rpl-primary-nav__mega-menu-action--home rpl-u-focusable-block rpl-type-p-small"
-        url="/"
-      >
-        <span class="rpl-primary-nav__mega-menu-action-icon rpl-u-margin-r-2">
-          <RplIcon name="icon-home" size="s" />
-        </span>
-        <span class="rpl-primary-nav__mega-menu-action-text">Home</span>
-      </RplLink>
+      <RplPrimaryNavMegaMenuHomeButton />
     </li>
 
     <!-- Repeat of parent as a clickable link -->
     <li v-if="parent" class="rpl-primary-nav__mega-menu-item">
-      <RplPrimaryNavMegaMenuAction :item="parent" type="link" />
+      <RplPrimaryNavMegaMenuAction
+        :item="parent"
+        :level="level"
+        position="first"
+        type="link"
+        :toggle-item="toggleItem"
+      />
     </li>
 
     <!-- Children -->
-    <li v-for="child in items" :key="child.id">
+    <li v-for="(child, i) in items" :key="child.id">
       <RplPrimaryNavMegaMenuAction
         :item="child"
         :type="child.items?.length ? 'toggle' : 'link'"
         :level="level"
+        :parent="parent?.id"
+        :position="i === items.length - 1 ? 'last' : undefined"
         :active-nav-items="activeNavItems"
         :toggle-item="toggleItem"
       />

--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
@@ -5,7 +5,7 @@ import {
   IRplPrimaryNavLogo,
   IRplPrimaryNavItem,
   IRplPrimaryNavActiveItems,
-  IRplPrimaryNavToggleItemOptions
+  RplPrimaryNavToggleItemOptions
 } from '../../constants'
 
 interface Props {
@@ -18,7 +18,7 @@ interface Props {
   isSearchActive: boolean
   activeNavItems: IRplPrimaryNavActiveItems
   toggleMobileMenu: () => void
-  toggleItem: (...args: IRplPrimaryNavToggleItemOptions) => void
+  toggleItem: (...args: RplPrimaryNavToggleItemOptions) => void
   toggleSearch: () => void
 }
 
@@ -90,6 +90,7 @@ const isItemActive = (item: IRplPrimaryNavItem) =>
           type="toggle"
           href="/"
           :active="isMegaNavActive"
+          focusKey="menu:toggle"
           @click="toggleMobileMenu()"
         >
           <span>Menu</span>&NoBreak;<span
@@ -115,9 +116,11 @@ const isItemActive = (item: IRplPrimaryNavItem) =>
       >
         <RplPrimaryNavBarAction
           v-if="item.items"
+          :id="item.id"
           type="toggle"
           :href="item.url"
           :active="isItemActive(item)"
+          :focusKey="`list:1:${item.id}`"
           @click="toggleItem(1, item)"
         >
           <span>{{ item.text }}</span
@@ -125,12 +128,13 @@ const isItemActive = (item: IRplPrimaryNavItem) =>
             ><RplIcon name="icon-chevron-down" size="xs"></RplIcon
           ></span>
         </RplPrimaryNavBarAction>
-
         <RplPrimaryNavBarAction
           v-else
+          :id="item.id"
           type="link"
           :href="item.url"
           :active="item.active"
+          :focusKey="`list:1:${item.id}`"
         >
           <span>{{ item.text }}</span>
         </RplPrimaryNavBarAction>

--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBarAction.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBarAction.vue
@@ -1,19 +1,53 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import { usePrimaryNavFocus } from '../../../../composables/usePrimaryNavFocus'
+
 interface Props {
   type: string
+  id?: string
   href?: string | undefined
   active?: boolean
+  focusKey?: string
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
+  id: undefined,
   active: false,
-  href: undefined
+  href: undefined,
+  focusKey: undefined
 })
+
+const action = ref(null)
+
+const { setFocus, forceFocus, hasQuickExit, hasUserActions } =
+  usePrimaryNavFocus(action, props.focusKey)
+
+const handleFocus = (event) => {
+  if (!props.active) return
+
+  event.preventDefault()
+
+  if (hasQuickExit) {
+    setFocus('links:exit')
+    return
+  } else if (hasUserActions) {
+    const foundAction = forceFocus(
+      '.rpl-primary-nav__mega-menu-user-action :is(a, button)'
+    )
+
+    if (foundAction) return
+  }
+
+  setFocus(
+    props.focusKey === 'menu:toggle' ? 'list:home' : `list:2:${props.id}`
+  )
+}
 </script>
 
 <template>
   <component
     :is="type === 'toggle' ? 'button' : 'a'"
+    ref="action"
     :class="{
       'rpl-primary-nav__nav-bar-action': true,
       'rpl-primary-nav__nav-bar-action--toggle': type === 'toggle',
@@ -24,6 +58,7 @@ withDefaults(defineProps<Props>(), {
       'rpl-u-focusable-block': true
     }"
     :href="href"
+    @keydown.tab.exact="handleFocus"
   >
     <div>
       <slot></slot>

--- a/packages/ripple-ui-core/src/components/primary-nav/components/quick-exit/RplPrimaryNavQuickExit.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/quick-exit/RplPrimaryNavQuickExit.vue
@@ -1,15 +1,23 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import RplButton from '../../../button/RplButton.vue'
+import { usePrimaryNavFocus } from '../../../../composables/usePrimaryNavFocus'
 
 interface Props {
   url?: string
   label?: string
+  parent?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   url: 'https://www.google.com',
-  label: 'Quick Exit'
+  label: 'Quick Exit',
+  parent: undefined
 })
+
+const exit = ref(null)
+
+const { setFocus, navCollapsed } = usePrimaryNavFocus(exit, 'links:exit')
 
 const clickHandler = () => {
   const newTab = window.open(props.url, '_blank')
@@ -18,14 +26,24 @@ const clickHandler = () => {
     newTab.focus()
   }
 }
+
+const handleBackFocus = (event) => {
+  // Only hijack tabbing if the quick exit is within a menu
+  if (props.parent || navCollapsed) {
+    event.preventDefault()
+    setFocus(navCollapsed ? 'menu:toggle' : `list:1:${props?.parent}`)
+  }
+}
 </script>
 
 <template>
   <RplButton
+    ref="exit"
     el="a"
     :url="url"
     :label="label"
     variant="destructive"
     @click="clickHandler()"
+    @keydown.shift.tab.exact="handleBackFocus"
   />
 </template>

--- a/packages/ripple-ui-core/src/components/primary-nav/constants.ts
+++ b/packages/ripple-ui-core/src/components/primary-nav/constants.ts
@@ -1,3 +1,5 @@
+import { Ref } from 'vue'
+
 export interface IRplPrimaryNavLogo {
   href: string
   src: string
@@ -19,8 +21,16 @@ export interface IRplPrimaryNavActiveItems {
   level3?: IRplPrimaryNavItem
 }
 
-export type IRplPrimaryNavToggleItemOptions = [
+export type RplPrimaryNavToggleItemOptions = [
   level: 1 | 2 | 3,
   item: IRplPrimaryNavItem,
   open?: boolean
 ]
+
+export interface IRplPrimaryNavFocusOptions {
+  focus: Ref
+  setFocus: (string) => void
+  navCollapsed: boolean
+  hasQuickExit: boolean
+  hasUserActions: boolean
+}

--- a/packages/ripple-ui-core/src/components/primary-nav/fixtures/sample.ts
+++ b/packages/ripple-ui-core/src/components/primary-nav/fixtures/sample.ts
@@ -17,27 +17,35 @@ export const RplPrimaryNavItems = [
           }
         ]
       },
+      { id: '4', text: 'Second level B', url: '#' },
+      { id: '5', text: 'Second level C', url: '#' },
+      { id: '6', text: 'Second level D', url: '#' },
       {
-        id: '55',
-        text: 'Second level C',
+        id: '7',
+        text: 'Second level E',
         url: '#',
         items: [
+          { id: '7.1', text: 'Third level B', url: '#' },
+          { id: '7.2', text: 'Third level C', url: '#' },
+          { id: '7.3', text: 'Third level D', url: '#' },
+          { id: '7.4', text: 'Third level E', url: '#' },
           {
-            id: '22',
-            text: 'Third level A',
+            id: '7.5',
+            text: 'Third level F',
             url: '#',
             items: [
-              {
-                id: '33',
-                text: 'Fourth level A link with some text that will need to wrap',
-                url: '#'
-              }
+              { id: '7.6', text: 'Fourth level A', url: '#' },
+              { id: '7.7', text: 'Fourth level B', url: '#' },
+              { id: '7.8', text: 'Fourth level C', url: '#' },
+              { id: '7.9', text: 'Fourth level D', url: '#' }
             ]
-          }
+          },
+          { id: '7.10', text: 'Third level G', url: '#' },
+          { id: '7.11', text: 'Third level H', url: '#' },
+          { id: '7.12', text: 'Third level I', url: '#' }
         ]
       },
-      { id: '6', text: 'Second level D', url: '#' },
-      { id: '7', text: 'Second level E', url: '#' },
+
       { id: '8', text: 'Second level F', url: '#' },
       { id: '9', text: 'Second level G', url: '#' },
       { id: '10', text: 'Second level H', url: '#' },
@@ -67,6 +75,11 @@ export const RplPrimaryNavItems = [
             text: 'Third level link with some text that will need to wrap',
             url: '#',
             items: [{ id: '23', text: 'Fourth level', url: '#' }]
+          },
+          {
+            id: '22.5',
+            text: 'Another third level link',
+            url: '#'
           }
         ]
       },

--- a/packages/ripple-ui-core/src/composables/usePrimaryNavFocus.ts
+++ b/packages/ripple-ui-core/src/composables/usePrimaryNavFocus.ts
@@ -1,0 +1,39 @@
+import { Ref, inject, watch } from 'vue'
+import { IRplPrimaryNavFocusOptions } from '../components/primary-nav/constants'
+
+export function usePrimaryNavFocus(element: Ref, key: string) {
+  const {
+    focus,
+    setFocus,
+    navCollapsed,
+    hasQuickExit,
+    hasUserActions
+  }: IRplPrimaryNavFocusOptions = inject('navFocus')
+
+  watch(focus, (value) => {
+    const el = element?.value?.$el || element?.value
+
+    if (el && value === key) {
+      el.focus()
+    }
+  })
+
+  const forceFocus = (selector: string): boolean => {
+    const element = document.querySelector<HTMLInputElement>(selector)
+
+    if (element) {
+      element?.focus()
+      setFocus('')
+    }
+
+    return Boolean(element)
+  }
+
+  return {
+    setFocus,
+    forceFocus,
+    navCollapsed,
+    hasQuickExit,
+    hasUserActions
+  }
+}


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-855

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add basic tab support to our primary nav

### Notes

Our primary nav isn't nested at all so we don't get tabbing for free, we may want to restructure the nav in the future so the markup is nested.

### Screenshots

#### Desktop
![desktop](https://user-images.githubusercontent.com/287178/231059668-5d53f0c6-ee49-426d-a957-faf89d1c9b85.gif)

#### Mobile
![mobile](https://user-images.githubusercontent.com/287178/231059607-9a5a23e8-218f-40cb-83e7-4fa77540191b.gif)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

