### PR TITLE
fix(@dpc-sdp/ripple-ui-core): fixed level 4 nav links with children not being clickable

### DIFF
--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuList.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuList.vue
@@ -48,7 +48,7 @@ withDefaults(defineProps<Props>(), {
     <li v-for="(child, i) in items" :key="child.id">
       <RplPrimaryNavMegaMenuAction
         :item="child"
-        :type="child.items?.length ? 'toggle' : 'link'"
+        :type="child.items?.length && level < 4 ? 'toggle' : 'link'"
         :level="level"
         :parent="parent?.id"
         :position="i === items.length - 1 ? 'last' : undefined"


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-932

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Display level 4 nav items that have children as links rather than menu buttons
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

