### PR TITLE
[R20-737] Redefine token-set props in theme

### DIFF
--- a/examples/nuxt-app/app.config.ts
+++ b/examples/nuxt-app/app.config.ts
@@ -7,8 +7,6 @@ export default defineAppConfig({
       'rpl-clr-primary': '#6B19A3',
       'rpl-clr-primary-alt': '#3F006B',
       'rpl-clr-primary-alpha': 'rgba(107, 25, 163, 0.5)',
-      'rpl-clr-type-primary-accessible': 'var(--rpl-clr-primary)',
-      'rpl-clr-type-primary-alt-accessible': 'var(--rpl-clr-primary-alt)',
       'rpl-clr-accent': '#6DDD97',
       'rpl-clr-accent-alt': '#EAFAF0',
       'rpl-clr-link': '#6B19A3',
@@ -16,7 +14,22 @@ export default defineAppConfig({
       'rpl-clr-gradient-horizontal':
         'linear-gradient(90deg, #382484 0%, #5A0099 20%, #7623B0 35%, #2E7478 50%, #2FA26F 70%, #2FCE6A 80%)',
       'rpl-clr-gradient-vertical':
-        'linear-gradient(180deg, #382484 0%, #5A0099 20%, #7623B0 35%, #2E7478 50%, #2FA26F 70%, #2FCE6A 80%)'
+        'linear-gradient(180deg, #382484 0%, #5A0099 20%, #7623B0 35%, #2E7478 50%, #2FA26F 70%, #2FCE6A 80%)',
+      'rpl-clr-type-primary-accessible': 'var(--rpl-clr-primary)',
+      'rpl-clr-type-primary-alt-accessible': 'var(--rpl-clr-primary-alt)',
+      'rpl-clr-footer-alt': 'var(--rpl-clr-primary)',
+      'rpl-clr-footer': 'var(--rpl-clr-primary-alt)',
+      'rpl-clr-type-footer-accessible':
+        'var(--rpl-clr-type-primary-alt-accessible)'
+
+      // The following should also be included when their parent values are changed
+
+      // 'rpl-clr-type-light': 'var(--rpl-clr-light)',
+      // 'rpl-clr-type-default': 'var(--rpl-clr-dark)',
+      // 'rpl-clr-type-focus-contrast': 'var(--rpl-clr-dark)',
+      // 'rpl-clr-type-accent-contrast': 'var(--rpl-clr-light)',
+      // 'rpl-clr-type-primary-contrast': 'var(--rpl-clr-light)',
+      // 'rpl-clr-type-footer-contrast': 'var(--rpl-clr-type-primary-contrast)'
     }
   }
 })


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-737

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Just noting it here, as this will be needed in new site themes as well (copied from jira):

> It looks like when we override values for theming, the inherited properties are not passed on eg.
>
>```--rpl-clr-type-light: var(--rpl-clr-light);```
>
> If we change `--rpl-clr-light` then `--rpl-clr-type-light` doesn’t automatically get the new value. This isn’t a big deal, it can just be redefined in the theme, we just need to remember to do it (document / add to default config).

- Updated in nuxt-app

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

