### PR TITLE
fix(@dpc-sdp/nuxt-ripple): fixed console error when request event was…

### DIFF
--- a/packages/nuxt-ripple/composables/use-merge-section-tags.ts
+++ b/packages/nuxt-ripple/composables/use-merge-section-tags.ts
@@ -12,9 +12,11 @@ const mergeTags = (existingTags: string, newTags: string): string => {
 export const useMergeSectionTags = async (
   sectionCacheTags: any
 ): Promise<void> => {
+  // event will be undefined if the request is on the client side
   const event = useRequestEvent()
+
   // Section.io cache tags must be set on the response header to invalidate the cache after a change in drupal
-  if (sectionCacheTags) {
+  if (event && sectionCacheTags) {
     const currentResponseHeaders = getResponseHeaders(event)
 
     const currentSectionTags: string =


### PR DESCRIPTION
… being fetched client side

nuxt doesn't expose the useRequestEvent on the client, only the server so it was failing

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

