### PR TITLE
chore(@dpc-sdp/nuxt-ripple): clean up linter warnings

### DIFF
--- a/packages/nuxt-ripple/server/api/tide/webform_submission/[...].ts
+++ b/packages/nuxt-ripple/server/api/tide/webform_submission/[...].ts
@@ -1,7 +1,6 @@
 //@ts-nocheck runtime imports
-import { defineEventHandler, getQuery, H3Event } from 'h3'
-import { createHandler, logger, TideSiteApi } from '@dpc-sdp/ripple-tide-api'
-import { useNitroApp } from '#imports'
+import { defineEventHandler, H3Event } from 'h3'
+import { createHandler, logger } from '@dpc-sdp/ripple-tide-api'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 
 export const createSearchHandler = async (event: H3Event) => {

--- a/packages/nuxt-ripple/server/routes/sitemap.xml.ts
+++ b/packages/nuxt-ripple/server/routes/sitemap.xml.ts
@@ -1,7 +1,6 @@
 //@ts-nocheck runtime imports
-import { defineEventHandler, getQuery, H3Event } from 'h3'
-import { createHandler, logger, TideSiteApi } from '@dpc-sdp/ripple-tide-api'
-import { useNitroApp } from '#imports'
+import { defineEventHandler, H3Event } from 'h3'
+import { createHandler, logger } from '@dpc-sdp/ripple-tide-api'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 
 export const createSitemapProxyHandler = async (event: H3Event) => {

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/SearchBanner.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/SearchBanner.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // @ts-ignore
-import { useRuntimeConfig, useRouter, useNuxtApp } from '#imports'
+import { useNuxtApp, useRouter } from '#imports'
 import { isExternalUrl } from '@dpc-sdp/ripple-ui-core'
 
 const router = useRouter()

--- a/packages/ripple-tide-search/components/TideSearchPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useRuntimeConfig, useFetch, useRoute } from '#imports'
 import useTideSearch from './../composables/use-tide-search'
 import { FilterConfigItem, MappedSearchResult } from 'ripple-tide-search/types'

--- a/packages/ripple-tide-search/server/api/tide/search/[...].ts
+++ b/packages/ripple-tide-search/server/api/tide/search/[...].ts
@@ -1,7 +1,6 @@
 //@ts-nocheck runtime imports
-import { defineEventHandler, getQuery, H3Event } from 'h3'
-import { createHandler, logger, TideSiteApi } from '@dpc-sdp/ripple-tide-api'
-import { useNitroApp } from '#imports'
+import { defineEventHandler, H3Event } from 'h3'
+import { createHandler, logger } from '@dpc-sdp/ripple-tide-api'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 
 export const createSearchHandler = async (event: H3Event) => {


### PR DESCRIPTION
### What I did
<!-- Summary of changes made in the Pull Request  -->
- Just getting rid of some linter warnings about unused imports 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

