### PR TITLE
[R20-1311] Default fallback icon

### DIFF
--- a/packages/ripple-ui-core/src/components/contact-us/RplContactUs.stories.mdx
+++ b/packages/ripple-ui-core/src/components/contact-us/RplContactUs.stories.mdx
@@ -71,6 +71,11 @@ export const SingleTemplate = (args) => ({
           text: '@instagramhandle',
           url: 'https://i',
           icon: 'icon-instagram'
+        },
+        {
+          text: '@falsehandle',
+          url: 'https://no',
+          icon: 'icon-fake'
         }
       ]
     }}

--- a/packages/ripple-ui-core/src/components/icon/RplIcon.vue
+++ b/packages/ripple-ui-core/src/components/icon/RplIcon.vue
@@ -21,6 +21,9 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const inSprite = ref(RplCoreIconNames.find((key) => key === props.name))
+const inCustomImports = ref(
+  Object.keys(customIconImports).find((key) => key === props.name)
+)
 
 const asyncIcon = computed(() => {
   if (!inSprite.value) {
@@ -47,7 +50,13 @@ const classes = computed(() => [
 
 <template>
   <span :class="classes">
-    <component :is="asyncIcon" v-if="name && !inSprite && asyncIcon" />
+    <template v-if="name && !inSprite">
+      <component :is="asyncIcon" v-if="inCustomImports" />
+      <svg v-else :role="title ? undefined : 'presentation'">
+        <title v-if="title">{{ title }}</title>
+        <use xlink:href="#icon-link-external-square-filled"></use>
+      </svg>
+    </template>
     <svg v-else-if="name" :role="title ? undefined : 'presentation'">
       <title v-if="title">{{ title }}</title>
       <use :xlink:href="`#${name}`"></use>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1311

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Slightly rework `RplIcon` to introduce a default fallback if the name prop isn't in either core or custom lists
- Might be worth adding an error log to sumo if the fallback is hit (it could indicate an icon isn't being used properly)
- Default is the highly specific `icon-link-external-square-filled`, there wasn't really anything more generic available in the core set

![Screenshot 2023-08-23 at 1 24 33 pm](https://github.com/dpc-sdp/ripple-framework/assets/863542/01e6dffe-c76a-4d7a-ac0d-f5b3115bd578)

### How to test
<!-- Summary of how to test  -->
- Added a purposefully non-matching entry to the end of `RplContactUs` in storybook to demonstrate
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

