### PR TITLE
fix(@dpc-sdp/ripple-tide-api): fixed normaliseImageUrl crashing app if run without env vars

### DIFF
--- a/packages/ripple-tide-api/src/utils/normaliseImageUrl.ts
+++ b/packages/ripple-tide-api/src/utils/normaliseImageUrl.ts
@@ -4,6 +4,10 @@ const isRelativeUrl = (url) => {
 }
 
 const normaliseImageUrl = (baseUrl: string, imageUrl: string) => {
+  if (!baseUrl) {
+    return imageUrl
+  }
+
   const baseWithNoTrailingSlash = baseUrl.replace(/\/$/, '')
 
   if (!imageUrl) {


### PR DESCRIPTION


<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

