### PR TITLE
[R20-1322] Move social share url concern to caller

### DIFF
--- a/packages/nuxt-ripple/components/TideSidebarSocialShare.vue
+++ b/packages/nuxt-ripple/components/TideSidebarSocialShare.vue
@@ -2,13 +2,20 @@
   <RplSocialShare
     data-sidebar-component-id="tide-sidebar-social-share"
     :pagetitle="pageTitle"
+    :url="url"
   />
 </template>
 
 <script setup lang="ts">
+import { useRoute } from 'vue-router'
+
 interface Props {
   pageTitle: string
 }
 
 defineProps<Props>()
+
+const { $app_origin } = useNuxtApp()
+
+const url = computed(() => `${$app_origin}${useRoute().path}`)
 </script>

--- a/packages/nuxt-ripple/composables/use-tide-page-meta.ts
+++ b/packages/nuxt-ripple/composables/use-tide-page-meta.ts
@@ -87,7 +87,6 @@ export default async (props: any) => {
     twitterImageAlt = site.socialImages.og.alt
   }
 
-  // TODO
   const { $app_origin } = useNuxtApp()
 
   // Define SEO meta

--- a/packages/ripple-ui-core/src/components/social-share/RplSocialShare.stories.mdx
+++ b/packages/ripple-ui-core/src/components/social-share/RplSocialShare.stories.mdx
@@ -29,6 +29,7 @@ export const SingleTemplate = (args) => ({
     args={{
       networks: Object.keys(RplSocialShareNetworks),
       pagetitle: 'Sample page title'
+      url: 'https://www.vic.gov.au/sample-page'
     }}
   >
     {SingleTemplate.bind()}

--- a/packages/ripple-ui-core/src/components/social-share/RplSocialShare.stories.mdx
+++ b/packages/ripple-ui-core/src/components/social-share/RplSocialShare.stories.mdx
@@ -28,7 +28,7 @@ export const SingleTemplate = (args) => ({
     play={a11yStoryCheck}
     args={{
       networks: Object.keys(RplSocialShareNetworks),
-      pagetitle: 'Sample page title'
+      pagetitle: 'Sample page title',
       url: 'https://www.vic.gov.au/sample-page'
     }}
   >

--- a/packages/ripple-ui-core/src/components/social-share/RplSocialShare.vue
+++ b/packages/ripple-ui-core/src/components/social-share/RplSocialShare.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, onMounted, computed } from 'vue'
+import { computed } from 'vue'
 import { RplSocialShareNetworks } from './constants'
 import RplSocialShareLink from './RplSocialShareLink.vue'
 
@@ -7,6 +7,7 @@ interface Props {
   title?: string
   networks?: string[]
   pagetitle: string
+  url: string // url to be determined by caller
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -18,18 +19,10 @@ const props = withDefaults(defineProps<Props>(), {
 const validNetworks = computed(() =>
   props.networks.filter((k) => Object.keys(RplSocialShareNetworks).includes(k))
 )
-
-const state = reactive({
-  url: ''
-})
-
-onMounted(() => {
-  state.url = location.href
-})
 </script>
 
 <template>
-  <div v-if="pagetitle && state.url" class="rpl-social-share rpl-u-screen-only">
+  <div v-if="pagetitle && url" class="rpl-social-share rpl-u-screen-only">
     <h3 v-if="title" class="rpl-social-share__title rpl-type-label-large">
       {{ title }}
     </h3>
@@ -40,7 +33,7 @@ onMounted(() => {
         :network="network"
         :title="pagetitle"
         :label="title"
-        :url="state.url"
+        :url="url"
       ></RplSocialShareLink>
     </div>
   </div>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1322

### What I did
<!-- Summary of changes made in the Pull Request  -->
- `RplSocialShare` is now just presentational, it will use whatever url is provided
- Set origin and path at caller, already set in `nuxt-ripple` (url is hard coded in storybook story)

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

