### PR TITLE
[R20-1440] make only title and url 'links'

### DIFF
--- a/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.css
+++ b/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.css
@@ -1,7 +1,6 @@
 @import '@dpc-sdp/ripple-ui-core/style/breakpoints';
 
 .rpl-search-result {
-  cursor: pointer;
   padding-top: var(--rpl-sp-5);
   padding-bottom: var(--rpl-sp-5);
 
@@ -34,8 +33,12 @@
 }
 
 .rpl-search-result__url {
+  --local-url-colour: var(--rpl-clr-neutral-600);
+  --local-clr-link-visited: var(--local-url-colour);
+
+  display: block;
   margin-top: var(--rpl-sp-1);
-  color: var(--rpl-clr-neutral-600);
+  color: var(--local-url-colour);
   text-decoration: none;
 }
 

--- a/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.css
+++ b/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.css
@@ -21,6 +21,10 @@
   color: var(--rpl-clr-neutral-600);
 }
 
+.rpl-search-result__heading {
+  cursor: pointer;
+}
+
 .rpl-search-result__title {
   color: var(--rpl-clr-link);
 
@@ -33,12 +37,8 @@
 }
 
 .rpl-search-result__url {
-  --local-url-colour: var(--rpl-clr-neutral-600);
-  --local-clr-link-visited: var(--local-url-colour);
-
-  display: block;
   margin-top: var(--rpl-sp-1);
-  color: var(--local-url-colour);
+  color: var(--rpl-clr-neutral-600);
   text-decoration: none;
 }
 

--- a/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
+++ b/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import RplTextLink from '../text-link/RplTextLink.vue'
-import { useAccessibleContainer } from '../../composables/useAccessibleContainer'
 import {
   useRippleEvent,
   rplEventPayload
@@ -27,8 +26,6 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-search-result', emit)
 
-const { container, trigger } = useAccessibleContainer()
-
 const displayUrl = computed(() => props.url.replace('https://', ''))
 
 const handleClick = () => {
@@ -45,21 +42,23 @@ const handleClick = () => {
 </script>
 
 <template>
-  <div ref="container" class="rpl-search-result">
+  <div class="rpl-search-result">
     <div v-if="$slots.meta" class="rpl-search-result__meta rpl-type-p-small">
       <slot name="meta"></slot>
     </div>
     <h2 class="rpl-search-result__title rpl-type-h3">
-      <RplTextLink ref="trigger" :url="url" @click="handleClick">
+      <RplTextLink :url="url" @click="handleClick">
         {{ title }}
       </RplTextLink>
     </h2>
-    <div
-      v-if="url"
+    <RplTextLink
+      :url="url"
+      tabindex="-1"
       class="rpl-search-result__url rpl-type-p-small rpl-u-screen-only"
+      @click="handleClick"
     >
       {{ displayUrl }}
-    </div>
+    </RplTextLink>
     <div v-if="$slots.details" class="rpl-search-result__details rpl-type-p">
       <slot name="details"></slot>
     </div>

--- a/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
+++ b/packages/ripple-ui-core/src/components/result-listing/RplSearchResult.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import RplTextLink from '../text-link/RplTextLink.vue'
+import { useAccessibleContainer } from '../../composables/useAccessibleContainer'
 import {
   useRippleEvent,
   rplEventPayload
@@ -26,6 +27,8 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-search-result', emit)
 
+const { container, trigger } = useAccessibleContainer()
+
 const displayUrl = computed(() => props.url.replace('https://', ''))
 
 const handleClick = () => {
@@ -46,19 +49,20 @@ const handleClick = () => {
     <div v-if="$slots.meta" class="rpl-search-result__meta rpl-type-p-small">
       <slot name="meta"></slot>
     </div>
-    <h2 class="rpl-search-result__title rpl-type-h3">
-      <RplTextLink :url="url" @click="handleClick">
-        {{ title }}
-      </RplTextLink>
-    </h2>
-    <RplTextLink
-      :url="url"
-      tabindex="-1"
-      class="rpl-search-result__url rpl-type-p-small rpl-u-screen-only"
-      @click="handleClick"
-    >
-      {{ displayUrl }}
-    </RplTextLink>
+    <div ref="container" class="rpl-search-result__heading">
+      <h2 class="rpl-search-result__title rpl-type-h3">
+        <RplTextLink ref="trigger" :url="url" @click="handleClick">
+          {{ title }}
+        </RplTextLink>
+      </h2>
+      <div
+        v-if="url"
+        aria-hidden="true"
+        class="rpl-search-result__url rpl-type-p-small rpl-u-screen-only"
+      >
+        {{ displayUrl }}
+      </div>
+    </div>
     <div v-if="$slots.details" class="rpl-search-result__details rpl-type-p">
       <slot name="details"></slot>
     </div>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1440

### To discuss

A couple of issue were brought up on the above ticket (and in discussion), with the desired outcome to be as follows:
- The mouse pointer should only be shown when hovering over the actual link which is the title (and the text shouldn't be clickable). This would avoid the confusion caused when focusing a result item, then hovering another result and not seeing the wrong URL preview shown 

This change addresses that issue i.e now the title and URL are the only elements that are clickable; having said that I'm not sold this, technically all our cards have the same 'issue'.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

