### PR TITLE
RplPrimaryNavBar: use src if printSrc is not supplied

### DIFF
--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
@@ -90,18 +90,20 @@ const handleToggleItem = (level: number, item) => {
           :aria-label="primaryLogo.altText"
           class="rpl-primary-nav__primary-logo-image"
         />
-        <img
-          v-else
-          class="rpl-primary-nav__primary-logo-image rpl-u-screen-only"
-          :src="primaryLogo.src"
-          :alt="primaryLogo.altText"
-        />
-        <img
-          v-if="primaryLogo?.src && primaryLogo?.printSrc"
-          class="rpl-primary-nav__primary-logo-image rpl-primary-nav__logo-alt rpl-u-print-only"
-          :src="primaryLogo.printSrc"
-          :alt="primaryLogo.altText"
-        />
+        <template v-else>
+          <img
+            class="rpl-primary-nav__primary-logo-image rpl-u-screen-only"
+            :src="primaryLogo.src"
+            :alt="primaryLogo.altText"
+          />
+          <img
+            class="rpl-primary-nav__primary-logo-image rpl-primary-nav__logo-alt rpl-u-print-only"
+            :src="
+              primaryLogo?.printSrc ? primaryLogo?.printSrc : primaryLogo.src
+            "
+            :alt="primaryLogo.altText"
+          />
+        </template>
       </RplLink>
 
       <!-- Logo divider -->

--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
@@ -90,20 +90,18 @@ const handleToggleItem = (level: number, item) => {
           :aria-label="primaryLogo.altText"
           class="rpl-primary-nav__primary-logo-image"
         />
-        <template v-else>
-          <img
-            class="rpl-primary-nav__primary-logo-image rpl-u-screen-only"
-            :src="primaryLogo.src"
-            :alt="primaryLogo.altText"
-          />
-          <img
-            class="rpl-primary-nav__primary-logo-image rpl-primary-nav__logo-alt rpl-u-print-only"
-            :src="
-              primaryLogo?.printSrc ? primaryLogo?.printSrc : primaryLogo.src
-            "
-            :alt="primaryLogo.altText"
-          />
-        </template>
+        <img
+          v-else
+          class="rpl-primary-nav__primary-logo-image rpl-u-screen-only"
+          :src="primaryLogo.src"
+          :alt="primaryLogo.altText"
+        />
+        <img
+          v-if="primaryLogo?.src"
+          class="rpl-primary-nav__primary-logo-image rpl-primary-nav__logo-alt rpl-u-print-only"
+          :src="primaryLogo?.printSrc ? primaryLogo?.printSrc : primaryLogo.src"
+          :alt="primaryLogo.altText"
+        />
       </RplLink>
 
       <!-- Logo divider -->


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- If print logo is defined in BE, display the primary logo for print (this will be a default in cases where the logo is dark-on-light)
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

