### PR TITLE
[R20-911] Use selected image if there are multiple in rpl-content

### DIFF
--- a/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
+++ b/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
@@ -137,7 +137,7 @@ const pluginEmbededVideo = function (this: any) {
 const pluginImages = function (this: any) {
   // Find all drupal image embeds
   this.find('.embedded-entity--media--image').map((i: any, el: any) => {
-    const $img = this.find('img')
+    const $img = this.find(el).find('img')
     const width = $img.attr('width')
     const src = $img.attr('src')
     const alt = $img.attr('alt')


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-911

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Update cheerio plugin to specify image where there are multiple in the same markup block
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

