### PR TITLE
[R20-1425] allow wider header content

### DIFF
--- a/packages/ripple-ui-core/src/components/header/RplHeader.vue
+++ b/packages/ripple-ui-core/src/components/header/RplHeader.vue
@@ -2,17 +2,18 @@
 import { computed } from 'vue'
 
 interface Props {
-  fullWidth?: boolean
+  contentWidth?: 'wide' | 'full'
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  fullWidth: false
+  contentWidth: undefined
 })
 
 const mainClasses = computed(() => ({
   'rpl-header__main': true,
   'rpl-col-12': true,
-  'rpl-col-7-m': !props.fullWidth
+  'rpl-col-7-m': !props.contentWidth,
+  'rpl-col-10-m': props.contentWidth === 'wide'
 }))
 </script>
 

--- a/packages/ripple-ui-core/src/components/header/RplHeroHeader.vue
+++ b/packages/ripple-ui-core/src/components/header/RplHeroHeader.vue
@@ -54,6 +54,17 @@ const emit = defineEmits<{
 const highlight = computed(
   () => props.theme === 'reverse' || props.theme === 'neutral'
 )
+const showActions = computed(
+  () => (props.primaryAction || props.secondaryAction) && !props.background
+)
+const showLinks = computed(
+  () => props.links?.items?.length && !props.background
+)
+const contentWidth = computed(() => {
+  if (props.fullWidth) return 'full'
+
+  return !showLinks.value ? 'wide' : null
+})
 
 const classes = computed(() => ({
   'rpl-header--hero': true,
@@ -101,7 +112,7 @@ const handleClick = (event) => {
 </script>
 
 <template>
-  <RplHeader :class="classes" :full-width="fullWidth">
+  <RplHeader :class="classes" :content-width="contentWidth">
     <template v-if="background || cornerTop || cornerBottom" #behind>
       <RplImage
         v-if="background"
@@ -131,14 +142,14 @@ const handleClick = (event) => {
     >
       <slot></slot>
     </p>
-    <template v-if="(primaryAction || secondaryAction) && !background" #lower>
+    <template v-if="showActions" #lower>
       <RplHeaderActions
         :primary="primaryAction"
         :secondary="secondaryAction"
         @item-click="handleClick"
       />
     </template>
-    <template v-if="links && !background" #aside>
+    <template v-if="showLinks" #aside>
       <RplHeaderLinks
         :title="links?.title"
         :items="


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1425

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Allow header content to be 7 (default) 10 (wide) or 12 (full) cols

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

