### PR TITLE
[R20-1341] allow media and tables to span full width

### DIFF
--- a/packages/ripple-ui-core/src/components/content/RplContent.css
+++ b/packages/ripple-ui-core/src/components/content/RplContent.css
@@ -6,7 +6,9 @@
   letter-spacing: var(--rpl-type-ls-1);
 
   @media (--rpl-bp-m) {
-    max-width: var(--rpl-content-max-width);
+    > :not(.rpl-media-embed, .rpl-iframe, .rpl-img, .rpl-table) {
+      max-width: var(--rpl-content-max-width);
+    }
   }
 
   & > :first-child {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1341

### What I did
<!-- Summary of changes made in the Pull Request  -->
- To match Ripple 1 we now allow media elements and tables to span full width, instead of being capped to the max-content-width of 615px

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

