### PR TITLE
[R20-1531] add support for icons in description lists

### DIFF
--- a/packages/ripple-ui-core/src/components/description-list/RplDescriptionList.css
+++ b/packages/ripple-ui-core/src/components/description-list/RplDescriptionList.css
@@ -8,12 +8,15 @@
   margin: 0;
 
   .rpl-icon {
-    transform: translateY(3px);
+    position: absolute;
+    top: 3px;
+    left: 0;
   }
 }
 
 .rpl-description-list__term {
   font-weight: var(--rpl-type-weight-bold);
+  position: relative;
   display: flex;
   gap: var(--rpl-sp-2);
 }
@@ -36,15 +39,27 @@
 }
 
 .rpl-description-list__inline-wrap {
-  display: flex;
-  gap: var(--rpl-sp-2);
+  position: relative;
 }
 
-.rpl-description-list__inline-wrap .rpl-description-list__term,
+.rpl-description-list__inline-wrap .rpl-description-list__term {
+  position: initial;
+  display: inline-flex;
+}
+
 .rpl-description-list__inline-wrap .rpl-description-list__description {
   display: inline;
 }
 
-.rpl-description-list__inline-icon {
-  display: flex;
+.rpl-description-list--with-icon {
+  padding-left: var(--rpl-sp-5);
+}
+
+.rpl-description-list--only-icon {
+  padding-left: var(--rpl-sp-6);
+}
+
+.rpl-description-list--only-icon .rpl-description-list__description,
+.rpl-description-list--only-icon + .rpl-description-list__description {
+  margin-left: 0;
 }

--- a/packages/ripple-ui-core/src/components/description-list/RplDescriptionList.css
+++ b/packages/ripple-ui-core/src/components/description-list/RplDescriptionList.css
@@ -1,13 +1,21 @@
 @import '@dpc-sdp/ripple-ui-core/style/breakpoints';
 
 .rpl-description-list {
+  --local-list-spacing: var(--rpl-sp-2);
+
   display: grid;
   grid-template-columns: max-content auto;
   margin: 0;
+
+  .rpl-icon {
+    transform: translateY(3px);
+  }
 }
 
 .rpl-description-list__term {
   font-weight: var(--rpl-type-weight-bold);
+  display: flex;
+  gap: var(--rpl-sp-2);
 }
 
 .rpl-description-list__description {
@@ -16,20 +24,27 @@
 
 .rpl-description-list__term,
 .rpl-description-list__description {
-  margin-top: var(--rpl-sp-1);
-  margin-bottom: var(--rpl-sp-1);
+  &:not(:first-of-type) {
+    margin-top: var(--local-list-spacing);
+  }
 }
 
 .rpl-description-list--inline {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: var(--local-list-spacing);
 }
 
 .rpl-description-list__inline-wrap {
-  margin-top: var(--rpl-sp-2);
-  margin-bottom: var(--rpl-sp-2);
+  display: flex;
+  gap: var(--rpl-sp-2);
 }
 
 .rpl-description-list__inline-wrap .rpl-description-list__term,
 .rpl-description-list__inline-wrap .rpl-description-list__description {
   display: inline;
+}
+
+.rpl-description-list__inline-icon {
+  display: flex;
 }

--- a/packages/ripple-ui-core/src/components/description-list/RplDescriptionList.stories.mdx
+++ b/packages/ripple-ui-core/src/components/description-list/RplDescriptionList.stories.mdx
@@ -40,6 +40,12 @@ export const SlotTemplate = (args) => ({
 <Meta
   title='Core/Containers/Description list'
   component={RplDescriptionList}
+  argTypes={{
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'icon']
+    }
+  }}
 />
 
 # Description list
@@ -79,6 +85,21 @@ export const SlotTemplate = (args) => ({
   </Story>
 </Canvas>
 
+<Canvas>
+  <Story
+    name='Default / With icons'
+    play={a11yStoryCheck}
+    args={{
+      items: [
+        { term: "Date:", description: "17th of November 2021", iconName: "icon-exclamation-circle-filled" },
+        { term: "Author:", description: "Department of Premier and Cabinet", iconName: "icon-user-circle-filled" },
+        { term: "Content:", description: "And here is some interesting content.", iconName: "icon-document" }
+      ]
+    }}
+  >
+    {InlineTemplate.bind()}
+  </Story>
+</Canvas>
 
 ## Inline
 
@@ -129,14 +150,44 @@ export const SlotTemplate = (args) => ({
   </Story>
 </Canvas>
 
+<Canvas>
+  <Story
+    name='Inline / With icons'
+    play={a11yStoryCheck}
+    args={{
+      inline: true,
+      items: [
+        { term: "Closes:", description: "2nd of June 2023", iconName: "icon-exclamation-circle-filled", iconColour: "warning" },
+        { term: "Admission:", description: "Entry is free", iconName: "icon-check-circle-filled", iconColour: "success" },
+        { term: "Content:", description: "This is a line of text to use for testing extreme long-title edge cases: it is so long that it will not only fill, but also overflow, the entire width of an ordinary device.", iconName: "icon-document" }
+      ]
+    }}
+  >
+    {InlineTemplate.bind()}
+  </Story>
+</Canvas>
 
 <Canvas>
   <Story
     name='With link'
     play={a11yStoryCheck}
-    args={{
-    }}
   >
     {SlotTemplate.bind()}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Icons only'
+    play={a11yStoryCheck}
+    args={{
+      variant: "icon",
+      items: [
+        { term: "Closes:", description: "2nd of June 2023", iconName: "icon-exclamation-circle-filled", iconColour: "warning" },
+        { term: "Admission:", description: "Entry is free before 9am", iconName: "icon-check-circle-filled", iconColour: "success" },
+      ]
+    }}
+  >
+    {InlineTemplate.bind()}
   </Story>
 </Canvas>

--- a/packages/ripple-ui-core/src/components/description-list/RplDescriptionList.vue
+++ b/packages/ripple-ui-core/src/components/description-list/RplDescriptionList.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
-import type { IRplDescriptionListItem } from './constants'
+import type {
+  IRplDescriptionListItem,
+  IRplDescriptionListVariant
+} from './constants'
 import RplDescriptionListItem from './RplDescriptionListItem.vue'
 
 interface Props {
   inline?: boolean
   items?: Array<IRplDescriptionListItem>
+  variant?: IRplDescriptionListVariant
 }
 
 withDefaults(defineProps<Props>(), {
   inline: false,
-  items: () => []
+  items: () => [],
+  variant: 'default'
 })
 </script>
 
@@ -22,9 +27,15 @@ withDefaults(defineProps<Props>(), {
     }"
   >
     <template v-for="row in items" :key="row.term">
-      <RplDescriptionListItem :inline="inline" :term="row.term">{{
-        row.description
-      }}</RplDescriptionListItem>
+      <RplDescriptionListItem
+        :inline="inline"
+        :term="row.term"
+        :variant="variant"
+        :icon-name="row?.iconName"
+        :icon-colour="row?.iconColour"
+      >
+        {{ row.description }}
+      </RplDescriptionListItem>
     </template>
     <slot />
   </dl>

--- a/packages/ripple-ui-core/src/components/description-list/RplDescriptionListItem.vue
+++ b/packages/ripple-ui-core/src/components/description-list/RplDescriptionListItem.vue
@@ -1,22 +1,60 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import RplIcon from '../icon/RplIcon.vue'
+import { RplIconNames } from '../icon/constants'
+import { RplColorThemes } from '../../lib/constants'
+import { IRplDescriptionListVariant } from './constants'
+
 interface Props {
   inline?: boolean
   term: string
+  variant?: IRplDescriptionListVariant
+  iconName?: (typeof RplIconNames)[number]
+  iconColour?: (typeof RplColorThemes)[number]
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   inline: false,
-  items: () => []
+  variant: 'default',
+  iconName: undefined,
+  iconColour: 'default'
 })
+
+const iconOnly = computed(() => props.variant === 'icon')
+const termClass = computed(() => ({ 'rpl-u-visually-hidden': iconOnly.value }))
 </script>
 
 <template>
   <div v-if="inline" class="rpl-description-list__inline-wrap">
-    <dt class="rpl-description-list__term">{{ term }}</dt>
-    <dd class="rpl-description-list__description"><slot /></dd>
+    <RplIcon
+      v-if="iconName && !iconOnly"
+      :name="iconName"
+      :colour="iconColour"
+      aria-hidden="true"
+    />
+    <div :class="`rpl-description-list__inline-${variant}`">
+      <dt class="rpl-description-list__term">
+        <RplIcon
+          v-if="iconName && iconOnly"
+          :name="iconName"
+          :colour="iconColour"
+          aria-hidden="true"
+        /><span :class="termClass">{{ term }}</span>
+      </dt>
+      <dd class="rpl-description-list__description"><slot /></dd>
+    </div>
   </div>
   <template v-else>
-    <dt class="rpl-description-list__term">{{ term }}</dt>
+    <dt
+      :class="`rpl-description-list__term rpl-description-list__term-${variant}`"
+    >
+      <RplIcon
+        v-if="iconName"
+        :name="iconName"
+        :colour="iconColour"
+        aria-hidden="true"
+      /><span :class="termClass">{{ term }}</span>
+    </dt>
     <dd class="rpl-description-list__description"><slot /></dd>
   </template>
 </template>

--- a/packages/ripple-ui-core/src/components/description-list/RplDescriptionListItem.vue
+++ b/packages/ripple-ui-core/src/components/description-list/RplDescriptionListItem.vue
@@ -21,33 +21,30 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const iconOnly = computed(() => props.variant === 'icon')
+const iconClasses = computed(() => ({
+  'rpl-description-list--with-icon': props.iconName,
+  'rpl-description-list--only-icon': iconOnly.value
+}))
 const termClass = computed(() => ({ 'rpl-u-visually-hidden': iconOnly.value }))
 </script>
 
 <template>
-  <div v-if="inline" class="rpl-description-list__inline-wrap">
-    <RplIcon
-      v-if="iconName && !iconOnly"
-      :name="iconName"
-      :colour="iconColour"
-      aria-hidden="true"
-    />
-    <div :class="`rpl-description-list__inline-${variant}`">
-      <dt class="rpl-description-list__term">
-        <RplIcon
-          v-if="iconName && iconOnly"
-          :name="iconName"
-          :colour="iconColour"
-          aria-hidden="true"
-        /><span :class="termClass">{{ term }}</span>
-      </dt>
-      <dd class="rpl-description-list__description"><slot /></dd>
-    </div>
+  <div
+    v-if="inline"
+    :class="{ 'rpl-description-list__inline-wrap': true, ...iconClasses }"
+  >
+    <dt class="rpl-description-list__term">
+      <RplIcon
+        v-if="iconName"
+        :name="iconName"
+        :colour="iconColour"
+        aria-hidden="true"
+      /><span :class="termClass">{{ term }}</span>
+    </dt>
+    <dd class="rpl-description-list__description"><slot /></dd>
   </div>
   <template v-else>
-    <dt
-      :class="`rpl-description-list__term rpl-description-list__term-${variant}`"
-    >
+    <dt :class="{ 'rpl-description-list__term': true, ...iconClasses }">
       <RplIcon
         v-if="iconName"
         :name="iconName"

--- a/packages/ripple-ui-core/src/components/description-list/constants.ts
+++ b/packages/ripple-ui-core/src/components/description-list/constants.ts
@@ -1,4 +1,11 @@
+import { RplIconNames } from '../icon/constants'
+import { RplColorThemes } from '../../lib/constants'
+
 export type IRplDescriptionListItem = {
   term: string
   description: string
+  iconName?: (typeof RplIconNames)[number]
+  iconColour?: (typeof RplColorThemes)[number]
 }
+
+export type IRplDescriptionListVariant = 'default' | 'icon'


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1531

### What I did
<!-- Summary of changes made in the Pull Request  -->
- adds support for icons in description lists

<img width="928" alt="Screenshot 2023-09-18 at 1 43 21 pm" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/ada5fa91-27a6-4062-b19f-c1e91e4ccb7c">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

