### PR TITLE
[R20-1425] allow wider header content 

### DIFF
--- a/packages/ripple-ui-core/src/components/header/RplHeader.vue
+++ b/packages/ripple-ui-core/src/components/header/RplHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useSlots } from 'vue'
 
 interface Props {
   fullWidth?: boolean
@@ -9,10 +9,13 @@ const props = withDefaults(defineProps<Props>(), {
   fullWidth: false
 })
 
+const slots = useSlots()
+
 const mainClasses = computed(() => ({
   'rpl-header__main': true,
   'rpl-col-12': true,
-  'rpl-col-7-m': !props.fullWidth
+  'rpl-col-7-m': !props.fullWidth && slots.aside,
+  'rpl-col-10-m': !props.fullWidth && !slots.aside
 }))
 </script>
 

--- a/packages/ripple-ui-core/src/components/header/RplHeroHeader.vue
+++ b/packages/ripple-ui-core/src/components/header/RplHeroHeader.vue
@@ -138,7 +138,7 @@ const handleClick = (event) => {
         @item-click="handleClick"
       />
     </template>
-    <template v-if="links && !background" #aside>
+    <template v-if="links?.items?.length && !background" #aside>
       <RplHeaderLinks
         :title="links?.title"
         :items="

--- a/packages/ripple-ui-core/src/components/header/RplIntroHeader.vue
+++ b/packages/ripple-ui-core/src/components/header/RplIntroHeader.vue
@@ -52,7 +52,7 @@ const handleClick = (event) => {
     <div v-if="$slots.default" data-cy="summary">
       <slot></slot>
     </div>
-    <template v-if="links" #aside>
+    <template v-if="links?.items?.length" #aside>
       <RplHeaderLinks
         :title="links?.title"
         :items="


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1425

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Make header content 10 cols when no 'sidebar' exists

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

