### PR TITLE
[R20-943] - Added hidePromoCardStripe feature flag to toggle promo card rainbow

### DIFF
--- a/packages/ripple-tide-api/types.d.ts
+++ b/packages/ripple-tide-api/types.d.ts
@@ -204,6 +204,10 @@ export interface IRplFeatureFlags {
    * @description Option to disable the display of topics and tags on all content types
    */
   disableTopicTags?: boolean
+  /**
+   * @description Option to disable the display of coloured/rainbow stripes on top of promo cards
+   */
+  hidePromoCardStripe?: boolean
 }
 
 declare module 'nitropack' {

--- a/packages/ripple-ui-core/src/components/card/RplPromoCard.vue
+++ b/packages/ripple-ui-core/src/components/card/RplPromoCard.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
 import { RplCardElements, RplCardTitleClasses } from './constants'
 import { useAccessibleContainer } from '../../composables/useAccessibleContainer'
 import RplImage from '../image/RplImage.vue'
 import RplCard from './RplCard.vue'
 import RplTextLink from '../text-link/RplTextLink.vue'
 import { IRplImageType } from '../image/constants'
+import type { IRplFeatureFlags } from '@dpc-sdp/ripple-tide-api/types'
 
 interface Props {
   el?: (typeof RplCardElements)[number]
@@ -25,13 +26,19 @@ withDefaults(defineProps<Props>(), {
 const titleClasses = computed(() => RplCardTitleClasses)
 
 const { container, trigger } = useAccessibleContainer()
+
+// In SDP sites, the rainbow stripe can be toggled on/off globally via a feature flag.
+// This setting will override the highlight prop.
+const { hidePromoCardStripe }: IRplFeatureFlags = inject('featureFlags', {
+  hidePromoCardStripe: false
+})
 </script>
 
 <template>
   <RplCard
     ref="container"
     type="promo"
-    :highlight="highlight"
+    :highlight="hidePromoCardStripe ? false : highlight"
     :link="url"
     :el="el"
   >


### PR DESCRIPTION


<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: R20-943

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

