### PR TITLE
[R20-1522] increase menu depth for breadcrumbs

### DIFF
--- a/packages/ripple-tide-api/src/services/lib/site-menu.ts
+++ b/packages/ripple-tide-api/src/services/lib/site-menu.ts
@@ -92,8 +92,8 @@ const getHierarchicalMenu = function (menu, activeUrl, enabledCheck = false) {
         text: link.attributes.title,
         url:
           link.attributes?.url ||
-          link.attributes.link.url ||
-          link.attributes.link.uri,
+          link.attributes.link?.url ||
+          link.attributes.link?.uri,
         id: link.id.replace(/^(menu_link_content:)/, ''),
         parent: link.attributes.parent
           ? link.attributes.parent.replace(/^(menu_link_content:)/, '')

--- a/packages/ripple-tide-api/src/services/tide-api-base.ts
+++ b/packages/ripple-tide-api/src/services/tide-api-base.ts
@@ -87,7 +87,7 @@ export default class TideApiBase extends HttpClient {
     const params = {
       site: siteId,
       filter: {
-        max_depth: 4,
+        max_depth: 7,
         fields: 'title,url,parent,weight'
       }
     }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1522

### What I did
<!-- Summary of changes made in the Pull Request  -->
- increase menu query depth so breadcrumbs work on deeply nested pages
- added `?` to menu URL generation as I noticed when testing this against legalaid (develop) some deeply nested items don't actually have a URL

<img width="1069" alt="Screenshot 2023-09-20 at 9 54 19 am" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/3610e365-40ad-479f-8e39-4d9229da684d">

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

