### PR TITLE
[R20-1463] add custom loading indicator

### DIFF
--- a/packages/nuxt-ripple/app.vue
+++ b/packages/nuxt-ripple/app.vue
@@ -1,6 +1,6 @@
 <template>
   <NuxtLayout>
-    <NuxtLoadingIndicator color="var(--rpl-clr-primary)" />
+    <TideLoadingIndicator />
     <NuxtPage />
   </NuxtLayout>
 </template>

--- a/packages/nuxt-ripple/components/TideLoadingIndicator.vue
+++ b/packages/nuxt-ripple/components/TideLoadingIndicator.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter, useNuxtApp } from '#imports'
+
+interface Props {
+  delay?: number
+  duration?: number
+  height?: number
+  colour?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  delay: 200,
+  duration: 2000,
+  height: 3,
+  colour: 'var(--rpl-clr-primary)'
+})
+
+const router = useRouter()
+const nuxtApp = useNuxtApp()
+const progress = ref(0)
+const timer = ref(null)
+const throttle = ref(null)
+
+const start = () => {
+  if (typeof window !== 'undefined') {
+    throttle.value = setTimeout(() => {
+      timer.value = setInterval(() => {
+        if (progress.value < 100) progress.value += 1
+      }, props.duration / 100)
+    }, props.delay)
+  }
+}
+
+const finish = () => {
+  if (typeof window !== 'undefined') {
+    clearInterval(timer.value)
+    clearTimeout(throttle.value)
+
+    if (progress.value) progress.value = 100
+
+    setTimeout(() => (progress.value = 0), 100)
+  }
+}
+
+router.onError(finish)
+nuxtApp.hook('page:start', start)
+nuxtApp.hook('page:finish', finish)
+
+const style = computed(() => ({
+  height: `${props.height}px`,
+  background: props.colour,
+  opacity: progress.value ? 1 : 0,
+  transform: `scaleX(${progress.value}%)`
+}))
+</script>
+
+<template>
+  <div class="tide-loading-indicator" :style="style" />
+</template>
+
+<style>
+.tide-loading-indicator {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 999;
+  transform-origin: left;
+  transition: transform 0.1s;
+}
+</style>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1463

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Nuxt recently made a change (https://github.com/nuxt/nuxt/pull/21656) that meant the loading indicator no-longer works for us, so this adds our own TideLoadingIndicator

<img width="977" alt="Screenshot 2023-08-22 at 9 33 02 am" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/a436b1a4-15e6-4f0a-98a3-ae781b17f8cb">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

