### PR TITLE
[R20-1511] add dataLayer event for error pages

### DIFF
--- a/packages/nuxt-ripple-analytics/lib/routeChange.ts
+++ b/packages/nuxt-ripple-analytics/lib/routeChange.ts
@@ -17,6 +17,7 @@ export default function ({ route, site, page }): IRplAnalyticsEventPayload {
     publication_name: page?.publication?.text,
     search_term: trimValue(route.query?.q),
     site_section: page?.siteSection?.name,
+    status_code: page?.statusCode || 200,
     platform_event: 'page/routeChange'
   }
 

--- a/packages/nuxt-ripple-analytics/lib/tracker.ts
+++ b/packages/nuxt-ripple-analytics/lib/tracker.ts
@@ -26,6 +26,7 @@ export interface IRplAnalyticsEventPayload {
   component?: string
   component_options?: string
   // Route properties
+  status_code?: number
   content_type?: string
   search_term?: string
   site_section?: string
@@ -36,9 +37,6 @@ export interface IRplAnalyticsEventPayload {
     prod_measurement_id?: string
     uat_measurement_id?: string
   }
-  // Error properties
-  status_code?: number
-  status_message?: string
 }
 
 /**

--- a/packages/nuxt-ripple-analytics/lib/tracker.ts
+++ b/packages/nuxt-ripple-analytics/lib/tracker.ts
@@ -36,6 +36,9 @@ export interface IRplAnalyticsEventPayload {
     prod_measurement_id?: string
     uat_measurement_id?: string
   }
+  // Error properties
+  status_code?: number
+  status_message?: string
 }
 
 /**

--- a/packages/nuxt-ripple-analytics/plugins/analytics.ts
+++ b/packages/nuxt-ripple-analytics/plugins/analytics.ts
@@ -31,20 +31,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   /* @ts-ignore process is extended by webpack */
   if (process.client) {
-    nuxtApp.hook('tide:error', (error) => {
-      trackEvent({
-        event: 'error',
-        status_code: error.statusCode,
-        status_message: error?.statusMessage,
-        page_url: useRoute().fullPath,
-        platform_event: 'page/error'
-      })
-    })
-
-    nuxtApp.hook('page:finish', () => {
+    nuxtApp.hook('tide:page', ({ page, site }) => {
       const route = useRoute()
-      const site = nuxtApp.payload.data?.[`site-${runtimeConfig.site}`]
-      const page = nuxtApp.payload.data?.[`page-${route.fullPath}`]
 
       if (appConfig?.analytics?.routeChange === false) return
 

--- a/packages/nuxt-ripple-analytics/plugins/analytics.ts
+++ b/packages/nuxt-ripple-analytics/plugins/analytics.ts
@@ -31,6 +31,16 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   /* @ts-ignore process is extended by webpack */
   if (process.client) {
+    nuxtApp.hook('tide:error', (error) => {
+      trackEvent({
+        event: 'error',
+        status_code: error.statusCode,
+        status_message: error?.statusMessage,
+        page_url: useRoute().fullPath,
+        platform_event: 'page/error'
+      })
+    })
+
     nuxtApp.hook('page:finish', () => {
       const route = useRoute()
       const site = nuxtApp.payload.data?.[`site-${runtimeConfig.site}`]

--- a/packages/nuxt-ripple/error.vue
+++ b/packages/nuxt-ripple/error.vue
@@ -12,9 +12,9 @@
   </template>
   <TideBaseLayout
     v-else
-    :pageTitle="`${props.error?.statusCode} - ${props.error?.statusMessage}`"
+    :pageTitle="page.title"
     :site="site"
-    :page="{}"
+    :page="page"
     :siteSection="{}"
     class="tide-error"
   >
@@ -41,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { useNuxtApp, useTideSite } from '#imports'
+import { useTideSite } from '#imports'
 import { computed, onMounted } from 'vue'
 
 interface Props {
@@ -53,6 +53,10 @@ const props = defineProps<Props>()
 const is500 = computed(() => props.error?.statusCode === 500)
 const title = computed(() => (is500.value ? 'Sorry!' : 'Oops!'))
 const site = is500.value ? undefined : await useTideSite()
+const page = computed(() => ({
+  title: `${props.error?.statusCode} - ${props.error?.statusMessage}`,
+  statusCode: props.error?.statusCode
+}))
 
 onMounted(() => {
   // Since the template is skipped on 500, need to tell cypress that the page is ready
@@ -60,10 +64,6 @@ onMounted(() => {
     document.body.setAttribute('data-nuxt-hydrated', 'true')
   }
 })
-
-const nuxtApp = useNuxtApp()
-
-nuxtApp.callHook('tide:error', props.error)
 </script>
 
 <style>

--- a/packages/nuxt-ripple/error.vue
+++ b/packages/nuxt-ripple/error.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { useTideSite } from '#imports'
+import { useNuxtApp, useTideSite } from '#imports'
 import { computed, onMounted } from 'vue'
 
 interface Props {
@@ -60,6 +60,10 @@ onMounted(() => {
     document.body.setAttribute('data-nuxt-hydrated', 'true')
   }
 })
+
+const nuxtApp = useNuxtApp()
+
+nuxtApp.callHook('tide:error', props.error)
 </script>
 
 <style>

--- a/packages/nuxt-ripple/types.d.ts
+++ b/packages/nuxt-ripple/types.d.ts
@@ -4,7 +4,6 @@ import { TideAlert } from './src/mapping/alerts/site-alerts-mapping'
 import { TideContact } from './src/mapping/sidebar-contacts/sidebar-contacts-mapping-types'
 import { TideTopicTag } from './src/mapping/topic-tags/topic-tags-mapping'
 import { HookResult } from '@nuxt/schema'
-import type { H3Error } from 'h3'
 
 export type TideApiResponse = any
 
@@ -193,6 +192,5 @@ declare module '#app' {
       page: Partial<TidePageBase>
       site: Partial<TideSiteData>
     }) => HookResult
-    'tide:error': (error: H3Error) => HookResult
   }
 }

--- a/packages/nuxt-ripple/types.d.ts
+++ b/packages/nuxt-ripple/types.d.ts
@@ -4,6 +4,7 @@ import { TideAlert } from './src/mapping/alerts/site-alerts-mapping'
 import { TideContact } from './src/mapping/sidebar-contacts/sidebar-contacts-mapping-types'
 import { TideTopicTag } from './src/mapping/topic-tags/topic-tags-mapping'
 import { HookResult } from '@nuxt/schema'
+import type { H3Error } from 'h3'
 
 export type TideApiResponse = any
 
@@ -192,5 +193,6 @@ declare module '#app' {
       page: Partial<TidePageBase>
       site: Partial<TideSiteData>
     }) => HookResult
+    'tide:error': (error: H3Error) => HookResult
   }
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1511

### What I did
<!-- Summary of changes made in the Pull Request  -->
-  Use new tide hook for dataLayer events so DL event includes 404 pages

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

