### PR TITLE
fix faulty isProduction check

### DIFF
--- a/packages/nuxt-ripple-analytics/lib/routeChange.ts
+++ b/packages/nuxt-ripple-analytics/lib/routeChange.ts
@@ -4,11 +4,12 @@ import { getBreadcrumbs } from '#imports'
 const trimValue = (value: any) =>
   typeof value === 'string' ? value.trim() : value
 
-export default function ({ route, site, page }): IRplAnalyticsEventPayload {
-  const production =
-    typeof process !== 'undefined' &&
-    process?.env?.LAGOON_ENVIRONMENT_TYPE === 'production'
-
+export default function ({
+  production,
+  route,
+  site,
+  page
+}): IRplAnalyticsEventPayload {
   const payload: IRplAnalyticsEventPayload = {
     production,
     event: 'routeChange',

--- a/packages/nuxt-ripple-analytics/lib/routeChange.ts
+++ b/packages/nuxt-ripple-analytics/lib/routeChange.ts
@@ -1,15 +1,13 @@
 import { IRplAnalyticsEventPayload } from './tracker'
 import { getBreadcrumbs } from '#imports'
+import { useRuntimeConfig } from '#app'
 
 const trimValue = (value: any) =>
   typeof value === 'string' ? value.trim() : value
 
-export default function ({
-  production,
-  route,
-  site,
-  page
-}): IRplAnalyticsEventPayload {
+export default function ({ route, site, page }): IRplAnalyticsEventPayload {
+  const production = useRuntimeConfig()?.public?.isProduction
+
   const payload: IRplAnalyticsEventPayload = {
     production,
     event: 'routeChange',

--- a/packages/nuxt-ripple-analytics/plugins/analytics.ts
+++ b/packages/nuxt-ripple-analytics/plugins/analytics.ts
@@ -26,6 +26,7 @@ const setupGTM = (GTM_ID: string) => {
 export default defineNuxtPlugin((nuxtApp) => {
   const appConfig = useAppConfig()?.ripple
   const runtimeConfig = useRuntimeConfig()?.public?.tide
+  const production = useRuntimeConfig()?.public?.isProduction
   const eventListeners: Record<string, any> =
     appConfig?.analytics?.eventListeners
 
@@ -38,7 +39,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
       if (appConfig?.analytics?.routeChange === false) return
 
-      let payload = routeChange({ route, site, page })
+      let payload = routeChange({ production, route, site, page })
 
       // let the main nuxt app and layers extend or override the payload
       if (typeof appConfig?.analytics?.routeChange === 'object') {

--- a/packages/nuxt-ripple-analytics/plugins/analytics.ts
+++ b/packages/nuxt-ripple-analytics/plugins/analytics.ts
@@ -26,7 +26,6 @@ const setupGTM = (GTM_ID: string) => {
 export default defineNuxtPlugin((nuxtApp) => {
   const appConfig = useAppConfig()?.ripple
   const runtimeConfig = useRuntimeConfig()?.public?.tide
-  const production = useRuntimeConfig()?.public?.isProduction
   const eventListeners: Record<string, any> =
     appConfig?.analytics?.eventListeners
 
@@ -39,7 +38,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
       if (appConfig?.analytics?.routeChange === false) return
 
-      let payload = routeChange({ production, route, site, page })
+      let payload = routeChange({ route, site, page })
 
       // let the main nuxt app and layers extend or override the payload
       if (typeof appConfig?.analytics?.routeChange === 'object') {

--- a/packages/nuxt-ripple/nuxt.config.ts
+++ b/packages/nuxt-ripple/nuxt.config.ts
@@ -19,6 +19,7 @@ export default defineNuxtConfig({
     public: {
       siteUrl: '',
       apiUrl: '',
+      isProduction: process.env?.LAGOON_ENVIRONMENT_TYPE === 'production',
       tide: {
         baseUrl: 'https://develop.content.reference.sdp.vic.gov.au',
         site: '8888'


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Set isProduction flag as part of runtime config

_See production=true in client side analytics events (when LAGOON_ENVIRONMENT_TYPE===production)_

<img width="591" alt="Screenshot 2023-08-25 at 12 40 04 pm" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/a719c8b6-6a33-4e6c-b07a-f4185675a0ea">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

