### PR TITLE
[R20-1344] search listing date 'range'

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/events.feature
+++ b/examples/nuxt-app/test/features/search-listing/events.feature
@@ -1,0 +1,17 @@
+Feature: Events collection
+
+  Background:
+    Given the site endpoint returns fixture "/site/reference" with status 200
+
+  @mockserver
+  Example: Results formatting
+    Given the page endpoint for path "/events" returns fixture "/search-listing/events/page" with status 200
+    And the search network request is stubbed with fixture "/search-listing/events/response" and status 200
+    When I visit the page "/events"
+    Then the search listing page should have 2 results
+    And the search listing layout should be "grid"
+    And the search network request should be called with the "/search-listing/events/request" fixture
+    And the event search listing results should have following items:
+      | title              | url                 | date                      | content                                                                                                                       | location  |
+      | Autumn Garden Tour | /autumn-garden-tour | 4 March 2023              | A special guided tour of the Shrine Reserve including Devonshire Tea.                                                         | Melbourne |
+      | March to Art       | /march-art          | 19 March to 21 March 2023 | Join us for a relaxing afternoon of folk, indie, jazz & contemporary music and performances by veteran musicians and artists. | Bendigo   |

--- a/examples/nuxt-app/test/features/search-listing/filters.feature
+++ b/examples/nuxt-app/test/features/search-listing/filters.feature
@@ -22,7 +22,6 @@ Feature: Search listing - Filter
     When I toggle the search listing filters section
     Then the search listing dropdown field labelled "Raw filter example" should have the value "Dogs, Birds"
 
-
   @mockserver
   Example: Term filter - Should reflect a single value from the URL
     Given the page endpoint for path "/filters" returns fixture "/search-listing/filters/page" with status 200
@@ -97,6 +96,20 @@ Feature: Search listing - Filter
 
     When I toggle the search listing filters section
     Then the search listing dropdown field labelled "Custom function filter example" should have the value "Open, Closed"
+
+  @mockserver
+  Example: Range filter - Should reflect a single value from the URL
+    Given the page endpoint for path "/filters" returns fixture "/search-listing/filters/page" with status 200
+    And the search network request is stubbed with fixture "/search-listing/filters/response" and status 200
+
+    When I visit the page "/filters?rangeFilterFrom=2022-05-20"
+    Then the search listing page should have 2 results
+    And the search network request should be called with the "/search-listing/filters/request-range" fixture
+
+    Then the filters toggle should show 1 applied filters
+
+    When I toggle the search listing filters section
+    Then the search listing date field labelled "Select a date" should have the value "2022-05-20"
 
   @mockserver
   Example: Clear filters

--- a/examples/nuxt-app/test/fixtures/search-listing/events/page.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/events/page.json
@@ -1,0 +1,121 @@
+{
+  "title": "Event listing",
+  "changed": "2023-08-22T05:31:10+00:00",
+  "created": "2023-08-22T02:19:10+00:00",
+  "type": "tide_search_listing",
+  "nid": "0af58113-6c1d-4b29-bbed-a166d8410c9c",
+  "sidebar": {},
+  "status": "published",
+  "topicTags": [],
+  "siteSection": null,
+  "meta": {
+    "langcode": "en",
+    "description": "",
+    "additional": [
+      {
+        "tag": "meta",
+        "attributes": {
+          "name": "title",
+          "content": "Event listing | Vic.gov.au"
+        }
+      },
+      {
+        "tag": "link",
+        "attributes": {
+          "rel": "canonical",
+          "href": "https://nginx-php.pr-1554.content-vic.sdp4.sdp.vic.gov.au/whatson"
+        }
+      }
+    ],
+    "keywords": "",
+    "image": null
+  },
+  "showContentRating": true,
+  "summary": null,
+  "afterResults": "",
+  "introText": null,
+  "config": {
+    "searchListingConfig": {
+      "resultsPerPage": 9,
+      "labels": {
+        "submit": "Search by keyword",
+        "placeholder": "Search by keyword..."
+      },
+      "customSort": [
+        {
+          "field_event_date_end_value": "asc"
+        }
+      ]
+    },
+    "queryConfig": {
+      "match_phrase": {
+        "title": {
+          "query": "{{query}}"
+        }
+      }
+    },
+    "results": {
+      "layout": {
+        "component": "TideSearchResultsGrid"
+      },
+      "item": {
+        "*": {
+          "component": "TideEventSearchResult"
+        }
+      }
+    },
+    "globalFilters": [
+      {
+        "terms": {
+          "type": [
+            "event"
+          ]
+        }
+      },
+      {
+        "terms": {
+          "field_node_site": [
+            4
+          ]
+        }
+      }
+    ],
+    "userFilters": [
+      {
+        "id": "category",
+        "component": "TideSearchFilterDropdown",
+        "filter": {
+          "type": "terms",
+          "value": "field_event_category_name"
+        },
+        "aggregations": {
+          "field": "field_event_category_name",
+          "source": "elastic"
+        },
+        "props": {
+          "id": "category",
+          "label": "Event Category",
+          "placeholder": "Select event category",
+          "type": "RplFormDropdown",
+          "multiple": true
+        }
+      },
+      {
+        "id": "date",
+        "component": "TideSearchFilterDate",
+        "classes": "rpl-col-12-m",
+        "filter": {
+          "type": "range",
+          "comparator": "gte",
+          "value": "field_event_date_end_value"
+        },
+        "props": {
+          "id": "date",
+          "label": "Event date",
+          "type": "RplFormDate"
+        }
+      }
+    ]
+  },
+  "_fetched": 1692682318351
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/events/request.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/events/request.json
@@ -1,0 +1,34 @@
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match_all": {}
+        }
+      ],
+      "filter": [
+        {
+          "terms": {
+            "type": [
+              "event"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [
+              4
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "size": 9,
+  "from": 0,
+  "sort": [
+    {
+      "field_event_date_end_value": "asc"
+    }
+  ]
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/events/response.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/events/response.json
@@ -1,0 +1,259 @@
+{
+  "took": 2,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 204,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "a83890f7a31dea14e1ae83c6f0afacca--elasticsearch_index_develop_node",
+        "_id": "entity:node/30004:en",
+        "_score": null,
+        "_ignored": [
+          "body.keyword"
+        ],
+        "_source": {
+          "_language": "en",
+          "node_grants": [
+            "node_access_all:0"
+          ],
+          "url": [
+            "/site-290/autumn-garden-tour"
+          ],
+          "body": [
+            "As the leaves start to turn, explore the Shrine Reserve on this special guided tour. Learn how the architectural vision for the Shrine is reflected in the gardens and symbology of plantings. Discover the role of trees in remembrance and how the sprawling gardens provide respite to remember those who have served our nation in peacekeeping and war. There are two tour times available: 10.30am and 1pm. Tour duration is 90 minutes.  Between the tours, a Devonshire tea is available to both groups and included in the ticket price. This will run from 12pm to 1pm. The starting point of the tour is the Shrine Visitor Centre. ﻿Important information to read before you book: A moderate level of fitness is required for this tour. It involves walking on both paved and grassed surfaces with some small inclines. Covered and comfortable walking shoes are recommended.  Come prepared with a hat, sunscreen and water in hot weather. In the event of extreme weather, you will be contacted by the Shrine with alternative arrangements. "
+          ],
+          "changed": [
+            "2023-01-24T13:05:21+11:00"
+          ],
+          "created": [
+            "2023-01-23T14:36:11+11:00"
+          ],
+          "field_event_category_name": [
+            "Talks and workshops"
+          ],
+          "field_event_category_tid": [
+            97
+          ],
+          "field_event_category_uuid": [
+            "24886bff-c722-4180-ad83-38c2449004da"
+          ],
+          "field_event_date_end_value": [
+            "2023-03-04T14:30:00+11:00"
+          ],
+          "field_event_date_start_value": [
+            "2023-03-04T10:30:00+11:00"
+          ],
+          "field_event_details_event_address_1": [
+            "Shrine of Remembrance"
+          ],
+          "field_event_details_event_address_line2": [
+            ""
+          ],
+          "field_event_details_event_administrative_area": [
+            ""
+          ],
+          "field_event_details_event_locality": [
+            "Melbourne"
+          ],
+          "field_event_details_event_postal_code": [
+            "3004"
+          ],
+          "field_event_details_event_price_from": [
+            "20"
+          ],
+          "field_landing_page_summary": [
+            "A special guided tour of the Shrine Reserve including Devonshire Tea."
+          ],
+          "field_media_image_absolute_path": [
+            "https://develop.content.vic.gov.au/sites/default/files/2023-01/Untitled-design-%282%29.png"
+          ],
+          "field_node_primary_csite": [
+            290
+          ],
+          "field_node_site": [
+            290,
+            4
+          ],
+          "field_paragraph_link": [
+            "https://shrine.rezdy.com/543825/autumn-garden-tour?_gl\u003d1%2A8zm3br%2A_ga%2ANTg0MjIzNDEyLjE2NDY2MDQ5NjQ.%2A_ga_J7SXS0R0D6%2AMTY3NDQ0MjEzMy4zMDguMS4xNjc0NDQ0OTUzLjU3LjAuMA.."
+          ],
+          "field_paragraph_link_text": [
+            "Book now"
+          ],
+          "field_topic": [
+            1
+          ],
+          "field_topic_name": [
+            "Arts, culture \u0026 heritage"
+          ],
+          "field_topic_path": [
+            "/topic/arts-culture-heritage"
+          ],
+          "field_topic_uuid": [
+            "46178ef3-78f4-4a5a-ab84-492e3a5a61b6"
+          ],
+          "langcode": [
+            "en"
+          ],
+          "nid": [
+            30004
+          ],
+          "status": [
+            true
+          ],
+          "summary_processed": [
+            ""
+          ],
+          "title": [
+            "Autumn Garden Tour"
+          ],
+          "type": [
+            "event"
+          ],
+          "uid": [
+            9804
+          ],
+          "uuid": [
+            "93f454fd-7ccc-48c8-9e2f-23c0d0f42d2e"
+          ]
+        },
+        "sort": [
+          1677900600000
+        ]
+      },
+      {
+        "_index": "a83890f7a31dea14e1ae83c6f0afacca--elasticsearch_index_develop_node",
+        "_id": "entity:node/30892:en",
+        "_score": null,
+        "_ignored": [
+          "body.keyword"
+        ],
+        "_source": {
+          "_language": "en",
+          "node_grants": [
+            "node_access_all:0"
+          ],
+          "url": [
+            "/site-290/march-art"
+          ],
+          "body": [
+            "Join us for a relaxing afternoon of folk, indie, jazz and contemporary music and performances by veteran musicians and artists. Stay for the Last Post Service at 4.45pm to close out the afternoon in reflection, camaraderie and commemoration.   Bring a picnic \u0026 rug! Coffee, tea and snacks are available at the Shrine Shop. This is a no-alcohol, family event.   Presented by the  Australian National Veterans Art Museum (ANVAM) as part of their annual Arts Festival, March to Art: Create ."
+          ],
+          "changed": [
+            "2023-02-28T14:10:41+11:00"
+          ],
+          "created": [
+            "2023-02-28T14:03:56+11:00"
+          ],
+          "field_event_category_name": [
+            "Talks and workshops"
+          ],
+          "field_event_category_tid": [
+            97
+          ],
+          "field_event_category_uuid": [
+            "24886bff-c722-4180-ad83-38c2449004da"
+          ],
+          "field_event_date_end_value": [
+            "2023-03-21T16:30:00+11:00"
+          ],
+          "field_event_date_start_value": [
+            "2023-03-19T13:30:00+11:00"
+          ],
+          "field_event_details_event_address_1": [
+            "Education Courtyard, Shrine of Remembrance"
+          ],
+          "field_event_details_event_address_line2": [
+            ""
+          ],
+          "field_event_details_event_administrative_area": [
+            "VIC"
+          ],
+          "field_event_details_event_locality": [
+            "Bendigo"
+          ],
+          "field_event_details_event_postal_code": [
+            "3001"
+          ],
+          "field_event_details_event_requirements_name": [
+            "Free admission",
+            "Child friendly"
+          ],
+          "field_event_details_event_requirements_tid": [
+            86,
+            85
+          ],
+          "field_event_details_event_requirements_uuid": [
+            "88709d94-4be0-4a38-803d-f1d178edcdcf",
+            "a603acbb-b184-4ce6-bc17-5f676663df98"
+          ],
+          "field_event_intro_text": [
+            "Live music at the Shrine"
+          ],
+          "field_landing_page_summary": [
+            "Join us for a relaxing afternoon of folk, indie, jazz \u0026 contemporary music and performances by veteran musicians and artists."
+          ],
+          "field_media_image_absolute_path": [
+            "https://develop.content.vic.gov.au/sites/default/files/2023-02/818-x-496.jpg"
+          ],
+          "field_node_primary_csite": [
+            290
+          ],
+          "field_node_site": [
+            290,
+            4
+          ],
+          "field_topic": [
+            3
+          ],
+          "field_topic_name": [
+            "Communities"
+          ],
+          "field_topic_path": [
+            "/topic/communities"
+          ],
+          "field_topic_uuid": [
+            "99d1629f-0227-4e91-bd83-e5998636074a"
+          ],
+          "langcode": [
+            "en"
+          ],
+          "nid": [
+            30892
+          ],
+          "status": [
+            true
+          ],
+          "summary_processed": [
+            ""
+          ],
+          "title": [
+            "March to Art"
+          ],
+          "type": [
+            "event"
+          ],
+          "uid": [
+            7443
+          ],
+          "uuid": [
+            "73aa803c-009c-4174-be97-5a00b4cf9458"
+          ]
+        },
+        "sort": [
+          1679203800000
+        ]
+      }
+    ]
+  }
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/filters/page.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/filters/page.json
@@ -167,6 +167,20 @@
             }
           ]
         }
+      },
+      {
+        "id": "rangeFilterFrom",
+        "component": "TideSearchFilterDate",
+        "filter": {
+          "type": "range",
+          "comparator": "gte",
+          "value": "rangeFilterFrom.value"
+        },
+        "props": {
+          "id": "rangeFilterFrom",
+          "label": "Select a date",
+          "type": "RplFormDate"
+        }
       }
     ]
   }

--- a/examples/nuxt-app/test/fixtures/search-listing/filters/request-range.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/filters/request-range.json
@@ -1,0 +1,38 @@
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match_all": {}
+        }
+      ],
+      "filter": [
+        {
+          "terms": {
+            "type": ["grant"]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [8888]
+          }
+        },
+        {
+          "range": {
+            "rangeFilterFrom.value": { "gte": "2022-05-20" }
+          }
+        }
+      ]
+    }
+  },
+  "size": 10,
+  "from": 0,
+  "sort": [
+    {
+      "_score": "desc"
+    },
+    {
+      "_doc": "desc"
+    }
+  ]
+}

--- a/packages/ripple-test-utils/step_definitions/content-types/event.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/event.ts
@@ -21,3 +21,28 @@ Then(
     })
   }
 )
+
+Then(
+  'the event search listing results should have following items:',
+  (dataTable: DataTable) => {
+    const table = dataTable.hashes()
+
+    table.forEach((row, i: number) => {
+      cy.get('.tide-event-search-result')
+        .eq(i)
+        .then((item) => {
+          cy.wrap(item).as('item')
+          cy.get('@item').should('contain', row.title)
+          cy.get('@item').should('contain', row.content)
+          cy.get('@item')
+            .find('a')
+            .should('have.attr', 'href')
+            .should('contain', row.url)
+          cy.get('@item').find('.rpl-card__meta').should('contain', row.date)
+          cy.get('@item')
+            .find('.tide-event-search-result__location')
+            .should('contain', row.location)
+        })
+    })
+  }
+)

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -168,6 +168,29 @@ When(
   }
 )
 
+Then(
+  `the search listing date field labelled {string} should have the value {string}`,
+  (label: string, value: string) => {
+    cy.get(`legend`)
+      .contains(label)
+      .parent()
+      .invoke('attr', 'id')
+      .then((dropdownId) => {
+        const [year, month, day] = value.split('-')
+        cy.get(`#${dropdownId}`).as('selectedDate')
+        cy.get('@selectedDate')
+          .find(`#${dropdownId}__day`)
+          .should('have.value', Number(day))
+        cy.get('@selectedDate')
+          .find(`#${dropdownId}__month`)
+          .should('have.value', Number(month))
+        cy.get('@selectedDate')
+          .find(`#${dropdownId}__year`)
+          .should('have.value', Number(year))
+      })
+  }
+)
+
 When(`I toggle the search listing filters section`, () => {
   cy.get(`button`).contains('Refine search').click()
 })

--- a/packages/ripple-tide-event/components/global/TideEventSearchResult.vue
+++ b/packages/ripple-tide-event/components/global/TideEventSearchResult.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { getSearchResultValue, useSearchResult } from '#imports'
+import { formatDateRange } from '@dpc-sdp/ripple-ui-core'
+
+interface Props {
+  result: any
+}
+
+const props = defineProps<Props>()
+
+const { title, url, summary, image } = useSearchResult(props.result)
+
+const date = computed(() => {
+  return formatDateRange({
+    from: getSearchResultValue(
+      props.result,
+      'field_event_date_start_value',
+      true
+    ),
+    to: getSearchResultValue(props.result, 'field_event_date_end_value', true)
+  })
+})
+
+const location = computed(() => {
+  const locality = getSearchResultValue(
+    props.result,
+    'field_event_details_event_locality',
+    true
+  )
+
+  return Array.isArray(locality) ? locality[0] : locality
+})
+</script>
+
+<template>
+  <RplNavCard
+    :title="title"
+    :url="url"
+    :image="image"
+    class="tide-event-search-result"
+  >
+    <template #meta>
+      <RplTag v-if="date" variant="neutral" :label="date" />
+    </template>
+    <p>{{ summary }}</p>
+    <span v-if="location" class="tide-event-search-result__location">
+      <RplIcon name="icon-pin" colour="default" />
+      {{ location }}
+    </span>
+  </RplNavCard>
+</template>
+
+<style>
+.tide-event-search-result__location {
+  display: flex;
+  gap: var(--rpl-sp-2);
+  align-items: center;
+  margin-top: var(--rpl-sp-3);
+}
+</style>

--- a/packages/ripple-tide-search/components/TideSearchFilters.vue
+++ b/packages/ripple-tide-search/components/TideSearchFilters.vue
@@ -9,7 +9,9 @@
       <div
         v-for="filter in filterInputs"
         :key="filter.id"
-        class="rpl-col-12 rpl-col-6-m"
+        :class="`rpl-col-12 ${
+          filter?.columns ? filter.columns : 'rpl-col-6-m'
+        }`"
       >
         <component
           :is="filter.component"

--- a/packages/ripple-tide-search/components/global/TideSearchFilterDate.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchFilterDate.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+interface Props {
+  id: string
+  label: string
+  timestamp?: string
+}
+defineProps<Props>()
+</script>
+
+<template>
+  <FormKit
+    :id="id"
+    :key="`${id}-${timestamp}`"
+    :name="id"
+    type="RplFormDate"
+    :label="label"
+  />
+</template>

--- a/packages/ripple-tide-search/composables/useTideSearch.ts
+++ b/packages/ripple-tide-search/composables/useTideSearch.ts
@@ -120,9 +120,11 @@ export default (
   const userFilters = computed(() => {
     return Object.keys(filterForm.value).map((key: string) => {
       const itm = userFilterConfig.find((itm: any) => itm.id === key)
+      let filterVal = filterForm.value[key]
 
-      const filterVal =
-        filterForm.value[key] && Array.from(filterForm.value[key])
+      if (itm.component === 'TideSearchFilterDropdown') {
+        filterVal = filterForm.value[key] && Array.from(filterForm.value[key])
+      }
 
       // Need to work out if form has value - will be different for different controls
       const hasValue = (v: unknown) => {
@@ -150,6 +152,20 @@ export default (
             prefix: {
               [`${itm.filter.value}`]: {
                 value: Array.isArray(filterVal) ? filterVal[0] : filterVal
+              }
+            }
+          }
+        }
+
+        /**
+         * The ES range query expects a single value
+         *  - Comparators are gt, gte, lt and lte: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
+         */
+        if (itm.filter.type === 'range') {
+          return {
+            range: {
+              [`${itm.filter.value}`]: {
+                [`${itm.filter.comparator}`]: filterVal
               }
             }
           }
@@ -321,12 +337,17 @@ export default (
    * Updates the URL to trigger a new search, always returns to page 1 to avoid empty pages
    */
   const submitSearch = async () => {
+    const filterFormValues = Object.fromEntries(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      Object.entries(filterForm.value).filter(([key, value]) => value)
+    )
+
     await navigateTo({
       path: route.path,
       query: {
         page: 1,
         q: searchTerm.value || undefined,
-        ...filterForm.value
+        ...filterFormValues
       }
     })
   }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1344

### What I did
<!-- Summary of changes made in the Pull Request  -->
- adding support for date inputs and 'range' query i.e. select date from or date to

<img width="437" alt="Screenshot 2023-08-24 at 9 10 44 am" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/49c05bd8-efbd-4762-aa16-79995f3b474d">

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

