### PR TITLE
fix(@dpc-sdp/nuxt-ripple-analytics): send all values to dataLayer

### DIFF
--- a/packages/nuxt-ripple-analytics/lib/tracker.ts
+++ b/packages/nuxt-ripple-analytics/lib/tracker.ts
@@ -38,12 +38,21 @@ export interface IRplAnalyticsEventPayload {
   }
 }
 
-const filterPayload = (payload: IRplAnalyticsEventPayload) =>
+const mapPayload = (payload: IRplAnalyticsEventPayload) =>
   Object.fromEntries(
-    Object.entries(payload).filter(
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      ([key, value]) => value !== null && value !== undefined && value !== ''
-    )
+    Object.entries(payload).map(([key, value]) => {
+      let newValue = value
+
+      if (
+        value === null ||
+        value === '' ||
+        (Array.isArray(value) && !value.length)
+      ) {
+        newValue = undefined
+      }
+
+      return [key, newValue]
+    })
   )
 
 export const trackEvent = (payload: IRplAnalyticsEventPayload) => {
@@ -53,5 +62,5 @@ export const trackEvent = (payload: IRplAnalyticsEventPayload) => {
     throw new Error('dataLayer was not initialised correctly')
   }
 
-  window.dataLayer.push(filterPayload(payload))
+  window.dataLayer.push(mapPayload(payload))
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
Send value's to the dataLayer as undefined if not in use, previously we just sent the 'in-use' values i.e. if a search page wasn't using filters we wouldn't include the filters key. However this is causing issues see JF comment below for context.

_"Because of how GTM reads from the dataLayer, if it does not find a property in the most recent dataLayer event, it will look for it going back through the array (basically it flattens all the items into a single model it reads from)  but this causes issues where values from previous DL events end up in the current GA4 event - which we don’t want. So whenever one of the params is not being used, could you please still include it but set its value to undefined (the native undefined, not a string) ."_

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

