### PR TITLE
[R20-1329] add optional noresults message to search bar

### DIFF
--- a/packages/ripple-ui-core/src/components/search-bar/RplSearchBar.css
+++ b/packages/ripple-ui-core/src/components/search-bar/RplSearchBar.css
@@ -161,3 +161,14 @@
     background: var(--rpl-clr-neutral-300);
   }
 }
+
+.rpl-search-bar__menu-noresults {
+  display: flex;
+  align-items: center;
+  padding: var(--rpl-sp-3);
+
+  @media (--rpl-bp-m) {
+    padding-left: var(--rpl-sp-4);
+    padding-right: var(--rpl-sp-4);
+  }
+}

--- a/packages/ripple-ui-core/src/components/search-bar/RplSearchBar.vue
+++ b/packages/ripple-ui-core/src/components/search-bar/RplSearchBar.vue
@@ -19,16 +19,18 @@ interface Props {
   autoFocus?: boolean
   inputLabel?: string
   inputValue?: string
-  submitLabel?: string
+  submitLabel?: string | boolean
   suggestions?: string[]
   maxSuggestionsDisplayed?: number
   placeholder?: string
   globalEvents?: boolean
+  showNoResults?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   variant: 'default',
   autoFocus: false,
+  showNoResults: false,
   inputLabel: 'Search',
   submitLabel: 'Search',
   inputValue: '',
@@ -260,6 +262,21 @@ watch(activeOptionId, async (newId) => {
         @keydown.enter.prevent="handleSubmit('enter')"
       />
 
+      <template
+        v-if="
+          showNoResults &&
+          suggestions.length === 0 &&
+          internalValue.length > 0 &&
+          isOpen
+        "
+      >
+        <slot name="noresults">
+          <div class="rpl-search-bar__menu">
+            <span class="rpl-search-bar__menu-noresults"> No results </span>
+          </div>
+        </slot>
+      </template>
+
       <div
         v-if="suggestions.length && isOpen"
         :id="menuId"
@@ -299,6 +316,7 @@ watch(activeOptionId, async (newId) => {
         class="rpl-search-bar-submit rpl-u-focusable-inline"
       >
         <span
+          v-if="submitLabel"
           class="rpl-search-bar-submit__label rpl-type-label rpl-type-weight-bold"
           >{{ submitLabel }}</span
         >
@@ -309,5 +327,3 @@ watch(activeOptionId, async (newId) => {
     </div>
   </form>
 </template>
-
-<style src="./RplSearchBar.css" />

--- a/packages/ripple-ui-core/src/components/search-bar/RplSearchBar.vue
+++ b/packages/ripple-ui-core/src/components/search-bar/RplSearchBar.vue
@@ -327,3 +327,5 @@ watch(activeOptionId, async (newId) => {
     </div>
   </form>
 </template>
+
+<style src="./RplSearchBar.css" />


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1329

### What I did
<!-- Summary of changes made in the Pull Request  -->
- added optional no results message for search bar suggestions. This allows it to display a message where there is a term entered but no suggestions. Needed for Know your council 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

