### PR TITLE
docs(docs): added alert directing users to old storybook

### DIFF
--- a/docs/components/app/AppLayout.vue
+++ b/docs/components/app/AppLayout.vue
@@ -4,6 +4,7 @@
   <Meta name="twitter:card" content="summary_large_image" />
   <RplIconSprite />
   <div :class="`docs-theme--${theme}`">
+    <slot name="aboveHeader" />
     <AppNavbar>
       <template #menuContents>
         <slot name="menuContents" />

--- a/docs/layouts/home.vue
+++ b/docs/layouts/home.vue
@@ -1,5 +1,16 @@
 <template>
   <AppLayout background="alt">
+    <template #aboveHeader>
+      <RplAlertsContainer>
+        <RplAlert
+          message="These Docs are for Ripple version 2.0. If you are looking for the original Ripple Storybook please click below"
+          linkText="View Ripple 1 storybook"
+          linkUrl="https://master--5e736ff82649250022dd830c.chromatic.com/"
+          alert-id="storybook-alert"
+          :isDismissible="false"
+        />
+      </RplAlertsContainer>
+    </template>
     <template #aboveBody>
       <DocsHeroHeader :title="title" :description="subheader" />
 

--- a/packages/ripple-ui-core/src/components/alert/RplAlert.vue
+++ b/packages/ripple-ui-core/src/components/alert/RplAlert.vue
@@ -19,6 +19,7 @@ interface Props {
   linkUrl?: string
   dismissed?: boolean
   alertId: string
+  isDismissible?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -27,7 +28,8 @@ const props = withDefaults(defineProps<Props>(), {
   message: '',
   linkText: '',
   linkUrl: '',
-  dismissed: false
+  dismissed: false,
+  isDismissible: true
 })
 
 const emit = defineEmits<{
@@ -98,6 +100,7 @@ onResizeHeight(alertRef, (height) => {
         </RplTextLink>
       </div>
       <button
+        v-if="isDismissible"
         class="rpl-alert__btn-close rpl-u-focusable-inline rpl-u-focusable--alt-colour"
         data-cy="dismiss"
         @click="onClose"


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1063

![Screenshot 2023-06-14 at 4 03 38 pm](https://github.com/dpc-sdp/ripple-framework/assets/5309152/9a52fe4d-8398-48f8-85e1-647e0841c037)

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

