### PR TITLE
fix(@dpc-sdp/ripple-ui-core): fixed table font size for paragraphs and lists

### DIFF
--- a/packages/ripple-ui-core/src/styles/components/_table.css
+++ b/packages/ripple-ui-core/src/styles/components/_table.css
@@ -26,9 +26,14 @@
 
   table {
     border-collapse: collapse;
-    font-size: var(--rpl-type-size-1);
-    line-height: var(--rpl-type-lh-3);
-    letter-spacing: var(--rpl-type-ls-1);
+
+    &,
+    p,
+    li {
+      font-size: var(--rpl-type-size-1);
+      line-height: var(--rpl-type-lh-3);
+      letter-spacing: var(--rpl-type-ls-1);
+    }
   }
 
   thead {


### PR DESCRIPTION


<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:https://digital-vic.atlassian.net/browse/R20-953

### What I did
<!-- Summary of changes made in the Pull Request  -->
- The designs for tables have smaller text than the rest of the wysiwyg content
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

