### PR TITLE
feat(@dpc-sdp/nuxt-ripple): fix error when page meta isn't set

### DIFF
--- a/packages/nuxt-ripple/composables/use-tide-language.ts
+++ b/packages/nuxt-ripple/composables/use-tide-language.ts
@@ -10,7 +10,9 @@ export default (page: any) => {
         meta.tag === 'meta' && meta.attributes?.property === 'og:locale'
     )
 
-    return lang?.attributes?.content?.toLowerCase() || page.meta?.langcode
+    return (
+      lang?.attributes?.content?.toLowerCase() || page?.meta?.langcode || 'en'
+    )
   })
 
   const found = computed(() => languages?.[locale.value] || null)


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add optional chaining to page.meta as sometimes it won't exist

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

