### PR TITLE
[R20-775] persistant quick exit

### DIFF
--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -28,6 +28,7 @@
           :siteMenu="site?.menus.menuMain"
           :currentPath="route.path"
           :currentPageTitle="pageTitle"
+          :besideQuickExit="site?.showQuickExit"
         />
       </slot>
     </template>

--- a/packages/nuxt-ripple/components/TideBreadcrumbs.vue
+++ b/packages/nuxt-ripple/components/TideBreadcrumbs.vue
@@ -2,6 +2,7 @@
   <RplBreadcrumbs
     v-if="breadcrumbs"
     :items="breadcrumbs"
+    :besideQuickExit="besideQuickExit"
     data-cy="breadcrumbs"
   />
 </template>
@@ -20,10 +21,12 @@ interface Props {
   items?: IRplBreadcrumbsItem[]
   currentPath: string
   currentPageTitle: string
+  besideQuickExit: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  items: () => []
+  items: () => [],
+  besideQuickExit: false
 })
 
 const breadcrumbs = computed(() => {

--- a/packages/ripple-tide-publication/components/global/TidePublication.vue
+++ b/packages/ripple-tide-publication/components/global/TidePublication.vue
@@ -16,7 +16,10 @@
     </template>
     <template #breadcrumbs>
       <slot name="breadcrumbs">
-        <TideBreadcrumbs :items="page.breadcrumbs" />
+        <TideBreadcrumbs
+          :items="page.breadcrumbs"
+          :besideQuickExit="site?.showQuickExit"
+        />
       </slot>
     </template>
     <template #aboveBody="{ hasBreadcrumbs }">

--- a/packages/ripple-tide-publication/components/global/TidePublicationPage.vue
+++ b/packages/ripple-tide-publication/components/global/TidePublicationPage.vue
@@ -16,7 +16,10 @@
     </template>
     <template #breadcrumbs>
       <slot name="breadcrumbs">
-        <TideBreadcrumbs :items="page.breadcrumbs" />
+        <TideBreadcrumbs
+          :items="page.breadcrumbs"
+          :besideQuickExit="site?.showQuickExit"
+        />
       </slot>
     </template>
     <template #aboveBody="{ hasBreadcrumbs }">

--- a/packages/ripple-tide-publication/pages/[...slug]/print-all.vue
+++ b/packages/ripple-tide-publication/pages/[...slug]/print-all.vue
@@ -53,6 +53,7 @@ onMounted(() => {
             { text: parentPage.title, url: parentPage.url },
             { text: 'Print' }
           ]"
+          :besideQuickExit="site?.showQuickExit"
         />
       </slot>
     </template>

--- a/packages/ripple-ui-core/src/components/breadcrumbs/RplBreadcrumbs.css
+++ b/packages/ripple-ui-core/src/components/breadcrumbs/RplBreadcrumbs.css
@@ -80,4 +80,10 @@
       color: var(--rpl-clr-type-default);
     }
   }
+
+  &--beside-exit {
+    --local-width-spacer: 124px;
+
+    max-width: calc(100% - var(--local-horizontal-offset) * 3 - var(--local-width-spacer));
+  }
 }

--- a/packages/ripple-ui-core/src/components/breadcrumbs/RplBreadcrumbs.vue
+++ b/packages/ripple-ui-core/src/components/breadcrumbs/RplBreadcrumbs.vue
@@ -8,15 +8,24 @@ interface IRplBreadcrumbsItem {
 
 interface Props {
   items: IRplBreadcrumbsItem[]
+  besideQuickExit?: boolean
 }
 
-withDefaults(defineProps<Props>(), {
-  items: () => []
+const props = withDefaults(defineProps<Props>(), {
+  items: () => [],
+  besideQuickExit: false
 })
 </script>
 
 <template>
-  <nav aria-label="breadcrumbs" class="rpl-breadcrumbs rpl-u-screen-only">
+  <nav
+    aria-label="breadcrumbs"
+    :class="{
+      'rpl-breadcrumbs': true,
+      'rpl-u-screen-only': true,
+      'rpl-breadcrumbs--beside-exit': props.besideQuickExit
+    }"
+  >
     <ol v-if="items.length > 0" class="rpl-breadcrumbs__items rpl-type-p">
       <li
         v-for="(item, index) of items"

--- a/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.css
+++ b/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.css
@@ -3,11 +3,12 @@
 
 .rpl-primary-nav {
   --local-nav-bar-height: 48px;
+  --local-nav-bar-padding: var(--rpl-sp-3);
 
   position: relative;
   width: 100%;
-  height: calc(var(--local-nav-bar-height) + var(--rpl-sp-3));
-  padding: var(--rpl-sp-3);
+  height: calc(var(--local-nav-bar-height) + var(--local-nav-bar-padding));
+  padding: var(--local-nav-bar-padding);
 
   @media (--rpl-bp-s) {
     --local-nav-bar-height: 52px;
@@ -15,9 +16,7 @@
 
   @media (--rpl-bp-m) {
     --local-nav-bar-height: 60px;
-
-    height: calc(var(--local-nav-bar-height) + var(--rpl-sp-4));
-    padding: var(--rpl-sp-4);
+    --local-nav-bar-padding: var(--rpl-sp-4);
   }
 
   @media print {
@@ -41,6 +40,7 @@
   background-color: var(--rpl-clr-primary);
   border-radius: var(--rpl-border-radius-2);
   overflow: hidden;
+  z-index: var(--rpl-layer-2);
 
   @media (--rpl-bp-s) {
     --local-nav-bar-height: 52px;

--- a/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.vue
@@ -21,6 +21,7 @@ import {
   IRplPrimaryNavActiveItems,
   IRplPrimaryNavFocusOptions
 } from './constants'
+import RplPrimaryNavQuickExit from './components/quick-exit/RplPrimaryNavQuickExit.vue'
 
 interface Props {
   primaryLogo: IRplPrimaryNavLogo
@@ -269,6 +270,7 @@ provide('navFocus', navFocus)
         :show-quick-exit="showQuickExit"
       />
     </div>
+    <RplPrimaryNavQuickExit v-if="showQuickExit" variant="fixed" />
   </nav>
 </template>
 

--- a/packages/ripple-ui-core/src/components/primary-nav/components/quick-exit/RplPrimaryNavQuickExit.css
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/quick-exit/RplPrimaryNavQuickExit.css
@@ -1,0 +1,27 @@
+.rpl-primary-nav__quick-exit--fixed {
+  --local-quick-exit-offset: calc(var(--local-nav-bar-height) + var(--local-nav-bar-padding) + var(--rpl-sp-1));
+
+  width: auto;
+  top: var(--local-quick-exit-offset);
+  right: var(--local-nav-bar-padding);
+
+  &,
+  &:focus-visible {
+    position: absolute;
+  }
+}
+
+.rpl-primary-nav--hidden .rpl-primary-nav__quick-exit--fixed {
+  --local-quick-exit-offset: calc(var(--local-nav-bar-padding));
+}
+
+.rpl-primary-nav--fixed,
+.rpl-primary-nav--hidden {
+  .rpl-primary-nav__quick-exit--fixed {
+    &,
+    &:focus-visible {
+      position: fixed;
+    }
+  }
+}
+

--- a/packages/ripple-ui-core/src/components/primary-nav/components/quick-exit/RplPrimaryNavQuickExit.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/quick-exit/RplPrimaryNavQuickExit.vue
@@ -7,12 +7,14 @@ interface Props {
   url?: string
   label?: string
   parent?: string
+  variant?: 'inline' | 'fixed'
 }
 
 const props = withDefaults(defineProps<Props>(), {
   url: 'https://www.google.com',
   label: 'Quick Exit',
-  parent: undefined
+  parent: undefined,
+  variant: 'inline'
 })
 
 const exit = ref(null)
@@ -29,7 +31,7 @@ const clickHandler = () => {
 
 const handleBackFocus = (event) => {
   // Only hijack tabbing if the quick exit is within a menu
-  if (props.parent || navCollapsed) {
+  if ((props.parent || navCollapsed) && props.variant !== 'fixed') {
     event.preventDefault()
     setFocus(navCollapsed ? 'menu:toggle' : `list:1:${props?.parent}`)
   }
@@ -43,7 +45,10 @@ const handleBackFocus = (event) => {
     :url="url"
     :label="label"
     variant="destructive"
+    :class="`rpl-primary-nav__quick-exit rpl-primary-nav__quick-exit--${variant}`"
     @click="clickHandler()"
     @keydown.shift.tab.exact="handleBackFocus"
   />
 </template>
+
+<style src="./RplPrimaryNavQuickExit.css" />


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-775

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add persistant quick exit to nav, in the same vein as the header taking a prop to say if it's behind a breakcrumbs this adds a prop to breadcrumbs to say it's it's beside a quick exit.

<img width="915" alt="Screenshot 2023-05-23 at 4 39 30 pm" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/68b437a1-645c-412c-af96-168cde532cd1">


#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

