### PR TITLE
chore: :rocket: change publish process to be on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,8 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - main
-      - test-release
+  release:
+    types: [created]
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release:changelog": "changelogen --output --no-commit -r $(cat lerna.json | jq -r '.version')",
     "release:publish-alpha": "lerna publish --canary minor --preid alpha --dist-tag alpha --force-publish",
     "release:publish-next": "lerna publish --canary --preid next.$(git rev-parse --short HEAD) --dist-tag next --force-publish",
-    "release:publish": "changelogen gh release && lerna publish from-package",
+    "release:publish": "lerna publish from-package",
     "lint": "eslint . --ext .ts,.vue && stylelint 'packages/ripple-ui-core/**/*.css'",
     "test:unit": "jest --colors --runInBand",
     "test:components-core": "pnpm -F @dpc-sdp/ripple-ui-core test:components",


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Make NPM publish step come from GH Release instead of merge to main
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

