### PR TITLE
[R20-1234] include current site ID in search filters

### DIFF
--- a/packages/ripple-tide-api/src/services/tide-page.ts
+++ b/packages/ripple-tide-api/src/services/tide-page.ts
@@ -72,7 +72,7 @@ export default class TidePageApi extends TideApiBase {
             ...data
           })
         } else if (typeof componentMapping === 'function') {
-          const data = componentMapping.apply(this, [cmpData, pageData])
+          const data = componentMapping.apply(this, [cmpData, pageData, this])
           mappedComponents.push({
             uuid: cmpData.uuid || cmpData.id,
             ...data

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -112,6 +112,15 @@ const searchResultsMappingFn = (item): any => {
   }
 }
 
+const searchFilters = computed(() => {
+  if (!config.tide?.site) return props.filters
+
+  return [
+    ...props.filters,
+    { type: 'any', field: 'field_node_site', values: [config.tide.site] }
+  ]
+})
+
 const searchDriverOptions = {
   trackUrlState: false,
   alwaysSearchOnInitialLoad: true,
@@ -120,7 +129,7 @@ const searchDriverOptions = {
     sortList: props.sortBy
   },
   searchQuery: {
-    filters: props.filters,
+    filters: searchFilters.value,
     result_fields: {
       title: {
         raw: {

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -112,15 +112,6 @@ const searchResultsMappingFn = (item): any => {
   }
 }
 
-const searchFilters = computed(() => {
-  if (!config.tide?.site) return props.filters
-
-  return [
-    ...props.filters,
-    { type: 'any', field: 'field_node_site', values: [config.tide.site] }
-  ]
-})
-
 const searchDriverOptions = {
   trackUrlState: false,
   alwaysSearchOnInitialLoad: true,
@@ -129,7 +120,7 @@ const searchDriverOptions = {
     sortList: props.sortBy
   },
   searchQuery: {
-    filters: searchFilters.value,
+    filters: props.filters,
     result_fields: {
       title: {
         raw: {

--- a/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.test.ts
@@ -25,7 +25,7 @@ describe('contentCollectionMapping', () => {
             values: ['landing_page', 'news']
           },
           {
-            type: 'all',
+            type: 'any',
             field: 'field_topic',
             values: [8941, 8940]
           }

--- a/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.test.ts
@@ -28,6 +28,11 @@ describe('contentCollectionMapping', () => {
             type: 'any',
             field: 'field_topic',
             values: [8941, 8940]
+          },
+          {
+            type: 'any',
+            field: 'field_node_site',
+            values: ['8888']
           }
         ],
         sortBy: [
@@ -48,6 +53,8 @@ describe('contentCollectionMapping', () => {
       }
     }
 
-    expect(contentCollectionMapping(rawData)).toEqual(result)
+    expect(contentCollectionMapping(rawData, {}, { site: '8888' })).toEqual(
+      result
+    )
   })
 })

--- a/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.ts
@@ -49,7 +49,8 @@ export interface ITideContentCollectionConfig {
 }
 
 const getContentCollectionFiltersFromConfig = (
-  config: ITideContentCollectionConfig
+  config: ITideContentCollectionConfig,
+  siteId?: string
 ): IContentCollectionFilter[] => {
   const filters = []
   if (config.internal?.contentTypes) {
@@ -69,6 +70,15 @@ const getContentCollectionFiltersFromConfig = (
     )
     filters.push(...contentFieldFilters)
   }
+
+  if (siteId) {
+    filters.push({
+      type: 'any',
+      field: 'field_node_site',
+      values: [siteId]
+    })
+  }
+
   return filters
 }
 
@@ -91,7 +101,9 @@ const getContentCollectionSortBy = (config) => {
 }
 
 export const contentCollectionMapping = (
-  field
+  field,
+  pageData,
+  TidePageApi
 ): TideDynamicPageComponent<IContentCollection> => {
   return {
     component: 'TideLandingPageContentCollection',
@@ -104,7 +116,8 @@ export const contentCollectionMapping = (
         'callToAction'
       ]),
       filters: getContentCollectionFiltersFromConfig(
-        field.field_content_collection_config
+        field.field_content_collection_config,
+        TidePageApi?.site
       ),
       sortBy: getContentCollectionSortBy(field.field_content_collection_config),
       perPage: getField(

--- a/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.ts
@@ -61,17 +61,11 @@ const getContentCollectionFiltersFromConfig = (
   }
   if (config.internal?.contentFields) {
     const contentFieldFilters = Object.keys(config.internal?.contentFields).map(
-      (field) => {
-        const type =
-          config.internal?.contentFields[field].operator === 'OR'
-            ? 'any'
-            : 'all'
-        return {
-          type,
-          field,
-          values: config.internal?.contentFields[field].values
-        }
-      }
+      (field) => ({
+        field,
+        type: 'any',
+        values: config.internal?.contentFields[field].values
+      })
     )
     filters.push(...contentFieldFilters)
   }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1234

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Include current site ID in search filters, fix filter type

<img width="1454" alt="Screenshot 2023-07-12 at 1 43 45 pm" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/747c4861-fab4-4a9d-88c4-e5670ff7b8ac">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

