### PR TITLE
docs(docs): :memo: use different theme for card highlight as vic gov is wrong

### DIFF
--- a/docs/content/design-system/5.components/card.md
+++ b/docs/content/design-system/5.components/card.md
@@ -96,7 +96,7 @@ The highlight variant gives the card more visual prominence. Use this to guide u
 ::DocsExample
 ---
 id: core-navigation-card--promo
-argsString: 'graphicElement:Highlight'
+argsString: 'graphicElement:Heading+highlighted&globals=theme:docsTheme2'
 ---
 ::
 

--- a/docs/content/design-system/5.components/card.md
+++ b/docs/content/design-system/5.components/card.md
@@ -17,7 +17,8 @@ Ensure headings are direct and summaries are concise.
 
 ::DocsExample
 ---
-id: core-navigation-card--promo&args=graphicElement:None
+id: core-navigation-card--promo
+argsString: 'graphicElement:None'
 ---
 ::
 
@@ -96,7 +97,8 @@ The highlight variant gives the card more visual prominence. Use this to guide u
 ::DocsExample
 ---
 id: core-navigation-card--promo
-argsString: 'graphicElement:Heading+highlighted&globals=theme:docsTheme2'
+theme: 'docsTheme2'
+argsString: 'graphicElement:Highlight'
 ---
 ::
 

--- a/docs/content/framework/1.index.md
+++ b/docs/content/framework/1.index.md
@@ -9,7 +9,7 @@ layout: page
 
 ## What is it?
 
-The Ripple design system consists of the design elements and components used to build _any_ web application using the Victorian government brand. Ripple _framework_ is a collection of [Nuxt 3](2.key-concepts/1.nuxt.md) modules and [layers](2.key-concepts/2.nuxt-layers.md) primarily used to create headless SDP websites using the Tide Drupal CMS.
+The Ripple design system consists of the design elements and components used to build _any_ web application using the Victorian government brand. Ripple _framework_ is a collection of [Nuxt 3](/framework/key-concepts/nuxt) modules and [layers](/framework/key-concepts/nuxt-layers) primarily used to create headless SDP websites using the Tide Drupal CMS.
 
 
 ![ripple is made up of Figma design, CSS styles, Vue JS components and Nuxt JS Sites](/assets/img/modules/rpl-modules.png){.rpl-u-padding-t-4}

--- a/docs/content/framework/2.key-concepts/4.content-types.md
+++ b/docs/content/framework/2.key-concepts/4.content-types.md
@@ -17,7 +17,7 @@ Ripple content types consist of the following parts:
 
 ### API Mapping
 
-See [API Endpoints](/framework/key-concepts/API-endpoints) for more information the Tide API translation layer. For each content type we supply a function that maps the Tide Drupal API response into more concise fields that match the data needed for  
+See [API Endpoints](/framework/key-concepts/api-endpoints) for more information the Tide API translation layer. For each content type we supply a function that maps the Tide Drupal API response into more concise fields that match the data needed for  
 
 ### Template
 

--- a/docs/content/framework/3.guides/1.migrating.md
+++ b/docs/content/framework/3.guides/1.migrating.md
@@ -39,7 +39,7 @@ The migration of the following will be out of scope for sites without an MoU for
 Please review the following concepts before proceeding:
 
 - [Content types](/framework/key-concepts/content-types)
-- [API mapping](/framework/key-concepts/API-endpoints)
+- [API mapping](/framework/key-concepts/api-endpoints)
 - [Dynamic components](/framework/key-concepts/dynamic-components)
 
 ### Content types

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -29,5 +29,10 @@ export default defineNuxtConfig({
   },
   vite: {
     plugins: [ViteYaml()]
+  },
+  nitro: {
+    prerender: {
+      ignore: ['/storybook']
+    }
   }
 })


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Changed the theme for card highlight that we use in docs site, vic.gov.au doesn't use the highlight and content people got confused.
- 

### How to test
<!-- Summary of how to test  -->
- Check docs site
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

