### PR TITLE
[R20-1222] fix for overflowing dropdown content

### DIFF
--- a/packages/ripple-ui-forms/src/components/RplForm/RplForm.css
+++ b/packages/ripple-ui-forms/src/components/RplForm/RplForm.css
@@ -6,6 +6,10 @@
     border-left: var(--rpl-border-3) solid var(--rpl-clr-error);
     padding-left: var(--rpl-sp-3);
   }
+
+  fieldset {
+    min-width: auto;
+  }
 }
 
 .rpl-form__submit-guard {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1222

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add min-width to fieldsets, this fixes overflowing dropdowns

<img width="1540" alt="Screenshot 2023-08-09 at 5 24 11 pm" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/274e4647-629e-4943-a0b6-ce4c1f9307c7">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

