### PR TITLE
fix(@dpc-sdp/ripple-ui-core): fix divider displaying when no cobrand

### DIFF
--- a/examples/nuxt-app/test/features/site/theme.feature
+++ b/examples/nuxt-app/test/features/site/theme.feature
@@ -35,5 +35,6 @@ Feature: Site theme
     And the page endpoint for path "/" returns fixture "/landingpage/image-banner" with status 200
     Given I visit the page "/"
     Then the vic.gov.au logo should not be displayed
+    And the cobrand logo should be displayed
 
 

--- a/examples/nuxt-app/test/fixtures/site/disable-vic-logo.json
+++ b/examples/nuxt-app/test/fixtures/site/disable-vic-logo.json
@@ -6,6 +6,11 @@
     "twitter": {},
     "og": {}
   },
+  "siteLogo": {
+    "href": "/",
+    "src": "https://placehold.co/140x40",
+    "altText": ""
+  },
   "featureFlags": {
     "disablePrimaryLogo": true
   },

--- a/packages/ripple-test-utils/step_definitions/common/site/theme.ts
+++ b/packages/ripple-test-utils/step_definitions/common/site/theme.ts
@@ -39,3 +39,6 @@ Then('the vic.gov.au logo should be displayed', (theme: string) => {
 Then('the vic.gov.au logo should not be displayed', (theme: string) => {
   cy.get(`[aria-label="Victoria government logo"]`).should('not.exist')
 })
+Then('the cobrand logo should be displayed', (theme: string) => {
+  cy.get('.rpl-primary-nav__secondary-logo-image').should('exist')
+})

--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
@@ -105,7 +105,10 @@ const handleToggleItem = (level: number, item) => {
       </RplLink>
 
       <!-- Logo divider -->
-      <div v-if="secondaryLogo" class="rpl-primary-nav__logo-divider"></div>
+      <div
+        v-if="secondaryLogo && !disablePrimaryLogo"
+        class="rpl-primary-nav__logo-divider"
+      ></div>
 
       <!-- Secondary logo -->
       <RplLink


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- Fix divider showing when vic logo disabled

![Screenshot 2023-08-23 at 5 04 56 pm](https://github.com/dpc-sdp/ripple-framework/assets/2186721/e4bc0dbc-6404-4bc6-aaf5-720af41e506d)


### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

