### PR TITLE
fix(@dpc-sdp/nuxt-ripple): ensured that language specific fonts override all other fonts

### DIFF
--- a/packages/nuxt-ripple/composables/use-tide-language.ts
+++ b/packages/nuxt-ripple/composables/use-tide-language.ts
@@ -29,7 +29,7 @@ export default (page: any) => {
       style: [
         {
           children: `
-           .${language.value} { font-family: '${found.value?.name}', var(--rpl-type-font-family) }
+          .${language.value} * { font-family: '${found.value?.name}', var(--rpl-type-font-family) !important }
           `
         }
       ]


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- After the custom font change, the language css selector was no longer specific enough to override the fonts
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

