### PR TITLE
[R20-1274] site wide corner graphics

### DIFF
--- a/packages/nuxt-ripple/mapping/site/index.ts
+++ b/packages/nuxt-ripple/mapping/site/index.ts
@@ -35,6 +35,11 @@ export default {
 
       return src.field_acknowledgement_to_country
     },
+    cornerGraphic: {
+      top: (src: any) => getImageFromField(src, 'field_top_corner_graphic'),
+      bottom: (src: any) =>
+        getImageFromField(src, 'field_bottom_corner_graphic')
+    },
     acknowledgementFooter: 'field_acknowledgement_to_country',
     copyrightHtml: (src: any) => {
       return getBody(src.field_site_footer_text?.processed)
@@ -109,6 +114,8 @@ export default {
     'field_site_main_menu',
     'field_site_footer_menu',
     'field_site_logo',
+    'field_top_corner_graphic',
+    'field_bottom_corner_graphic',
     'field_site_footer_logos',
     'field_site_footer_logos.field_paragraph_media.field_media_image'
   ]

--- a/packages/nuxt-ripple/types.d.ts
+++ b/packages/nuxt-ripple/types.d.ts
@@ -18,6 +18,10 @@ export interface TideSiteData {
   showQuickExit: boolean
   acknowledgementHeader?: string
   acknowledgementFooter: string
+  cornerGraphic?: {
+    top?: TideImageField
+    bottom?: TideImageField
+  }
   copyrightHtml: string
   footerLogos: {
     alt: string

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage.vue
@@ -27,6 +27,8 @@
         :header="page.heroHeader"
         :hasBreadcrumbs="hasBreadcrumbs"
         :hideBottomCornerGraphic="!!page.primaryCampaign"
+        :cornerTop="site?.cornerGraphic?.top"
+        :cornerBottom="site?.cornerGraphic?.bottom"
       />
       <TideLandingPageHeroAcknowledgement
         v-if="page.showHeroAcknowledgement"

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/HeroHeader.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/HeroHeader.vue
@@ -2,11 +2,14 @@
 import { computed, inject } from 'vue'
 import { ITideHeroHeader } from '../../../mapping/hero-header/hero-header-mapping'
 import type { IRplFeatureFlags } from '@dpc-sdp/ripple-tide-api/types'
+import { TideImageField } from '@dpc-sdp/nuxt-ripple/types'
 
 const props = defineProps<{
   header: ITideHeroHeader
   hideBottomCornerGraphic: boolean
   hasBreadcrumbs: boolean
+  cornerTop?: TideImageField
+  cornerBottom?: TideImageField
 }>()
 
 const cornerTop = computed(() => {
@@ -14,7 +17,7 @@ const cornerTop = computed(() => {
     return false
   }
 
-  return props.header.cornerTopImage?.src || true
+  return props.header.cornerTopImage?.src || props.cornerTop?.src || true
 })
 
 const cornerBottom = computed(() => {
@@ -22,7 +25,7 @@ const cornerBottom = computed(() => {
     return false
   }
 
-  return props.header.cornerBottomImage?.src || true
+  return props.header.cornerBottomImage?.src || props.cornerBottom?.src || true
 })
 
 const secondaryAction = computed(() => {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1274

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add site wide corner graphics

<img width="2407" alt="Screenshot 2023-07-14 at 5 48 36 pm" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/f6a1e241-791f-4cdb-821f-97828defe04f">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

