### PR TITLE
[R20-1426] infer counter type

### DIFF
--- a/packages/ripple-tide-landing-page/mapping/components/webforms/webform-validation.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/webforms/webform-validation.ts
@@ -83,7 +83,7 @@ export const getValidation = (
   if (
     field['#minlength'] ||
     field['#maxlength'] ||
-    (field['#counter_type'] && field['#counter_minimum']) ||
+    field['#counter_minimum'] ||
     field['#counter_maximum']
   ) {
     const type = field['#counter_type'] === 'word' ? 'words' : 'characters'
@@ -91,7 +91,7 @@ export const getValidation = (
     let min = field['#minlength'] || 0
     let max = field['#maxlength'] || ''
 
-    if (field['#counter_type']) {
+    if (field['#counter_minimum'] || field['#counter_maximum']) {
       min = field['#counter_minimum'] || min
       max = field['#counter_maximum'] || max
     }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1426

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Infer counter type as API doesn't always return it

The Drupal API doesn't return default values, this means when a text field has the counter type under form validation set to 'characters' the frontend doesn't actually get informed of that, so validation doesn't work as one might expect. This probably needs a more in depth review, but this small update at least results in a more expected behavior for now. 

- _No counter type is returned when counter type is set to characters_

![Screenshot 2023-09-07 at 5 09 52 pm](https://github.com/dpc-sdp/ripple-framework/assets/287178/6f205127-129c-489f-b768-b1162b3c6d7c)

- _Here's the before and after of this update_

![before-after](https://github.com/dpc-sdp/ripple-framework/assets/287178/fd3289ce-ffbd-4fab-851f-fd8ba5a86116)


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

