### PR TITLE
[R20-533] disable global components

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/home.feature
+++ b/examples/nuxt-app/test/features/landingpage/home.feature
@@ -62,6 +62,7 @@ Feature: Home page
 
   @mockserver
   Scenario: Header component - Search banner
+    Given the endpoint "/api/tide/page" with query "?path=/search/cats&site=8888" returns fixture "/landingpage/home" with status 200
     Then a search banner with ID "1911" should exist with the placeholder "Test search placeholder"
     Then in a search banner with ID "1911", searching for "cats" should take me to "/search/cats"
 

--- a/examples/nuxt-app/test/fixtures/landingpage/home.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/home.json
@@ -220,7 +220,7 @@
   "bodyComponents": [
     {
       "uuid": "a99aa287-7fac-430b-864e-3a1b044460b1",
-      "component": "RplContent",
+      "component": "TideLandingPageContent",
       "id": "969",
       "internalAnchors": [
         {
@@ -240,7 +240,7 @@
     },
     {
       "uuid": "9ac2e9a6-958f-47d4-beb1-d1576e424571",
-      "component": "RplAccordion",
+      "component": "TideLandingPageAccordion",
       "id": "972",
       "title": "Test accordion title",
       "props": {
@@ -475,7 +475,7 @@
     },
     {
       "uuid": "ec0ec723-df8d-4e6c-8a5f-3780381b04f3",
-      "component": "RplKeyDatesCard",
+      "component": "TideLandingPageKeyDatesCard",
       "id": "988",
       "layout": "card",
       "props": {
@@ -498,7 +498,7 @@
     },
     {
       "uuid": "c83c8494-1cb9-429c-af8f-9a4fa3a1fc94",
-      "component": "RplTimeline",
+      "component": "TideLandingPageTimeline",
       "id": "992",
       "title": "Test timeline title",
       "props": {

--- a/examples/nuxt-app/test/fixtures/news/sample-news.json
+++ b/examples/nuxt-app/test/fixtures/news/sample-news.json
@@ -41,7 +41,7 @@
   "dynamicComponents": [
     {
       "uuid": "a99aa287-7fac-430b-864e-3a1b044460b1",
-      "component": "RplContent",
+      "component": "TideLandingPageContent",
       "id": "969",
       "props": {
         "html": "<p>Here is <em>some</em> sample <strong>rich</strong> text content</p>"

--- a/packages/nuxt-ripple/components/TideBreadcrumbs.vue
+++ b/packages/nuxt-ripple/components/TideBreadcrumbs.vue
@@ -7,7 +7,6 @@
 </template>
 
 <script setup lang="ts">
-import { RplBreadcrumbs } from '#components'
 import { computed, toRaw, unref } from 'vue'
 import { getBreadcrumbs } from '#imports'
 

--- a/packages/nuxt-ripple/components/TideDynamicComponents.vue
+++ b/packages/nuxt-ripple/components/TideDynamicComponents.vue
@@ -3,7 +3,6 @@ import type {
   TideDynamicPageComponent,
   TideDynamicComponentGroup
 } from '../types'
-import { RplPageComponent, RplCardGrid } from '#components'
 import { computed } from 'vue'
 import groupDynamicComponents from '../utils/groupDynamicComponents'
 interface Props {

--- a/packages/nuxt-ripple/error.vue
+++ b/packages/nuxt-ripple/error.vue
@@ -26,7 +26,6 @@
 </template>
 
 <script setup lang="ts">
-import { RplHeaderGraphic, RplErrorMessage } from '#components'
 import { useTideSite } from '#imports'
 import { computed } from 'vue'
 

--- a/packages/nuxt-ripple/pages/sitemap.vue
+++ b/packages/nuxt-ripple/pages/sitemap.vue
@@ -5,7 +5,6 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { RplHeroHeader } from '#components'
 import { useTideSite } from '#imports'
 
 const site = await useTideSite()

--- a/packages/ripple-test-utils/step_definitions/components/accordion.ts
+++ b/packages/ripple-test-utils/step_definitions/components/accordion.ts
@@ -9,7 +9,7 @@ Then(
     cy.get(`@component`).should(
       'have.attr',
       'data-component-type',
-      'RplAccordion'
+      'TideLandingPageAccordion'
     )
     cy.get('@component').within(() => {
       cy.get(`[data-cy="page-component-title"]`).should('have.text', title)

--- a/packages/ripple-test-utils/step_definitions/components/basic-text.ts
+++ b/packages/ripple-test-utils/step_definitions/components/basic-text.ts
@@ -8,7 +8,7 @@ Then(
     cy.get(`@component`).should(
       'have.attr',
       'data-component-type',
-      'RplContent'
+      'TideLandingPageContent'
     )
     cy.get('@component').should('contain', content)
   }

--- a/packages/ripple-test-utils/step_definitions/components/key-dates.ts
+++ b/packages/ripple-test-utils/step_definitions/components/key-dates.ts
@@ -1,15 +1,13 @@
 import { Then, DataTable } from '@badeball/cypress-cucumber-preprocessor'
 
+const componentID = 'TideLandingPageKeyDatesCard'
+
 Then(
   'a key dates card with ID {string} should exist with the title {string}',
   (id: string, title: string) => {
     cy.get(`[data-component-id="${id}"]`).as('component')
     cy.get('@component').should('exist')
-    cy.get(`@component`).should(
-      'have.attr',
-      'data-component-type',
-      'RplKeyDatesCard'
-    )
+    cy.get(`@component`).should('have.attr', 'data-component-type', componentID)
     cy.get('@component').within(() => {
       cy.get(`[data-cy="title"]`).should('have.text', title)
     })
@@ -21,11 +19,7 @@ Then(
   (id: string, ctaText: string, ctaLink: string) => {
     cy.get(`[data-component-id="${id}"]`).as('component')
     cy.get('@component').should('exist')
-    cy.get(`@component`).should(
-      'have.attr',
-      'data-component-type',
-      'RplKeyDatesCard'
-    )
+    cy.get(`@component`).should('have.attr', 'data-component-type', componentID)
     cy.get('@component').within(() => {
       cy.get(`[data-cy="cta"]`).should('have.text', ctaText)
       cy.get(`[data-cy="cta"]`).should('have.attr', 'href', ctaLink)
@@ -42,11 +36,7 @@ Then(
     const table = dataTable.hashes()
     cy.get(`[data-component-id="${id}"]`).as('component')
     cy.get('@component').should('exist')
-    cy.get(`@component`).should(
-      'have.attr',
-      'data-component-type',
-      'RplKeyDatesCard'
-    )
+    cy.get(`@component`).should('have.attr', 'data-component-type', componentID)
     cy.get('@component').within(() => {
       cy.get(`.rpl-card__keydate`).as('dateItems')
     })

--- a/packages/ripple-test-utils/step_definitions/components/timeline.ts
+++ b/packages/ripple-test-utils/step_definitions/components/timeline.ts
@@ -1,15 +1,12 @@
 import { Then, DataTable } from '@badeball/cypress-cucumber-preprocessor'
+const componentID = 'TideLandingPageTimeline'
 
 Then(
   'a timeline with ID {string} should exist with the title {string}',
   (id: string, title: string) => {
     cy.get(`[data-component-id="${id}"]`).as('component')
     cy.get('@component').should('exist')
-    cy.get(`@component`).should(
-      'have.attr',
-      'data-component-type',
-      'RplTimeline'
-    )
+    cy.get(`@component`).should('have.attr', 'data-component-type', componentID)
     cy.get('@component').within(() => {
       cy.get(`[data-cy="page-component-title"]`).should('have.text', title)
     })
@@ -22,11 +19,7 @@ Then(
     const table = dataTable.hashes()
     cy.get(`[data-component-id="${id}"]`).as('component')
     cy.get('@component').should('exist')
-    cy.get(`@component`).should(
-      'have.attr',
-      'data-component-type',
-      'RplTimeline'
-    )
+    cy.get(`@component`).should('have.attr', 'data-component-type', componentID)
     cy.get('@component').within(() => {
       cy.get(`.rpl-timeline__item`).as('timelineItems')
     })

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/Accordion.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/Accordion.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { RplAccordion } from '#components'
-
 defineProps<{
   id: string
   title: string

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/CallToAction.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/CallToAction.vue
@@ -10,8 +10,6 @@
 </template>
 
 <script setup lang="ts">
-import { RplCallToActionCard } from '#components'
-
 interface Props {
   title: string
   image: {

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/CardCarousel.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/CardCarousel.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { RplCardCarousel } from '#components'
 import { ITideCardCarouselItem } from '../../../mapping/page-components/card-carousel/card-carousel-mapping'
 
 const props = defineProps<{

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/CardSharedMeta.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/CardSharedMeta.vue
@@ -26,7 +26,6 @@
 </template>
 
 <script setup lang="ts">
-import { RplTag } from '#components'
 import { formatDate } from '#imports'
 import { formatDateRange, getGrantStatus } from '@dpc-sdp/ripple-ui-core'
 import { computed } from 'vue'

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/Content.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/Content.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { RplContent } from '#components'
+
+defineProps<{
+  html: string
+}>()
+</script>
+
+<template>
+  <RplContent :html="html" />
+</template>

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/Content.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/Content.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { RplContent } from '#components'
-
 defineProps<{
   html: string
 }>()

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -7,7 +7,10 @@
           <RplResultListing>
             <template v-for="item in results" :key="item.id">
               <RplResultListingItem>
-                <RplSearchResult v-bind="item.props" :content="item.slots.default" />
+                <RplSearchResult
+                  v-bind="item.props"
+                  :content="item.slots.default"
+                />
               </RplResultListingItem>
             </template>
           </RplResultListing>
@@ -17,13 +20,20 @@
     <template v-else>
       <ul class="rpl-grid" style="--local-grid-cols: 12">
         <template v-for="item in results" :key="item.id">
-          <component :is="display.component" :class="cardClasses" v-bind="item.props">
+          <component
+            :is="display.component"
+            :class="cardClasses"
+            v-bind="item.props"
+          >
             {{ item.slots.default }}
           </component>
         </template>
       </ul>
     </template>
-    <div v-if="link.url" class="rpl-type-label rpl-type-weight-bold rpl-u-margin-t-6">
+    <div
+      v-if="link.url"
+      class="rpl-type-label rpl-type-weight-bold rpl-u-margin-t-6"
+    >
       <RplTextLink v-bind="link" />
     </div>
   </div>

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/HeroAcknowledgement.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/HeroAcknowledgement.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RplAcknowledgement } from '#components'
 defineProps<{
   message: string
 }>()

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/HeroHeader.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/HeroHeader.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RplHeroHeader } from '#components'
 import { computed, inject } from 'vue'
 import { ITideHeroHeader } from '../../../mapping/hero-header/hero-header-mapping'
 import type { IRplFeatureFlags } from '@dpc-sdp/ripple-tide-api/types'

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/InPageNavigation.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/InPageNavigation.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RplInPageNavigation } from '#components'
 import { computed } from 'vue'
 
 interface Props {

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/IntroBanner.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/IntroBanner.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { TideUrlField } from '@dpc-sdp/ripple-tide-api/types'
-import { RplContent, RplIntroHeader } from '#components'
 
 defineProps<{
   title: string

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/KeyDatesCard.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/KeyDatesCard.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { RplKeyDatesCard } from '#components'
+import type {
+  RplCardElements,
+  IRplCardItem
+} from '@dpc-sdp/ripple-ui-core/src/components/card/constants'
+
+defineProps<{
+  ctaTitle: string
+  el?: (typeof RplCardElements)[number]
+  items: IRplCardItem[]
+  title?: string
+  url?: string
+}>()
+</script>
+
+<template>
+  <RplKeyDatesCard v-bind="$props" />
+</template>

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/KeyDatesCard.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/KeyDatesCard.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RplKeyDatesCard } from '#components'
 import type {
   RplCardElements,
   IRplCardItem

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/MediaEmbed.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/MediaEmbed.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { RplMediaEmbed } from '#components'
+import type {
+  RplMediaEmbedTypes,
+  RplMediaEmbedVariants,
+  RplMediaEmbedSizes
+} from '@dpc-sdp/ripple-ui-core/src/components/media-embed/constants'
+
+defineProps<{
+  type: RplMediaEmbedTypes
+  variant?: RplMediaEmbedVariants
+  size?: RplMediaEmbedSizes
+  title: string
+  src: string
+  showTitle?: boolean
+  transcriptUrl?: string
+  caption?: string
+  sourceCaption?: string
+  allowFullscreen?: boolean
+  dataContent?: string
+  downloadUrl?: string
+}>()
+</script>
+
+<template>
+  <RplMediaEmbed v-bind="$props" />
+</template>

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/MediaEmbed.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/MediaEmbed.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RplMediaEmbed } from '#components'
 import type {
   RplMediaEmbedTypes,
   RplMediaEmbedVariants,

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/MediaGallery.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/MediaGallery.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { RplMediaGallery } from '#components'
-
 defineProps<{
   id: string
   title: string

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/NavCard.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/NavCard.vue
@@ -14,8 +14,6 @@
 </template>
 
 <script setup lang="ts">
-import { RplNavCard } from '#components'
-
 interface Props {
   title: string
   summary: string

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/PrimaryCampaignBanner.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/PrimaryCampaignBanner.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RplPrimaryCampaign } from '#components'
 import { ITidePrimaryCampaign } from '../../../mapping/primary-campaign/primary-campaign-mapping'
 
 defineProps<{

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/PromoCard.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/PromoCard.vue
@@ -25,8 +25,6 @@
 </template>
 
 <script setup lang="ts">
-import { RplAvatarCard, RplPromoCard } from '#components'
-
 interface Props {
   title: string
   summary: string

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/SearchBanner.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/SearchBanner.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 // @ts-ignore
 import { useRuntimeConfig, useRouter, useNuxtApp } from '#imports'
-
-import { RplSearchBar } from '#components'
 import { isExternalUrl } from '@dpc-sdp/ripple-ui-core'
 
 const router = useRouter()

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/SecondaryCampaignBanner.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/SecondaryCampaignBanner.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RplSecondaryCampaign } from '#components'
 import { ITideSecondaryCampaign } from '../../../mapping/secondary-campaign/secondary-campaign-mapping'
 
 defineProps<{

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/StatsGrid.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/StatsGrid.vue
@@ -10,8 +10,6 @@
 </template>
 
 <script setup lang="ts">
-import { RplStatsGrid, RplStatsGridItem } from '#components'
-
 interface Props {
   variant: 'onLight' | 'onDark'
   items: Array<{

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/Timeline.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/Timeline.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RplTimeline } from '#components'
 import type { IRplImageType } from '@dpc-sdp/ripple-ui-core/src/components/image/constants'
 
 interface IRplTimelineItem {

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/Timeline.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/Timeline.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { RplTimeline } from '#components'
+import type { IRplImageType } from '@dpc-sdp/ripple-ui-core/src/components/image/constants'
+
+interface IRplTimelineItem {
+  image?: IRplImageType
+  title: string
+  subtitle: string
+  dateStart: string
+  dateEnd: string
+  current: boolean
+  description: string
+  url: string
+}
+
+defineProps<{
+  title?: string | null
+  items?: IRplTimelineItem[]
+}>()
+</script>
+
+<template>
+  <RplTimeline v-bind="$props" />
+</template>

--- a/packages/ripple-tide-landing-page/mapping/components/accordion/accordion-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/accordion/accordion-mapping.test.ts
@@ -85,7 +85,7 @@ const rawData = {
 describe('accordionMapping', () => {
   it('maps a raw json api response to the correct structure', () => {
     const result: TideDynamicPageComponent<ITideAccordion> = {
-      component: 'RplAccordion',
+      component: 'TideLandingPageAccordion',
       id: '4771',
       title: 'TEST_TITLE',
       props: {
@@ -111,7 +111,7 @@ describe('accordionMapping', () => {
 
   it('maps a raw json api response to the correct structure (numbered)', () => {
     const result: TideDynamicPageComponent<ITideAccordion> = {
-      component: 'RplAccordion',
+      component: 'TideLandingPageAccordion',
       id: '4771',
       title: 'TEST_TITLE',
       props: {

--- a/packages/ripple-tide-landing-page/mapping/components/accordion/accordion-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/accordion/accordion-mapping.ts
@@ -15,7 +15,7 @@ export const accordionMapping = (
   field
 ): TideDynamicPageComponent<ITideAccordion> => {
   return {
-    component: 'RplAccordion',
+    component: 'TideLandingPageAccordion',
     id: field.drupal_internal__id.toString(),
     title: field.field_paragraph_title,
     props: {

--- a/packages/ripple-tide-landing-page/mapping/components/basic-text/basic-text-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/basic-text/basic-text-mapping.test.ts
@@ -30,7 +30,7 @@ const rawData = {
 }
 
 const result: TideDynamicPageComponent<ITideBasicText> = {
-  component: 'RplContent',
+  component: 'TideLandingPageContent',
   id: '4768',
   internalAnchors: [
     {

--- a/packages/ripple-tide-landing-page/mapping/components/basic-text/basic-text-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/basic-text/basic-text-mapping.ts
@@ -15,7 +15,7 @@ export const basicTextMapping = (
   const rawHTML = getBody(field?.field_paragraph_body?.processed)
 
   return {
-    component: 'RplContent',
+    component: 'TideLandingPageContent',
     id: `${field.drupal_internal__id}`,
     internalAnchors: getAnchorLinksFromHTML(rawHTML, true),
     props: {

--- a/packages/ripple-tide-landing-page/mapping/components/complex-image/complex-image-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/complex-image/complex-image-mapping.test.ts
@@ -4,7 +4,7 @@ import { complexImageMapping, ITideComplexImage } from './complex-image-mapping'
 import rawData from './complex-image'
 
 const result: TideDynamicPageComponent<ITideComplexImage> = {
-  component: 'RplMediaEmbed',
+  component: 'TideLandingPageMediaEmbed',
   id: '943',
   props: {
     title: 'Complex Image Title',

--- a/packages/ripple-tide-landing-page/mapping/components/complex-image/complex-image-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/complex-image/complex-image-mapping.ts
@@ -17,7 +17,7 @@ export const complexImageMapping = (
   field: any
 ): TideDynamicPageComponent<ITideComplexImage> => {
   return {
-    component: 'RplMediaEmbed',
+    component: 'TideLandingPageMediaEmbed',
     id: `${field.drupal_internal__id}`,
     props: {
       title: field.field_complex_image_title,

--- a/packages/ripple-tide-landing-page/mapping/components/key-dates/key-dates-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/key-dates/key-dates-mapping.test.ts
@@ -94,7 +94,7 @@ describe('keyDatesMapping', () => {
   it('maps a raw json api response to the correct structure', () => {
     const result: TideDynamicPageComponent<ITideKeyDates> = {
       id: '4776',
-      component: 'RplKeyDatesCard',
+      component: 'TideLandingPageKeyDatesCard',
       layout: 'card',
       props: {
         title: 'Key calendar dates',

--- a/packages/ripple-tide-landing-page/mapping/components/key-dates/key-dates-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/key-dates/key-dates-mapping.ts
@@ -17,7 +17,7 @@ export const keyDatesMapping = (
 ): TideDynamicPageComponent<ITideKeyDates> => {
   const link = getLinkFromField(field, 'field_paragraph_cta')
   return {
-    component: 'RplKeyDatesCard',
+    component: 'TideLandingPageKeyDatesCard',
     id: field.drupal_internal__id.toString(),
     layout: 'card',
     props: {

--- a/packages/ripple-tide-landing-page/mapping/components/timeline/timeline-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/timeline/timeline-mapping.test.ts
@@ -359,7 +359,7 @@ const rawData = {
 describe('timelineMapping', () => {
   it('maps a raw json api response to the correct structure', () => {
     const result: TideDynamicPageComponent<ITideTimeline> = {
-      component: 'RplTimeline',
+      component: 'TideLandingPageTimeline',
       id: '6212',
       title: 'Testing timeline title',
       props: {

--- a/packages/ripple-tide-landing-page/mapping/components/timeline/timeline-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/timeline/timeline-mapping.ts
@@ -28,7 +28,7 @@ export const timelineMapping = (
   field
 ): TideDynamicPageComponent<ITideTimeline> => {
   return {
-    component: 'RplTimeline',
+    component: 'TideLandingPageTimeline',
     id: `${field.drupal_internal__id}`,
     title: field.field_paragraph_title,
     props: {

--- a/packages/ripple-tide-media/components/TideMediaBody.vue
+++ b/packages/ripple-tide-media/components/TideMediaBody.vue
@@ -14,7 +14,6 @@ export default { name: 'TideMediaBody' }
 
 <script setup lang="ts">
 import type { TideMediaMedia } from '../../types'
-import { RplContent } from '#components'
 
 defineProps<{
   media: TideMediaMedia

--- a/packages/ripple-tide-media/components/TideMediaHeader.vue
+++ b/packages/ripple-tide-media/components/TideMediaHeader.vue
@@ -14,7 +14,6 @@ export default { name: 'TideMediaHeader' }
 
 <script setup lang="ts">
 import type { TideMediaHeader } from '../../types'
-import { RplHeroHeader } from '#components'
 
 defineProps<{
   header: TideMediaHeader

--- a/packages/ripple-tide-media/components/global/TideMediaEmbeddedVideo.vue
+++ b/packages/ripple-tide-media/components/global/TideMediaEmbeddedVideo.vue
@@ -42,7 +42,6 @@
 <script setup lang="ts">
 import { TideSiteData } from '@dpc-sdp/ripple-tide-api/types'
 import type { TideMediaPage } from '../../types'
-import { RplMediaEmbed } from '#components'
 
 interface Props {
   site: TideSiteData

--- a/packages/ripple-tide-search/components/TideSearchPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchPage.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { RplSearchBar, RplHeroHeader } from '#components'
 import { useRuntimeConfig, useFetch, useRoute } from '#imports'
 import useTideSearch from './../composables/use-tide-search'
 import { FilterConfigItem, MappedSearchResult } from 'ripple-tide-search/types'

--- a/packages/ripple-ui-core/src/nuxt.ts
+++ b/packages/ripple-ui-core/src/nuxt.ts
@@ -22,8 +22,7 @@ export default <any>defineNuxtModule({
     addComponentsDir({
       extensions: ['vue'],
       path: join(__dirname, './../src/components'),
-      prefix: 'rpl',
-      global: true
+      prefix: 'rpl'
     })
 
     // Adds required PostCss plugins

--- a/packages/ripple-ui-forms/src/nuxt.ts
+++ b/packages/ripple-ui-forms/src/nuxt.ts
@@ -13,8 +13,7 @@ export default <any>defineNuxtModule({
       dirs.push({
         extensions: ['vue'],
         path: join(__dirname, './../src/components'),
-        prefix: 'rpl',
-        global: true
+        prefix: 'rpl'
       })
     }
   }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-533

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Remove defining Ripple-ui components global in nuxt app
- Add imports for previously global defined components

### How to test
<!-- Summary of how to test  -->
- Check lighthouse scores in reference site once deployed
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

