### PR TITLE
[R20-1636] Support D10 api in datatable mapping

### DIFF
--- a/packages/ripple-tide-api/types.d.ts
+++ b/packages/ripple-tide-api/types.d.ts
@@ -254,6 +254,7 @@ declare module 'nitropack' {
 
 // Mapping util interfaces
 export function getAddress(address: any): string
+export function getBody(body: any): string
 export function getBodyFromField(field: string, path: string | string[]): string
 export function getField(
   field: string,

--- a/packages/ripple-tide-landing-page/mapping/components/data-table/data-table-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/data-table/data-table-mapping.test.ts
@@ -1,6 +1,6 @@
 import { TideDynamicPageComponent } from '@dpc-sdp/ripple-tide-api/types'
 import { expect, describe, it } from '@jest/globals'
-import { dataTableMapping, ITideDataTable } from './data-table-mapping'
+import { selectDataTableMapping, ITideDataTable } from './data-table-mapping'
 
 const rawData = {
   links: {
@@ -29,6 +29,56 @@ const rawData = {
         'Row Three Column Two',
         'Row Three Column Three'
       ],
+      caption: ''
+    },
+    format: null,
+    caption: ''
+  },
+  field_first_column_table_header: false,
+  field_first_row_table_header: true,
+  field_table_orientation: true,
+  id: '1fea8825-5848-451d-a515-cf6bc1f36f67',
+  type: 'paragraph--data_table'
+}
+
+const rawDataV2 = {
+  links: {
+    self: {
+      href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/paragraph/data_table/1fea8825-5848-451d-a515-cf6bc1f36f67?resourceVersion=id%3A2115'
+    }
+  },
+  meta: { target_revision_id: 2115, drupal_internal__target_id: 1936 },
+  drupal_internal__id: 1936,
+  drupal_internal__revision_id: 2115,
+  langcode: 'en',
+  status: true,
+  created: '2023-04-28T23:40:45+00:00',
+  parent_id: '430',
+  parent_type: 'node',
+  parent_field_name: 'field_landing_page_component',
+  behavior_settings: [],
+  default_langcode: true,
+  revision_translation_affected: true,
+  field_data_table_content: {
+    value: {
+      '0': {
+        '0': 'Row One Column One',
+        '1': 'Row One Column Two',
+        '2': 'Row One Column Three',
+        weight: '0'
+      },
+      '1': {
+        '0': 'Row Two Column One',
+        '1': 'Row Two Column Two',
+        '2': 'Row Two Column Three',
+        weight: '1'
+      },
+      '2': {
+        '0': 'Row Three Column One',
+        '1': 'Row Three Column Two',
+        '2': 'Row Three Column Three',
+        weight: '2'
+      },
       caption: ''
     },
     format: null,
@@ -70,44 +120,56 @@ describe('introBannerMapping', () => {
       }
     }
 
-    expect(dataTableMapping(rawData)).toEqual(result)
+    expect(selectDataTableMapping(rawData)).toEqual(result)
   })
 
-  it('maps a table without a header row', () => {
-    const result: TideDynamicPageComponent<ITideDataTable> = {
-      component: 'TideLandingPageDataTable',
-      id: '1936',
-      props: {
-        caption: '',
-        headingType: { horizontal: false, vertical: false },
-        orientation: 'row',
-        columns: [
-          { objectKey: 'col0', isHTML: true },
-          { objectKey: 'col1', isHTML: true },
-          { objectKey: 'col2', isHTML: true }
-        ],
-        items: [
-          {
-            col0: 'Row One Column One',
-            col1: 'Row One Column Two',
-            col2: 'Row One Column Three'
-          },
-          {
-            col0: 'Row Two Column One',
-            col1: 'Row Two Column Two',
-            col2: 'Row Two Column Three'
-          },
-          {
-            col0: 'Row Three Column One',
-            col1: 'Row Three Column Two',
-            col2: 'Row Three Column Three'
-          }
-        ]
-      }
+  const result: TideDynamicPageComponent<ITideDataTable> = {
+    component: 'TideLandingPageDataTable',
+    id: '1936',
+    props: {
+      caption: '',
+      headingType: { horizontal: false, vertical: false },
+      orientation: 'row',
+      columns: [
+        { objectKey: 'col0', isHTML: true },
+        { objectKey: 'col1', isHTML: true },
+        { objectKey: 'col2', isHTML: true }
+      ],
+      items: [
+        {
+          col0: 'Row One Column One',
+          col1: 'Row One Column Two',
+          col2: 'Row One Column Three'
+        },
+        {
+          col0: 'Row Two Column One',
+          col1: 'Row Two Column Two',
+          col2: 'Row Two Column Three'
+        },
+        {
+          col0: 'Row Three Column One',
+          col1: 'Row Three Column Two',
+          col2: 'Row Three Column Three'
+        }
+      ]
     }
+  }
 
+  it('maps a table without a header row', () => {
     expect(
-      dataTableMapping({ ...rawData, field_first_row_table_header: false })
+      selectDataTableMapping({
+        ...rawData,
+        field_first_row_table_header: false
+      })
+    ).toEqual(result)
+  })
+
+  it('accepts the D10 API for data table mapping', () => {
+    expect(
+      selectDataTableMapping({
+        ...rawDataV2,
+        field_first_row_table_header: false
+      })
     ).toEqual(result)
   })
 })

--- a/packages/ripple-tide-landing-page/mapping/components/data-table/data-table-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/data-table/data-table-mapping.ts
@@ -25,17 +25,20 @@ const getColumnsFromEntries = (rows: any, firstRowIsHeader: boolean) => {
     return []
   }
 
-  return firstRow.map((val: any, index: number) => {
-    return {
-      label: firstRowIsHeader ? val : undefined,
-      objectKey: columnKey(index),
-      isHTML: true
+  // D10 API returns an object, legacy returns an array
+  return (Array.isArray(firstRow) ? firstRow : Object.values(firstRow)).map(
+    (val: any, index: number) => {
+      return {
+        label: firstRowIsHeader ? val : undefined,
+        objectKey: columnKey(index),
+        isHTML: true
+      }
     }
-  })
+  )
 }
 
-export const dataTableMapping = (
-  field
+export const dataTableMappingLegacy = (
+  field: any
 ): TideDynamicPageComponent<ITideDataTable> => {
   const entries = getField(field, 'field_data_table_content.value', {})
 
@@ -50,9 +53,7 @@ export const dataTableMapping = (
       return true
     })
     .map((entryKey) => {
-      const entry = entries[entryKey]
-
-      return entry.reduce((itemObj, val, index) => {
+      return entries[entryKey].reduce((itemObj: any, val: any, index: any) => {
         return {
           ...itemObj,
           [columnKey(index)]: getBody(val)
@@ -81,10 +82,73 @@ export const dataTableMapping = (
   }
 }
 
+export const dataTableMapping = (
+  field: any
+): TideDynamicPageComponent<ITideDataTable> => {
+  const sorted = Object.values(
+    getField(field, 'field_data_table_content.value', {})
+  )
+    .filter((e: any) => e.weight)
+    .sort((a: any, b: any) => a.weight - b.weight)
+
+  const items = Object.keys(sorted)
+    .filter((entryKey) => {
+      if (field?.field_first_row_table_header) {
+        // Exclude first row if it is a header
+        return entryKey !== '0'
+      }
+
+      return true
+    })
+    .map((entryKey) => {
+      const unprocessed: any = sorted[entryKey as any]
+      delete unprocessed.weight
+      const row: any = {}
+      for (const [key, value] of Object.entries(unprocessed)) {
+        row[columnKey(parseInt(key)) as any] = value
+      }
+      return row
+    })
+
+  const columns = getColumnsFromEntries(
+    sorted,
+    field?.field_first_row_table_header || false
+  )
+
+  return {
+    component: 'TideLandingPageDataTable',
+    id: `${field.drupal_internal__id}`,
+    props: {
+      caption: field?.field_data_table_content?.caption,
+      headingType: {
+        horizontal: field?.field_first_row_table_header,
+        vertical: field?.field_first_column_table_header
+      },
+      orientation: field?.field_table_orientation ? 'row' : 'column',
+      columns,
+      items
+    }
+  }
+}
+
 export const dataTableIncludes = []
+
+// D10 API returns an object, legacy returns an array
+export const selectDataTableMapping = (
+  field: any
+): TideDynamicPageComponent<ITideDataTable> => {
+  const raw = getField(field, 'field_data_table_content.value', {})
+
+  if (Array.isArray(raw[0])) {
+    return dataTableMappingLegacy(field)
+  } else {
+    // D10
+    return dataTableMapping(field)
+  }
+}
 
 export default {
   includes: dataTableIncludes,
-  mapping: dataTableMapping,
+  mapping: selectDataTableMapping,
   contentTypes: ['landing_page']
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1636

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Added mapping for new API and method for selecting which mapping to use (legacy uses an array for rows, new api uses object)
- Updated unit test

### How to test
<!-- Summary of how to test  -->
- Unit test
- https://develop.content.reference.sdp.vic.gov.au (D10) vs. https://nginx-php.pr-301.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au (D9)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

