### PR TITLE
fix(nuxt-ripple): ensure access token is passed through to API on SSR

### DIFF
--- a/packages/nuxt-ripple/composables/use-tide-page.ts
+++ b/packages/nuxt-ripple/composables/use-tide-page.ts
@@ -43,6 +43,7 @@ export const useTidePage = async (
 
   const headers = {}
 
+  // Need to manually pass the cookies needed for auth as they aren't automatically added when server rendered
   if (isPreviewPath(path)) {
     const accessTokenCookie = useCookie(AuthCookieNames.ACCESS_TOKEN)
     headers.cookie = `${AuthCookieNames.ACCESS_TOKEN}=${accessTokenCookie.value};`

--- a/packages/nuxt-ripple/composables/use-tide-page.ts
+++ b/packages/nuxt-ripple/composables/use-tide-page.ts
@@ -1,4 +1,5 @@
 import type { TidePageBase } from './../types'
+import { useCookie, isPreviewPath, AuthCookieNames } from '#imports'
 
 const isCacheTimeExpired = (date: number, expiryInMinutes = 5) => {
   // 5 minute default expiry in step with varnish cache
@@ -40,6 +41,13 @@ export const useTidePage = async (
     }
   }
 
+  const headers = {}
+
+  if (isPreviewPath(path)) {
+    const accessTokenCookie = useCookie(AuthCookieNames.ACCESS_TOKEN)
+    headers.cookie = `${AuthCookieNames.ACCESS_TOKEN}=${accessTokenCookie.value};`
+  }
+
   if (!pageData.value) {
     const { data, error } = await useFetch('/api/tide/page', {
       key: `page-${path}`,
@@ -48,6 +56,7 @@ export const useTidePage = async (
         path,
         site: siteId
       },
+      headers,
       async onResponse({ response }) {
         if (response.ok && response._data) {
           response._data['_fetched'] = Date.now()


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-292

### What I did
<!-- Summary of changes made in the Pull Request  -->
- On reference site, cookies don't get automatically passed through to the backend when the page is server rendered
- See here for a similar issue https://github.com/nuxt/nuxt/issues/13096

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

