### PR TITLE
[R20-1630] Only display promocard meta if values exist

### DIFF
--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/CardSharedMeta.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/CardSharedMeta.vue
@@ -1,6 +1,8 @@
 <template>
   <RplTag v-if="contentTypeLabel" :label="contentTypeLabel" variant="neutral" />
-  <span v-if="!contentTypeLabel" class="rpl-card__topic">{{ meta.topic }}</span>
+  <span v-if="!contentTypeLabel && meta.topic" class="rpl-card__topic">{{
+    meta.topic
+  }}</span>
   <span v-if="isGrant && grantStatus" class="rpl-card__status">
     <RplIcon
       v-if="

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/PromoCard.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/PromoCard.vue
@@ -10,7 +10,7 @@
     :image="image"
     :url="url"
   >
-    <template v-if="showMetadata" #meta>
+    <template v-if="showMetadata && metadataExists" #meta>
       <TideLandingPageCardSharedMeta :meta="metadata" />
     </template>
     <p>{{ summary }}</p>
@@ -23,13 +23,15 @@
     :highlight="displayStyle === 'noImage' || !image"
   >
     <p>{{ summary }}</p>
-    <template v-if="showMetadata" #meta>
+    <template v-if="showMetadata && metadataExists" #meta>
       <TideLandingPageCardSharedMeta :meta="metadata" />
     </template>
   </RplPromoCard>
 </template>
 
 <script setup lang="ts">
+import { computed } from '#imports'
+
 interface Props {
   title: string
   summary: string
@@ -51,5 +53,12 @@ interface Props {
   }
 }
 
-withDefaults(defineProps<Props>(), {})
+const props = withDefaults(defineProps<Props>(), {})
+
+const metadataExists = computed(
+  () =>
+    props.metadata.contentType?.length > 0 ||
+    props.metadata.topic?.length > 0 ||
+    props.metadata.isGrantOngoing
+)
 </script>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1630

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Check for metadata values before displaying meta container
- Also check for presence of topic before rendering el

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

