### PR TITLE
[R20-952] RplVerticalNav - fixed parents of active item being highlighted

### DIFF
--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNav.vue
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNav.vue
@@ -28,7 +28,7 @@ const processedItems = computed<IRplVerticalNavItem[]>(
               id: item.id,
               text: item.text,
               url: item.url,
-              active: item.active
+              active: item.active && !item.items.some((i) => i.active)
             },
             ...(item.items || [])
           ]
@@ -99,7 +99,7 @@ const { isItemExpanded, toggleItem } = useExpandableState(
           v-else
           :text="item.text"
           :href="item.url"
-          :active="item?.active && !item?.items?.length"
+          :active="item?.active && !item.items?.some((i) => i.active)"
         />
       </li>
     </ul>

--- a/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavChildList.vue
+++ b/packages/ripple-ui-core/src/components/vertical-nav/RplVerticalNavChildList.vue
@@ -27,7 +27,7 @@ const props = defineProps<Props>()
       <RplVerticalNavLink
         :text="item.text"
         :href="item.url"
-        :active="item?.active && !item?.items?.length"
+        :active="item?.active && !item.items?.some((i) => i.active)"
         :show-child-icon="props.level > 2"
         :tabindex="props.isExpanded ? '0' : '-1'"
       />


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-952

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

