### PR TITLE
feat(@dpc-sdp/ripple-ui-core): made search result date label customisable

### DIFF
--- a/packages/ripple-ui-core/src/components/result-listing/RplResultListing.stories.mdx
+++ b/packages/ripple-ui-core/src/components/result-listing/RplResultListing.stories.mdx
@@ -105,3 +105,36 @@ This is an example showing the result listing with extra details
     {SingleTemplate.bind()}
   </Story>
 </Canvas>
+
+## With custom date label
+
+This is an example showing that the date label can be customised
+
+<Canvas>
+  <Story
+    name='With custom date label'
+    play={a11yStoryCheck}
+    args={{
+      dateLabel: 'Custom label'
+    }}
+  >
+    {SingleTemplate.bind()}
+  </Story>
+</Canvas>
+
+## With no date label
+
+This is an example showing that the date label can be removed
+
+<Canvas>
+  <Story
+    name='With no date label'
+    play={a11yStoryCheck}
+    args={{
+      dateLabel: null,
+      updated: 'Some custom text'
+    }}
+  >
+    {SingleTemplate.bind()}
+  </Story>
+</Canvas>

--- a/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
+++ b/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
@@ -12,11 +12,13 @@ interface Props {
   url: string
   content?: string
   updated?: string
+  dateLabel?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   content: undefined,
-  updated: undefined
+  updated: undefined,
+  dateLabel: 'Updated'
 })
 
 const emit = defineEmits<{
@@ -67,7 +69,7 @@ const handleClick = () => {
       v-html="content"
     />
     <p v-if="updated" class="rpl-search-result__body rpl-type-p-small">
-      Updated: {{ updated }}
+      {{ dateLabel }}: {{ updated }}
     </p>
   </div>
 </template>

--- a/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
+++ b/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
@@ -69,7 +69,7 @@ const handleClick = () => {
       v-html="content"
     />
     <p v-if="updated" class="rpl-search-result__body rpl-type-p-small">
-      {{ dateLabel }}: {{ updated }}
+      {{ dateLabel ? `${dateLabel}: ` : '' }}{{ updated }}
     </p>
   </div>
 </template>


### PR DESCRIPTION


<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1165

### What I did
<!-- Summary of changes made in the Pull Request  -->
- In buying for vic search listing, the 'updated' date is actually the published date.
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

