### PR TITLE
[R20-1544] Add secondary campaign to search listing

### DIFF
--- a/packages/ripple-tide-landing-page/mapping/index.ts
+++ b/packages/ripple-tide-landing-page/mapping/index.ts
@@ -85,3 +85,5 @@ const tideLandingPageModule: IRplTideModuleMapping = {
 }
 
 export default tideLandingPageModule
+
+export { secondaryCampaignIncludes, secondaryCampaignMapping }

--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -9,12 +9,14 @@ import type {
   TideSearchListingResultLayout,
   TideSearchListingSortOption
 } from './../types'
+import type { ITideSecondaryCampaign } from '@dpc-sdp/ripple-tide-landing-page/mapping/secondary-campaign/secondary-campaign-mapping'
 import { useRippleEvent } from '@dpc-sdp/ripple-ui-core'
 import type { rplEventPayload } from '@dpc-sdp/ripple-ui-core'
 import { watch } from 'vue'
 
 interface TideContentPage extends TidePageBase {
   afterResults: string
+  secondaryCampaign: ITideSecondaryCampaign
 }
 
 interface Props {
@@ -424,6 +426,9 @@ watch(
           class="tide-content-after-results"
           :html="contentPage.afterResults"
         ></RplContent>
+      </RplPageComponent>
+      <RplPageComponent v-if="contentPage.secondaryCampaign">
+        <RplSecondaryCampaign v-bind="contentPage.secondaryCampaign" />
       </RplPageComponent>
     </template>
   </TideBaseLayout>

--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -427,6 +427,8 @@ watch(
           :html="contentPage.afterResults"
         ></RplContent>
       </RplPageComponent>
+    </template>
+    <template #belowBody>
       <RplPageComponent v-if="contentPage.secondaryCampaign">
         <RplSecondaryCampaign v-bind="contentPage.secondaryCampaign" />
       </RplPageComponent>

--- a/packages/ripple-tide-search/mapping/index.ts
+++ b/packages/ripple-tide-search/mapping/index.ts
@@ -6,6 +6,10 @@ import { getBodyFromField } from '@dpc-sdp/ripple-tide-api'
 import type { IRplTideModuleMapping } from '@dpc-sdp/ripple-tide-api/types'
 import { ApplicationError } from '@dpc-sdp/ripple-tide-api/errors'
 import { getUniqueListBy, parseJSONField } from './../mapping/utils'
+import {
+  secondaryCampaignIncludes,
+  secondaryCampaignMapping
+} from '@dpc-sdp/ripple-tide-landing-page/mapping'
 
 const getProcessedSearchListingConfig = async (src, tidePageApi) => {
   let rawConfig = null
@@ -185,7 +189,8 @@ const tideCollectionModule: IRplTideModuleMapping = {
     afterResults: (src: string) =>
       getBodyFromField(src, 'field_below_results_content'),
     introText: 'field_landing_page_intro_text',
-    config: getProcessedSearchListingConfig
+    config: getProcessedSearchListingConfig,
+    secondaryCampaign: secondaryCampaignMapping
   },
   includes: [
     ...tidePageBaseIncludes({
@@ -193,6 +198,7 @@ const tideCollectionModule: IRplTideModuleMapping = {
       withSidebarRelatedLinks: false,
       withSidebarSocialShare: false
     }),
+    ...secondaryCampaignIncludes,
     'field_listing_global_filters',
     'field_listing_user_filters',
     'field_listing_user_filters.field_field',

--- a/packages/ripple-tide-search/package.json
+++ b/packages/ripple-tide-search/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@dpc-sdp/ripple-tide-api": "workspace:*",
+    "@dpc-sdp/ripple-tide-landing-page": "workspace:*",
     "@dpc-sdp/ripple-ui-core": "workspace:*",
     "@dpc-sdp/ripple-ui-forms": "workspace:*",
     "@elastic/search-ui": "^1.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -718,6 +718,9 @@ importers:
       '@dpc-sdp/ripple-tide-api':
         specifier: workspace:*
         version: link:../ripple-tide-api
+      '@dpc-sdp/ripple-tide-landing-page':
+        specifier: workspace:*
+        version: link:../ripple-tide-landing-page
       '@dpc-sdp/ripple-ui-core':
         specifier: workspace:*
         version: link:../ripple-ui-core
@@ -9138,7 +9141,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.4
-      vue-component-type-helpers: 1.8.8
+      vue-component-type-helpers: 1.8.15
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -28385,8 +28388,8 @@ packages:
       typescript: 5.0.2
     dev: true
 
-  /vue-component-type-helpers@1.8.8:
-    resolution: {integrity: sha512-Ohv9HQY92nSbpReC6WhY0X4YkOszHzwUHaaN/lev5tHQLM1AEw+LrLeB2bIGIyKGDU7ZVrncXcv/oBny4rjbYg==}
+  /vue-component-type-helpers@1.8.15:
+    resolution: {integrity: sha512-RKiPRKW4BdwgmQ9vaNkHYKAThdTbgU4TOphVyyzqxRwsOJOoRIrb+vB49XLvs5CKPNrvxMXZMwPe5FyJCqFWyg==}
     dev: true
 
   /vue-demi@0.13.11(vue@3.3.4):


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1544

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Exported secondary campaign mapping, includes, interface from `ripple-tide-landing-page`
- Added secondary campaign mapping, includes, interface to `ripple-tide-search` search listing

### How to test
<!-- Summary of how to test  -->
- Used https://nginx-php.pr-333.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/ to set up a test listing (the search engine env didn't work on local, but the rest of the search listing template renders)
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

