### PR TITLE
[R20-1585] Filter out alerts with missing type relation

### DIFF
--- a/packages/nuxt-ripple/mapping/site/alerts/site-alerts-mapping.ts
+++ b/packages/nuxt-ripple/mapping/site/alerts/site-alerts-mapping.ts
@@ -47,19 +47,21 @@ const getAlertVariantForType = (
 }
 
 export const map = (src: TideApiResponse): TideAlert[] => {
-  const alerts = (src.site_alerts || []).map((rawAlert): TideAlert => {
-    const alertType = rawAlert.field_alert_type.name
-    const link = getLinkFromField(rawAlert, 'field_call_to_action')
+  const alerts = (src.site_alerts || [])
+    .filter((rawAlert: any) => rawAlert.field_alert_type)
+    .map((rawAlert: any) => {
+      const alertType = rawAlert.field_alert_type.name
+      const link = getLinkFromField(rawAlert, 'field_call_to_action')
 
-    return {
-      alertId: rawAlert.id,
-      variant: getAlertVariantForType(alertType),
-      iconName: getIconForType(alertType),
-      message: rawAlert.title || '',
-      linkText: link?.text || '',
-      linkUrl: link?.url || ''
-    }
-  })
+      return {
+        alertId: rawAlert.id,
+        variant: getAlertVariantForType(alertType),
+        iconName: getIconForType(alertType),
+        message: rawAlert.title || '',
+        linkText: link?.text || '',
+        linkUrl: link?.url || ''
+      }
+    })
   return sortAlertsByPriority(alerts)
 }
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1585

### What I did
<!-- Summary of changes made in the Pull Request  -->
- The site API call is returning incomplete alert nodes if they are associated via primary site ID, but _not_ site ID
- Our API firehose `_src` clearly shows these nodes, but linking direct to the BE API source does not
- For now, just filtering out any incomplete alert node to prevent the site from exploding (it really shouldn't), but will need to figure out why we're seeing those records in the first place

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

