### PR TITLE
[R20-1307] wysiwyg image widths

### DIFF
--- a/packages/ripple-ui-core/src/styles/components/_img.css
+++ b/packages/ripple-ui-core/src/styles/components/_img.css
@@ -1,4 +1,4 @@
 .rpl-img {
   object-fit: cover;
-  width: 100%;
+  max-width: 100%;
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1307

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Stop images within wysiwygs being 100% wide by default

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

