### PR TITLE
[R20-1383] allow supplying custom rpl icons

### DIFF
--- a/packages/ripple-ui-core/README.md
+++ b/packages/ripple-ui-core/README.md
@@ -40,6 +40,10 @@ There is no need to import the components as they will be registered globally by
 </template>
 ```
 
+#### Custom icons
+
+Within a Nuxt application or layer just place custom icons (svgs) within an `assets/icons` directory, they can then be used with the `RplIcon` component. For example `assets/icons/icon-moon.svg` can be used as `<RplIcon name="icon-moon" />`
+
 ## Usage (Vue)
 
 To use a component, import it from `@dpc-sdp/ripple-ui-core/vue`, note the addition of `/vue`.

--- a/packages/ripple-ui-core/src/components/icon/RplIcon.vue
+++ b/packages/ripple-ui-core/src/components/icon/RplIcon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, defineAsyncComponent } from 'vue'
+import { ref, computed, inject, defineAsyncComponent } from 'vue'
 import { RplIconSizes, RplCoreIconNames } from './constants'
 import { RplColorThemes } from '../../lib/constants'
 import customIconImports from './custom.js'
@@ -21,11 +21,14 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const inSprite = ref(RplCoreIconNames.find((key) => key === props.name))
+const providedIcons = inject('rplIcons', {})
 
 const asyncIcon = computed(() => {
   if (!inSprite.value) {
     try {
-      return defineAsyncComponent(customIconImports[props.name])
+      return defineAsyncComponent(
+        { ...customIconImports, ...providedIcons }[props.name]
+      )
     } catch (e) {
       console.error(
         `RplIcon error: Couldn't dynamically import icon with name "${props.name}"`

--- a/packages/ripple-ui-core/src/nuxt/index.ts
+++ b/packages/ripple-ui-core/src/nuxt/index.ts
@@ -2,14 +2,19 @@ import {
   defineNuxtModule,
   createResolver,
   addComponentsDir,
-  addPlugin
+  addPlugin,
+  addTemplate
 } from '@nuxt/kit'
 import vitePlugins from '../vite.plugins'
+import { getIcons } from './lib/icons'
 
 export default <any>defineNuxtModule({
   meta: {
     name: 'ripple-ui-core',
     configKey: 'ripple'
+  },
+  defaults: {
+    iconPath: 'assets/icons'
   },
   hooks: {
     'vite:extendConfig'(viteInlineConfig) {
@@ -31,6 +36,17 @@ export default <any>defineNuxtModule({
   },
   async setup(_options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
+    // Add any custom icons
+    const icons = await getIcons(_options.iconPath, nuxt.options._layers)
+    const iconMap = (icons || []).map(
+      ({ file, name }) => `'${name}': () => import('${file}?component')`
+    )
+    nuxt.options.alias['#icons'] =
+      addTemplate({
+        write: true,
+        filename: 'icons.mjs',
+        getContents: () => `export default { ${iconMap.join(',')} }`
+      }).dst || ''
     // Adds all ripple Vue components to autoimports in Nuxt
     addComponentsDir({
       extensions: ['vue'],

--- a/packages/ripple-ui-core/src/nuxt/lib/icons.ts
+++ b/packages/ripple-ui-core/src/nuxt/lib/icons.ts
@@ -1,0 +1,27 @@
+import { parse } from 'node:path'
+import { readdir } from 'node:fs/promises'
+
+export async function getIcons(
+  path: string,
+  layers: any
+): Promise<{ name: string; file: string }[]> {
+  let icons: any = []
+
+  for (const layer of layers) {
+    try {
+      const files = await readdir(`${layer.cwd}/${path}`)
+
+      icons = [
+        ...icons,
+        ...files.map((file) => ({
+          name: parse(file).name,
+          file: `${layer.cwd}/${path}/${file}`
+        }))
+      ]
+    } catch (e) {
+      /* no-log-needed */
+    }
+  }
+
+  return icons
+}

--- a/packages/ripple-ui-core/src/nuxt/runtime/plugin.ts
+++ b/packages/ripple-ui-core/src/nuxt/runtime/plugin.ts
@@ -1,10 +1,13 @@
+import icons from '#icons'
 import { rplEventBus } from './../../lib/eventbus'
 /* @ts-ignore */
 import { defineNuxtPlugin } from '#imports'
+
 /* @ts-ignore */
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use({
     install: (app) => {
+      app.provide('rplIcons', icons)
       app.provide('$rplEvent', rplEventBus)
     }
   })

--- a/packages/ripple-ui-core/src/nuxt/runtime/plugin.ts
+++ b/packages/ripple-ui-core/src/nuxt/runtime/plugin.ts
@@ -1,7 +1,8 @@
-import icons from '#icons'
 import { rplEventBus } from './../../lib/eventbus'
 /* @ts-ignore */
 import { defineNuxtPlugin } from '#imports'
+/* @ts-ignore */
+import icons from '#icons'
 
 /* @ts-ignore */
 export default defineNuxtPlugin((nuxtApp) => {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1383

### What I did
<!-- Summary of changes made in the Pull Request  -->
Allow for sites and layers to supply custom icons that can by used with `<RplIcon>`.

The default icon path is set `iconPath: 'assets/icons'`, so any icons added within `assets/icons` within layers or the main app can then be used as per normal `<RplIcon name="my-custom-icon" />`. You can also override core icons just by popping an icon with the same name in the `assets/icons` folder.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

