### PR TITLE
[R20-1480] Use li for card element

### DIFF
--- a/packages/ripple-tide-publication/components/TidePublicationChapterCard.vue
+++ b/packages/ripple-tide-publication/components/TidePublicationChapterCard.vue
@@ -1,5 +1,10 @@
 <template>
-  <RplNavCard :title="chapter.title" :url="chapter.url" class="rpl-col-12">
+  <RplNavCard
+    :title="chapter.title"
+    :url="chapter.url"
+    el="li"
+    class="rpl-col-12"
+  >
     <p>{{ chapter.summary }}</p>
   </RplNavCard>
 </template>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1480

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Publication index nav cards are marked up as a `ul`, so use an `li` for the card element
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

