### PR TITLE
fix(@dpc-sdp/ripple-tide-event): only show details with descriptions

### DIFF
--- a/packages/ripple-tide-event/components/TideEventOverview.vue
+++ b/packages/ripple-tide-event/components/TideEventOverview.vue
@@ -10,7 +10,7 @@
         {{ displayDate }}
       </RplDescriptionListItem>
       <RplDescriptionListItem
-        v-for="item in overview"
+        v-for="item in overviewList"
         :key="item.term"
         :term="item.term"
       >
@@ -58,6 +58,10 @@ const props = defineProps<Props>()
 
 const displayDate = computed(() =>
   formatDateRange(props.date, {}, props.showTime)
+)
+
+const overviewList = computed(() =>
+  props.overview.filter((item) => item.description)
 )
 </script>
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-960

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Only show event details that have content

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

