### PR TITLE
fix(@dpc-sdp/nuxt-ripple): correctly case content types with numbers

### DIFF
--- a/packages/nuxt-ripple/components/TideContentPage.vue
+++ b/packages/nuxt-ripple/components/TideContentPage.vue
@@ -42,10 +42,14 @@
 // @ts-ignore
 import { useTideSite, useTidePage } from '#imports'
 import { computed } from 'vue'
-import { pascalCase } from 'change-case'
+import { pascalCase, pascalCaseTransformMerge } from 'change-case'
 
 const site = await useTideSite()
 const page = await useTidePage()
 
-const componentName = computed(() => page && `Tide${pascalCase(page.type)}`)
+const componentName = computed(
+  () =>
+    page &&
+    `Tide${pascalCase(page.type, { transform: pascalCaseTransformMerge })}`
+)
 </script>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- The pascal case function we use converts `det_150_content` to `Det_150Content` by default, but we need it to be `Det150Content`

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

