### PR TITLE
[R20-1050] cleanup warnings on server build

### DIFF
--- a/packages/ripple-tide-api/src/index.ts
+++ b/packages/ripple-tide-api/src/index.ts
@@ -3,11 +3,10 @@ export { default as TideApiBase } from './services/tide-api-base.js'
 export { default as TidePageApi } from './services/tide-page.js'
 export { default as TideSiteApi } from './services/tide-site.js'
 export { default as logger } from './logger/logger.js'
-export { default as createHandler } from './utils/createHandler.js'
+export * from './utils/createHandler.js'
 export * from './utils/define-module.js'
 export * from './utils/formatPriceRange.js'
 export {
   addAnchorLinksToHTML,
   getAnchorLinksFromHTML
 } from './utils/anchorLinks.js'
-export * from './errors/errors.js'

--- a/packages/ripple-tide-api/src/utils/createHandler.ts
+++ b/packages/ripple-tide-api/src/utils/createHandler.ts
@@ -1,7 +1,7 @@
 //@ts-nocheck import typing needs fixing
 import { H3Event, sendError, createError } from 'h3'
-import { logger } from '@dpc-sdp/ripple-tide-api'
-import { UserFacingError } from '@dpc-sdp/ripple-tide-api/errors'
+import { logger } from '../index.js'
+import { UserFacingError } from '../errors/errors.js'
 
 const getPublicFacingStatusCode = (status: number) => {
   switch (status) {
@@ -32,7 +32,7 @@ const getPublicFacingStatusMessage = (status: number) => {
   }
 }
 
-const createHandler = async (
+export const createHandler = async (
   event: H3Event,
   logLabel: string,
   handlerFn: () => Promise<any>
@@ -74,5 +74,3 @@ const createHandler = async (
     }
   }
 }
-
-export default createHandler

--- a/packages/ripple-tide-publication/server/api/tide/publication-index.ts
+++ b/packages/ripple-tide-publication/server/api/tide/publication-index.ts
@@ -1,12 +1,10 @@
 import jsonapiParse from 'jsonapi-parse'
 import { defineEventHandler, getQuery, H3Event } from 'h3'
+import { createHandler, TideApiBase, logger } from '@dpc-sdp/ripple-tide-api'
 import {
-  createHandler,
-  TideApiBase,
   ApplicationError,
-  BadRequestError,
-  logger
-} from '@dpc-sdp/ripple-tide-api'
+  BadRequestError
+} from '@dpc-sdp/ripple-tide-api/errors'
 import type {
   RplTideModuleConfig,
   IRplTideModuleMapping,


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1050

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Attempting to cleanup server build warnings

This does remove the warnings that relate to `createHandler`, but the `useNitroApp` warnings still remain https://github.com/nuxt/nuxt/issues/18789

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

