### PR TITLE
[R20-1196] Pass entire complex option through as payload

### DIFF
--- a/packages/ripple-ui-core/src/components/search-bar/RplSearchBar.vue
+++ b/packages/ripple-ui-core/src/components/search-bar/RplSearchBar.vue
@@ -97,13 +97,15 @@ const handleInputChange = (e) => {
   isOpen.value = true
 }
 
-const handleSelectOption = (optionValue, focusBackOnInput) => {
+const handleSelectOption = (optionValue: any, focusBackOnInput) => {
+  const optionLabel = props.getOptionLabel(optionValue)
+
   if (focusBackOnInput) {
     inputRef.value.focus()
   }
 
   internalValue.value = optionValue
-  emit('update:inputValue', optionValue)
+  emit('update:inputValue', optionLabel)
   isOpen.value = false
 
   emitRplEvent(
@@ -111,8 +113,9 @@ const handleSelectOption = (optionValue, focusBackOnInput) => {
     {
       action: 'search',
       id: props.id,
-      text: optionValue,
-      value: optionValue,
+      text: optionLabel,
+      value: optionLabel,
+      payload: optionValue,
       type: 'suggestion'
     },
     { global: props.globalEvents }
@@ -305,18 +308,15 @@ const slug = (label: string) => label.toLowerCase().replace(/[^\w-]+/g, '-')
               slug(getOptionLabel(option))
             )
           }"
-          :tabindex="isOptionSelectable(option) ? '0' : '-1'"
+          tabindex="-1"
           @keydown.space.prevent="
-            isOptionSelectable(option) &&
-              handleSelectOption(getOptionLabel(option), true)
+            isOptionSelectable(option) && handleSelectOption(option, true)
           "
           @keydown.enter.prevent="
-            isOptionSelectable(option) &&
-              handleSelectOption(getOptionLabel(option), true)
+            isOptionSelectable(option) && handleSelectOption(option, true)
           "
           @click="
-            isOptionSelectable(option) &&
-              handleSelectOption(getOptionLabel(option), false)
+            isOptionSelectable(option) && handleSelectOption(option, false)
           "
           @keydown="isOptionSelectable(option) && handleKeydown"
         >


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Added new key to pass through entire complex option object, for further processing on consumer side (use case: using metadata to modify target URL from suggestion data)
- Also reverted back to `tabindex="-1"` to re-enable keyboard navigation (we are already managing keyboard events)

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

