### PR TITLE
fix(@dpc-sdp/ripple-ui-core): add max width to scrollable table story

### DIFF
--- a/packages/ripple-ui-core/src/components/content/RplContent.stories.mdx
+++ b/packages/ripple-ui-core/src/components/content/RplContent.stories.mdx
@@ -398,7 +398,7 @@ export const SingleTemplate = (args) => ({
     name='Table - Scrollable'
     play={a11yStoryCheck}
     args={{html: `
-     <div class="rpl-table">
+     <div class="rpl-storybook__page-content rpl-table">
       <div class="rpl-table__scroll-container" tabindex="0">
         <table>
           <caption>Optional table caption</caption>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add max width to scrollable table story

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

