### PR TITLE
fix: use derived page title instead of metatag value

### DIFF
--- a/examples/nuxt-app/test/features/site/shared-elements.feature
+++ b/examples/nuxt-app/test/features/site/shared-elements.feature
@@ -2,6 +2,14 @@ Feature: Shared site elements
 
   As a user I can view and interact with shared elements such as the primary nav and footer.
 
+  @mockserver @only
+  Scenario: Page title
+    Given the site endpoint returns fixture "/site/shared-elements" with status 200
+    And the page endpoint for path "/" returns fixture "/landingpage/home" with status 200
+    Given I visit the page "/"
+    Then the page title should be "Demo Landing Page | vic.gov.au"
+
+
   @mockserver
   Scenario: Breadcrumbs (page exists in menu)
     Given the site endpoint returns fixture "/site/shared-elements" with status 200

--- a/examples/nuxt-app/test/features/site/shared-elements.feature
+++ b/examples/nuxt-app/test/features/site/shared-elements.feature
@@ -2,7 +2,7 @@ Feature: Shared site elements
 
   As a user I can view and interact with shared elements such as the primary nav and footer.
 
-  @mockserver @only
+  @mockserver
   Scenario: Page title
     Given the site endpoint returns fixture "/site/shared-elements" with status 200
     And the page endpoint for path "/" returns fixture "/landingpage/home" with status 200

--- a/examples/nuxt-app/test/fixtures/landingpage/home.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/home.json
@@ -688,11 +688,7 @@
           "Row One Column Three"
         ],
         "items": [
-          [
-            "Row Two Column One",
-            "Row Two Column Two",
-            "Row Two Column Three"
-          ],
+          ["Row Two Column One", "Row Two Column Two", "Row Two Column Three"],
           [
             "Row Three Column One",
             "Row Three Column Two",
@@ -702,36 +698,36 @@
       }
     },
     {
-      "component":"TideLandingPageCategoryGrid",
-      "id":"7052",
-      "title":"Category Grid",
-      "props":{
-        "items":[
+      "component": "TideLandingPageCategoryGrid",
+      "id": "7052",
+      "title": "Category Grid",
+      "props": {
+        "items": [
           {
-            "title":"Card one",
-            "summary":"Card one summary",
-            "image":{
-              "src":"https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/Aerial-shot-of-new-housing-development.jpg",
-              "alt":"",
-              "focalPoint":null,
-              "height":667,
-              "title":"",
-              "width":1000
+            "title": "Card one",
+            "summary": "Card one summary",
+            "image": {
+              "src": "https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/Aerial-shot-of-new-housing-development.jpg",
+              "alt": "",
+              "focalPoint": null,
+              "height": 667,
+              "title": "",
+              "width": 1000
             },
-            "url":"/landing-page-cc-2"
+            "url": "/landing-page-cc-2"
           },
           {
-            "title":"Card two",
-            "summary":"Card two summary",
-            "image":{
-              "src":"https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/2018-19-State-Budget.jpg",
-              "alt":"",
-              "focalPoint":null,
-              "height":667,
-              "title":"",
-              "width":1000
+            "title": "Card two",
+            "summary": "Card two summary",
+            "image": {
+              "src": "https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/2018-19-State-Budget.jpg",
+              "alt": "",
+              "focalPoint": null,
+              "height": 667,
+              "title": "",
+              "width": 1000
             },
-            "url":"https://google.com/"
+            "url": "https://google.com/"
           }
         ]
       }
@@ -746,14 +742,14 @@
         "tag": "link",
         "attributes": {
           "rel": "canonical",
-          "href": "https://develop.content.reference.sdp.vic.gov.au/demo-landing-page"
+          "href": "https://www.vic.gov.au/demo-landing-page"
         }
       },
       {
         "tag": "meta",
         "attributes": {
           "name": "title",
-          "content": "Demo Landing Page | Single Digital Presence Content Management System"
+          "content": "Ignore this titel | Single Digital Presence Content Management System"
         }
       },
       {

--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -93,15 +93,20 @@
 
 <script setup lang="ts">
 // @ts-ignore
-import { useHead, useSiteTheme, useAppConfig, useRoute } from '#imports'
+import {
+  useHead,
+  useSiteTheme,
+  useAppConfig,
+  useRoute,
+  useTidePageMeta,
+  useTideLanguage
+} from '#imports'
 import { computed, onMounted, provide, ref } from 'vue'
 import { defu as defuMerge } from 'defu'
 import { TideSiteData } from '../types'
 import { TideTopicTag } from '../mapping/base/topic-tags/topic-tags-mapping'
 import { TideSiteSection } from '@dpc-sdp/ripple-tide-api/types'
 import hideAlertsOnLoadScript from '../utils/hideAlertsOnLoadScript.js'
-import useTidePageMeta from '../composables/use-tide-page-meta'
-import useTideLanguage from '../composables/use-tide-language'
 
 interface Props {
   site: TideSiteData
@@ -155,7 +160,6 @@ useHead({
   htmlAttrs: {
     lang: props.pageLanguage || 'en-AU'
   },
-  title: props.pageTitle,
   style: style && [
     {
       children: `:root, body { ${style} }`

--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -160,6 +160,7 @@ useHead({
   htmlAttrs: {
     lang: props.pageLanguage || 'en-AU'
   },
+  title: `${props.pageTitle} | ${site.name}`,
   style: style && [
     {
       children: `:root, body { ${style} }`

--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -160,7 +160,7 @@ useHead({
   htmlAttrs: {
     lang: props.pageLanguage || 'en-AU'
   },
-  title: `${props.pageTitle} | ${site.name}`,
+  title: `${props.page?.title} | ${props.site?.name}`,
   style: style && [
     {
       children: `:root, body { ${style} }`

--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -156,15 +156,20 @@ const style = useSiteTheme(
 
 const { direction, language } = useTideLanguage(props?.page)
 
-const pageTitle = computed(
-  () => `${props.pageTitle || props.page?.title || ''} | `
-)
+const pageTitle = computed(() => {
+  const titleOfPage = `${props.pageTitle || props.page?.title}`
+  const titleOfSite = `${props.site?.name}`
+  if (titleOfPage && titleOfSite) {
+    return `${titleOfPage} | ${titleOfSite}`
+  }
+  return titleOfSite
+})
 
 useHead({
   htmlAttrs: {
     lang: props.pageLanguage || 'en-AU'
   },
-  title: `${pageTitle.value}${props.site?.name}`,
+  title: pageTitle.value,
   style: style && [
     {
       children: `:root, body { ${style} }`
@@ -203,6 +208,6 @@ useHead({
 })
 
 if (props.page && props.page.meta) {
-  useTidePageMeta(props)
+  useTidePageMeta(props.page, props.site, pageTitle)
 }
 </script>

--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -156,11 +156,15 @@ const style = useSiteTheme(
 
 const { direction, language } = useTideLanguage(props?.page)
 
+const pageTitle = computed(
+  () => `${props.pageTitle || props.page?.title || ''} | `
+)
+
 useHead({
   htmlAttrs: {
     lang: props.pageLanguage || 'en-AU'
   },
-  title: `${props.page?.title} | ${props.site?.name}`,
+  title: `${pageTitle.value}${props.site?.name}`,
   style: style && [
     {
       children: `:root, body { ${style} }`

--- a/packages/nuxt-ripple/composables/use-tide-page-meta.ts
+++ b/packages/nuxt-ripple/composables/use-tide-page-meta.ts
@@ -25,7 +25,6 @@ export default async (props: any) => {
     htmlAttrs: {
       lang: props.pageLanguage || 'en-AU'
     },
-    title: `${props.pageTitle} | ${site.name}`,
     link: links
   })
 

--- a/packages/nuxt-ripple/composables/use-tide-page-meta.ts
+++ b/packages/nuxt-ripple/composables/use-tide-page-meta.ts
@@ -25,7 +25,7 @@ export default async (props: any) => {
     htmlAttrs: {
       lang: props.pageLanguage || 'en-AU'
     },
-    title: props.pageTitle,
+    title: `${props.pageTitle} | ${site.name}`,
     link: links
   })
 
@@ -36,7 +36,9 @@ export default async (props: any) => {
     },
     metaOverrides = {}
   additionalMeta
-    .filter((attr: any) => attr.tag === 'meta')
+    .filter(
+      (attr: any) => attr.tag === 'meta' && attr.attributes.name !== 'title'
+    )
     .map((attr: any) => {
       if (attr.attributes.name || attr.attributes.property)
         if (

--- a/packages/nuxt-ripple/composables/use-tide-page-meta.ts
+++ b/packages/nuxt-ripple/composables/use-tide-page-meta.ts
@@ -6,10 +6,7 @@ const metaProperty = (str: string) => {
   return p[0] + p[1].charAt(0).toUpperCase() + p[1].slice(1)
 }
 
-export default async (props: any) => {
-  const page = props.page
-  const site = props.site
-
+export default async (page, site, pageTitle) => {
   // Additional <link>s in head
   const links = []
   const additionalMeta = page.meta?.additional || []
@@ -93,7 +90,7 @@ export default async (props: any) => {
   // Define SEO meta
   useSeoMeta({
     description: description,
-    ogTitle: props.pageTitle,
+    ogTitle: pageTitle.value,
     ogDescription: description,
     ogType: 'website',
     ogUrl: $app_origin + page.meta.url,
@@ -101,7 +98,7 @@ export default async (props: any) => {
     ogImageAlt: featuredImageAlt,
     twitterCard: 'summary',
     twitterSite: $app_origin,
-    twitterTitle: props.pageTitle,
+    twitterTitle: pageTitle.value,
     twitterDescription: description,
     twitterImage: twitterImage,
     twitterImageAlt: twitterImageAlt,

--- a/packages/ripple-test-utils/step_definitions/common/shared-elements.ts
+++ b/packages/ripple-test-utils/step_definitions/common/shared-elements.ts
@@ -1,5 +1,9 @@
 import { Then, DataTable } from '@badeball/cypress-cucumber-preprocessor'
 
+Then('the page title should be {string}', (title: string) => {
+  cy.title().should('equal', title)
+})
+
 Then('the title should be {string}', (title: string) => {
   cy.get('[data-cy="hero-title"]').should('have.text', title)
 })


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- See https://digital-vic.atlassian.net/browse/SDPAP-8228?focusedCommentId=291108
- Change page title value to come from directly derived value instead of customised metatag value.

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

