### PR TITLE
[R20-1604] Add date to news card

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/news.feature
+++ b/examples/nuxt-app/test/features/search-listing/news.feature
@@ -1,0 +1,12 @@
+Feature: News collection
+
+  Background:
+    Given the site endpoint returns fixture "/site/reference" with status 200
+
+  @mockserver
+  Example: Results formatting
+    Given the page endpoint for path "/news" returns fixture "/search-listing/news/page" with status 200
+    And the search network request is stubbed with fixture "/search-listing/news/response" and status 200
+    When I visit the page "/news"
+    Then the search listing page should have 9 results
+    And the search listing layout should be "grid"

--- a/examples/nuxt-app/test/fixtures/search-listing/news/page.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/news/page.json
@@ -1,0 +1,68 @@
+{
+  "title": "News listing",
+  "changed": "2023-08-22T05:31:10+00:00",
+  "created": "2023-08-22T02:19:10+00:00",
+  "type": "tide_search_listing",
+  "nid": "0af58113-6c1d-4b29-bbed-a166d8410c9c",
+  "sidebar": {},
+  "status": "published",
+  "topicTags": [],
+  "siteSection": null,
+  "meta": {
+    "langcode": "en",
+    "description": "",
+    "additional": [
+      {
+        "tag": "meta",
+        "attributes": {
+          "name": "title",
+          "content": "News listing | Vic.gov.au"
+        }
+      },
+      {
+        "tag": "link",
+        "attributes": {
+          "rel": "canonical",
+          "href": "https://nginx-php.pr-1554.content-vic.sdp4.sdp.vic.gov.au/whatson"
+        }
+      }
+    ],
+    "keywords": "",
+    "image": null
+  },
+  "showContentRating": true,
+  "summary": null,
+  "afterResults": "",
+  "introText": null,
+  "config": {
+    "searchListingConfig": {
+      "resultsPerPage": 9,
+      "customSort": [{ "field_news_date": "desc" }]
+    },
+    "queryConfig": {
+      "multi_match": {
+        "query": "{{query}}",
+        "fields": [
+          "title^3",
+          "field_landing_page_summary^2",
+          "body",
+          "field_news_intro_text",
+          "summary_processed"
+        ]
+      }
+    },
+    "results": {
+      "layout": {
+        "component": "TideSearchResultsGrid"
+      },
+      "item": {
+        "news": {
+          "component": "TideSearchResultCard"
+        }
+      }
+    },
+    "globalFilters": [{ "terms": { "type": ["news"] } }],
+    "userFilters": []
+  },
+  "_fetched": 1692682318351
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/news/response.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/news/response.json
@@ -1,0 +1,373 @@
+{
+  "took": 1,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 23,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/164:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": [
+            "/site-8888/news-cc-1",
+            "/site-9138/news-cc-1",
+            "/site-9012/news-cc-1",
+            "/site-9143/news-cc-1"
+          ],
+          "body": [
+            "Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae Phasellus congue aliquam vehicula Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus. Nulla nec urna augue. Curabitur commodo nisi est, eu pulvinar tortor cursus vel. Morbi dictum ex est, et semper diam finibus eu. Cras rutrum, nunc a fringilla convallis, massa est vulputate velit, in blandit augue dui vitae elit. Donec hendrerit commodo augue, in maximus orci tempor congue. Mauris ultricies euismod orci, nec vehicula quam vehicula ac. Nunc dictum tortor dolor, nec eleifend orci luctus sed. Donec scelerisque cursus ex varius efficitur Morbi cursus placerat mi Nullam laoreet ante placerat Integer interdum nisl ut neque dictum, et sagittis metus feugiat. Sed in mattis neque. Duis at risus non ipsum semper dapibus. Sed enim sapien, molestie sed commodo vel, lacinia vitae risus. Proin sagittis diam nisi, sed rhoncus diam varius id. Sed malesuada felis tortor, scelerisque pretium elit tempor non. Pellentesque ultrices volutpat tincidunt. Fusce quis viverra urna, quis finibus nulla. Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam. Duis ligula lacus Phasellus est turpis, efficitur nec odio imperdiet Mauris tincidunt tincidunt felis vel tempus Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris."
+          ],
+          "changed": ["2023-12-08T13:27:27+11:00"],
+          "created": ["2023-12-08T13:27:27+11:00"],
+          "field_event_intro_text": [
+            "Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae"
+          ],
+          "field_landing_page_summary": [
+            "NP1 Etiam scelerisque lorem sit amet sapien iaculis, nec dignissim augue cursus. Mauris eu purus a neque tristique venenatis sit amet sed sem. Aenean viverra lectus ut tempus sollicitudin."
+          ],
+          "field_media_image_absolute_path": ["/cy/placeholder.png"],
+          "field_news_date": ["2050-07-02T09:00:00+10:00"],
+          "field_node_site": [8888, 9136, 9138, 9141, 9012, 9143],
+          "field_tags": [9116],
+          "field_tags_name": ["Content Collection Tag 1"],
+          "field_tags_path": ["/tags/content-collection-tag-1"],
+          "field_tags_uuid": ["11dede11-10c0-111e1-1101-000000000012"],
+          "field_topic": [9128],
+          "field_topic_name": ["Content Collection Topic 1"],
+          "field_topic_path": ["/topic/content-collection-topic-1"],
+          "field_topic_uuid": ["11dede11-10c0-111e1-1102-000000000022"],
+          "langcode": ["en"],
+          "nid": [164],
+          "status": [true],
+          "title": ["News for CC 1"],
+          "type": ["news"],
+          "uid": [1],
+          "uuid": ["11dede11-10c0-111e1-1100-000000000321"]
+        },
+        "sort": [2540329200000]
+      },
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/165:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": [
+            "/site-8888/news-cc-2",
+            "/site-9012/news-cc-2",
+            "/site-9138/news-cc-2",
+            "/site-9143/news-cc-2"
+          ],
+          "body": [
+            "Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae Phasellus congue aliquam vehicula Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus. Nulla nec urna augue. Curabitur commodo nisi est, eu pulvinar tortor cursus vel. Morbi dictum ex est, et semper diam finibus eu. Cras rutrum, nunc a fringilla convallis, massa est vulputate velit, in blandit augue dui vitae elit. Donec hendrerit commodo augue, in maximus orci tempor congue. Mauris ultricies euismod orci, nec vehicula quam vehicula ac. Nunc dictum tortor dolor, nec eleifend orci luctus sed. Donec scelerisque cursus ex varius efficitur Morbi cursus placerat mi Nullam laoreet ante placerat Integer interdum nisl ut neque dictum, et sagittis metus feugiat. Sed in mattis neque. Duis at risus non ipsum semper dapibus. Sed enim sapien, molestie sed commodo vel, lacinia vitae risus. Proin sagittis diam nisi, sed rhoncus diam varius id. Sed malesuada felis tortor, scelerisque pretium elit tempor non. Pellentesque ultrices volutpat tincidunt. Fusce quis viverra urna, quis finibus nulla. Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam. Duis ligula lacus Phasellus est turpis, efficitur nec odio imperdiet Mauris tincidunt tincidunt felis vel tempus Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris."
+          ],
+          "changed": ["2023-12-08T13:27:27+11:00"],
+          "created": ["2023-12-08T13:27:27+11:00"],
+          "field_event_intro_text": [
+            "Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae"
+          ],
+          "field_landing_page_summary": [
+            "NP2 Pellentesque a pharetra magna. Pellentesque vitae est a sapien mi enim, eu sodales diam pretium in. Quisque vitae quam et lectus condimentum ultricies."
+          ],
+          "field_news_date": ["2048-07-02T09:00:00+10:00"],
+          "field_node_site": [8888, 9141, 9012, 9138, 9143],
+          "field_tags": [9117],
+          "field_tags_name": ["Content Collection Tag 2"],
+          "field_tags_path": ["/tags/content-collection-tag-2"],
+          "field_tags_uuid": ["11dede11-10c0-111e1-1101-000000000013"],
+          "field_topic": [9128],
+          "field_topic_name": ["Content Collection Topic 1"],
+          "field_topic_path": ["/topic/content-collection-topic-1"],
+          "field_topic_uuid": ["11dede11-10c0-111e1-1102-000000000022"],
+          "langcode": ["en"],
+          "nid": [165],
+          "status": [true],
+          "title": ["News for CC 2"],
+          "type": ["news"],
+          "uid": [1],
+          "uuid": ["904e365b-611d-4819-a232-e8f96e7626d5"]
+        },
+        "sort": [2477257200000]
+      },
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/166:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": [
+            "/site-8888/news-cc-3",
+            "/site-9012/news-cc-3",
+            "/site-9138/news-cc-3",
+            "/site-9143/news-cc-3"
+          ],
+          "body": [
+            "Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae Phasellus congue aliquam vehicula Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus. Nulla nec urna augue. Curabitur commodo nisi est, eu pulvinar tortor cursus vel. Morbi dictum ex est, et semper diam finibus eu. Cras rutrum, nunc a fringilla convallis, massa est vulputate velit, in blandit augue dui vitae elit. Donec hendrerit commodo augue, in maximus orci tempor congue. Mauris ultricies euismod orci, nec vehicula quam vehicula ac. Nunc dictum tortor dolor, nec eleifend orci luctus sed. Donec scelerisque cursus ex varius efficitur Morbi cursus placerat mi Nullam laoreet ante placerat Integer interdum nisl ut neque dictum, et sagittis metus feugiat. Sed in mattis neque. Duis at risus non ipsum semper dapibus. Sed enim sapien, molestie sed commodo vel, lacinia vitae risus. Proin sagittis diam nisi, sed rhoncus diam varius id. Sed malesuada felis tortor, scelerisque pretium elit tempor non. Pellentesque ultrices volutpat tincidunt. Fusce quis viverra urna, quis finibus nulla. Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam. Duis ligula lacus Phasellus est turpis, efficitur nec odio imperdiet Mauris tincidunt tincidunt felis vel tempus Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris."
+          ],
+          "changed": ["2023-12-08T13:27:27+11:00"],
+          "created": ["2023-12-08T13:27:27+11:00"],
+          "field_event_intro_text": [
+            "Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae"
+          ],
+          "field_landing_page_summary": [
+            "NP3 Suspendisse condimentum turpis fermentum lectus feugiat massa maximus at. In hendrerit gravida imperdiet. Donec rutrum turpis et tempor pulvinar."
+          ],
+          "field_media_image_absolute_path": ["/cy/placeholder.png"],
+          "field_news_date": ["2023-12-08T13:29:41+11:00"],
+          "field_node_site": [8888, 9141, 9012, 9138, 9143],
+          "field_tags": [9116],
+          "field_tags_name": ["Content Collection Tag 1"],
+          "field_tags_path": ["/tags/content-collection-tag-1"],
+          "field_tags_uuid": ["11dede11-10c0-111e1-1101-000000000012"],
+          "field_topic": [9129],
+          "field_topic_name": ["Content Collection Topic 2"],
+          "field_topic_path": ["/topic/content-collection-topic-2"],
+          "field_topic_uuid": ["11dede11-10c0-111e1-1102-000000000023"],
+          "langcode": ["en"],
+          "nid": [166],
+          "status": [true],
+          "title": ["News for CC 3"],
+          "type": ["news"],
+          "uid": [1],
+          "uuid": ["4cf6e61e-9011-490b-9580-5b16f6de4e5b"]
+        },
+        "sort": [1702002581000]
+      },
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/101:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": [
+            "/site-9012/news-6-different-tags-no-feature-image-different-topic"
+          ],
+          "body": [
+            "Sing, O goddess, the anger of Achilles son of Peleus, that brought countless ills upon the Achaeans. Many a brave soul did it send hurrying down to Hades, and many a hero did it yield a prey to dogs and vultures, for so were the counsels of Jove fulfilled from the day on which the son of Atreus, king of men, and great Achilles, first fell out with one another. And which of the gods was it that set them on to quarrel? It was the son of Jove and Leto; for he was angry with the king and sent a pestilence upon the host to plague the people, because the son of Atreus had dishonoured Chryses his priest. Now Chryses had come to the ships of the Achaeans to free his daughter, and had brought with him a great ransom: moreover he bore in his hand the sceptre of Apollo wreathed with a suppliant’s wreath, and he besought the Achaeans, but most of all the two sons of Atreus, who were their chiefs. “Sons of Atreus,” he cried, “and all other Achaeans, may the gods who dwell in Olympus grant you to sack the city of Priam, and to reach your homes in safety; but free my daughter, and accept a ransom for her, in reverence to Apollo, son of Jove.” On this the rest of the Achaeans with one voice were for respecting the priest and taking the ransom that he offered; but not so Agamemnon, who spoke fiercely to him and sent him roughly away. “Old man,” said he, “let me not find you tarrying about our ships, nor yet coming hereafter. Your sceptre of the god and your wreath shall profit you nothing. I will not free her. She shall grow old in my house at Argos far from her own home, busying herself with her loom and visiting my couch; so go, and do not provoke me or it shall be the worse for you.” The old man feared him and obeyed. Not a word he spoke, but went by the shore of the sounding sea and prayed apart to King Apollo whom lovely Leto had borne. “Hear me,” he cried, “O god of the silver bow, that protectest Chryse and holy Cilla and rulest Tenedos with thy might, hear me oh thou of Sminthe. If I have ever decked your temple with garlands, or burned your thigh-bones in fat of bulls or goats, grant my prayer, and let your arrows avenge these my tears upon the Danaans.”"
+          ],
+          "changed": ["2023-05-30T15:28:16+10:00"],
+          "created": ["2023-05-30T13:20:41+10:00"],
+          "field_landing_page_summary": ["Summary"],
+          "field_media_image_absolute_path": ["/cy/placeholder.png"],
+          "field_news_date": ["2023-05-30T11:15:46+10:00"],
+          "field_node_site": [9013],
+          "field_tags": [8992, 8993],
+          "field_tags_name": ["Beluga", "Capybara"],
+          "field_tags_path": ["/tags/beluga", "/tags/capybara"],
+          "field_tags_uuid": [
+            "99fc600f-afcd-4e84-8700-edf1c2bf0fe5",
+            "e35c1c81-369d-478a-a72a-3a8f3d69f927"
+          ],
+          "field_topic": [8996],
+          "field_topic_name": ["Topic c"],
+          "field_topic_path": ["/topic/topic-c"],
+          "field_topic_uuid": ["d6edb3df-e898-4b9b-9b74-8795946f0d43"],
+          "langcode": ["en"],
+          "nid": [101],
+          "status": [true],
+          "title": ["News 12- multiple tags, feature image, site section"],
+          "type": ["news"],
+          "uid": [21],
+          "uuid": ["2d014075-6a6a-42b3-8bdd-477a556c8627"]
+        },
+        "sort": [1685409346000]
+      },
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/102:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": ["/site-9012/news-11-no-tags-no-feature-image"],
+          "body": [
+            "Sing, O goddess, the anger of Achilles son of Peleus, that brought countless ills upon the Achaeans. Many a brave soul did it send hurrying down to Hades, and many a hero did it yield a prey to dogs and vultures, for so were the counsels of Jove fulfilled from the day on which the son of Atreus, king of men, and great Achilles, first fell out with one another. And which of the gods was it that set them on to quarrel? It was the son of Jove and Leto; for he was angry with the king and sent a pestilence upon the host to plague the people, because the son of Atreus had dishonoured Chryses his priest. Now Chryses had come to the ships of the Achaeans to free his daughter, and had brought with him a great ransom: moreover he bore in his hand the sceptre of Apollo wreathed with a suppliant’s wreath, and he besought the Achaeans, but most of all the two sons of Atreus, who were their chiefs. “Sons of Atreus,” he cried, “and all other Achaeans, may the gods who dwell in Olympus grant you to sack the city of Priam, and to reach your homes in safety; but free my daughter, and accept a ransom for her, in reverence to Apollo, son of Jove.” On this the rest of the Achaeans with one voice were for respecting the priest and taking the ransom that he offered; but not so Agamemnon, who spoke fiercely to him and sent him roughly away. “Old man,” said he, “let me not find you tarrying about our ships, nor yet coming hereafter. Your sceptre of the god and your wreath shall profit you nothing. I will not free her. She shall grow old in my house at Argos far from her own home, busying herself with her loom and visiting my couch; so go, and do not provoke me or it shall be the worse for you.” The old man feared him and obeyed. Not a word he spoke, but went by the shore of the sounding sea and prayed apart to King Apollo whom lovely Leto had borne. “Hear me,” he cried, “O god of the silver bow, that protectest Chryse and holy Cilla and rulest Tenedos with thy might, hear me oh thou of Sminthe. If I have ever decked your temple with garlands, or burned your thigh-bones in fat of bulls or goats, grant my prayer, and let your arrows avenge these my tears upon the Danaans.”"
+          ],
+          "changed": ["2023-05-30T15:27:10+10:00"],
+          "created": ["2023-05-30T13:20:52+10:00"],
+          "field_landing_page_summary": ["Summary"],
+          "field_news_date": ["2023-05-30T11:15:46+10:00"],
+          "field_node_site": [9012],
+          "field_topic": [8996],
+          "field_topic_name": ["Topic c"],
+          "field_topic_path": ["/topic/topic-c"],
+          "field_topic_uuid": ["d6edb3df-e898-4b9b-9b74-8795946f0d43"],
+          "langcode": ["en"],
+          "nid": [102],
+          "status": [true],
+          "title": ["News 11- no tags, no feature image"],
+          "type": ["news"],
+          "uid": [21],
+          "uuid": ["329dde9f-4afd-469b-a579-fecb95ae382c"]
+        },
+        "sort": [1685409346000]
+      },
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/100:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": [
+            "/site-9012/news-6-different-tags-no-feature-image-different-topic"
+          ],
+          "body": [
+            "Sing, O goddess, the anger of Achilles son of Peleus, that brought countless ills upon the Achaeans. Many a brave soul did it send hurrying down to Hades, and many a hero did it yield a prey to dogs and vultures, for so were the counsels of Jove fulfilled from the day on which the son of Atreus, king of men, and great Achilles, first fell out with one another. And which of the gods was it that set them on to quarrel? It was the son of Jove and Leto; for he was angry with the king and sent a pestilence upon the host to plague the people, because the son of Atreus had dishonoured Chryses his priest. Now Chryses had come to the ships of the Achaeans to free his daughter, and had brought with him a great ransom: moreover he bore in his hand the sceptre of Apollo wreathed with a suppliant’s wreath, and he besought the Achaeans, but most of all the two sons of Atreus, who were their chiefs. “Sons of Atreus,” he cried, “and all other Achaeans, may the gods who dwell in Olympus grant you to sack the city of Priam, and to reach your homes in safety; but free my daughter, and accept a ransom for her, in reverence to Apollo, son of Jove.” On this the rest of the Achaeans with one voice were for respecting the priest and taking the ransom that he offered; but not so Agamemnon, who spoke fiercely to him and sent him roughly away. “Old man,” said he, “let me not find you tarrying about our ships, nor yet coming hereafter. Your sceptre of the god and your wreath shall profit you nothing. I will not free her. She shall grow old in my house at Argos far from her own home, busying herself with her loom and visiting my couch; so go, and do not provoke me or it shall be the worse for you.” The old man feared him and obeyed. Not a word he spoke, but went by the shore of the sounding sea and prayed apart to King Apollo whom lovely Leto had borne. “Hear me,” he cried, “O god of the silver bow, that protectest Chryse and holy Cilla and rulest Tenedos with thy might, hear me oh thou of Sminthe. If I have ever decked your temple with garlands, or burned your thigh-bones in fat of bulls or goats, grant my prayer, and let your arrows avenge these my tears upon the Danaans.”"
+          ],
+          "changed": ["2023-05-30T15:22:47+10:00"],
+          "created": ["2023-05-30T13:20:34+10:00"],
+          "field_landing_page_summary": ["Summary"],
+          "field_news_date": ["2023-05-30T11:15:46+10:00"],
+          "field_node_site": [9012],
+          "field_tags": [8993, 8992],
+          "field_tags_name": ["Capybara", "Beluga"],
+          "field_tags_path": ["/tags/capybara", "/tags/beluga"],
+          "field_tags_uuid": [
+            "e35c1c81-369d-478a-a72a-3a8f3d69f927",
+            "99fc600f-afcd-4e84-8700-edf1c2bf0fe5"
+          ],
+          "field_topic": [8994],
+          "field_topic_name": ["Topic b"],
+          "field_topic_path": ["/topic/topic-b"],
+          "field_topic_uuid": ["387a02bd-6d4b-4411-afdc-c2cfda53e101"],
+          "langcode": ["en"],
+          "nid": [100],
+          "status": [true],
+          "title": [
+            "News 6 - different tags, no feature image, different topic"
+          ],
+          "type": ["news"],
+          "uid": [21],
+          "uuid": ["67fa9e08-2d4f-4f58-9c3d-cf50771e28c5"]
+        },
+        "sort": [1685409346000]
+      },
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/94:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": ["/site-9012/news-1-no-tags-no-feature-image"],
+          "body": [
+            "Sing, O goddess, the anger of Achilles son of Peleus, that brought countless ills upon the Achaeans. Many a brave soul did it send hurrying down to Hades, and many a hero did it yield a prey to dogs and vultures, for so were the counsels of Jove fulfilled from the day on which the son of Atreus, king of men, and great Achilles, first fell out with one another. And which of the gods was it that set them on to quarrel? It was the son of Jove and Leto; for he was angry with the king and sent a pestilence upon the host to plague the people, because the son of Atreus had dishonoured Chryses his priest. Now Chryses had come to the ships of the Achaeans to free his daughter, and had brought with him a great ransom: moreover he bore in his hand the sceptre of Apollo wreathed with a suppliant’s wreath, and he besought the Achaeans, but most of all the two sons of Atreus, who were their chiefs. “Sons of Atreus,” he cried, “and all other Achaeans, may the gods who dwell in Olympus grant you to sack the city of Priam, and to reach your homes in safety; but free my daughter, and accept a ransom for her, in reverence to Apollo, son of Jove.” On this the rest of the Achaeans with one voice were for respecting the priest and taking the ransom that he offered; but not so Agamemnon, who spoke fiercely to him and sent him roughly away. “Old man,” said he, “let me not find you tarrying about our ships, nor yet coming hereafter. Your sceptre of the god and your wreath shall profit you nothing. I will not free her. She shall grow old in my house at Argos far from her own home, busying herself with her loom and visiting my couch; so go, and do not provoke me or it shall be the worse for you.” The old man feared him and obeyed. Not a word he spoke, but went by the shore of the sounding sea and prayed apart to King Apollo whom lovely Leto had borne. “Hear me,” he cried, “O god of the silver bow, that protectest Chryse and holy Cilla and rulest Tenedos with thy might, hear me oh thou of Sminthe. If I have ever decked your temple with garlands, or burned your thigh-bones in fat of bulls or goats, grant my prayer, and let your arrows avenge these my tears upon the Danaans.”"
+          ],
+          "changed": ["2023-05-30T11:17:10+10:00"],
+          "created": ["2023-05-30T11:17:10+10:00"],
+          "field_landing_page_summary": ["Summary"],
+          "field_news_date": ["2023-05-30T11:15:46+10:00"],
+          "field_node_site": [9012],
+          "field_topic": [8996],
+          "field_topic_name": ["Topic c"],
+          "field_topic_path": ["/topic/topic-c"],
+          "field_topic_uuid": ["d6edb3df-e898-4b9b-9b74-8795946f0d43"],
+          "langcode": ["en"],
+          "nid": [94],
+          "status": [true],
+          "title": ["News 1 - no tags, no feature image"],
+          "type": ["news"],
+          "uid": [21],
+          "uuid": ["bed62abd-2b72-4d12-9e92-f08acfd44de4"]
+        },
+        "sort": [1685409346000]
+      },
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/97:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": ["/site-9012/news-5-no-tags-feature-image-different-topic"],
+          "body": [
+            "Sing, O goddess, the anger of Achilles son of Peleus, that brought countless ills upon the Achaeans. Many a brave soul did it send hurrying down to Hades, and many a hero did it yield a prey to dogs and vultures, for so were the counsels of Jove fulfilled from the day on which the son of Atreus, king of men, and great Achilles, first fell out with one another. And which of the gods was it that set them on to quarrel? It was the son of Jove and Leto; for he was angry with the king and sent a pestilence upon the host to plague the people, because the son of Atreus had dishonoured Chryses his priest. Now Chryses had come to the ships of the Achaeans to free his daughter, and had brought with him a great ransom: moreover he bore in his hand the sceptre of Apollo wreathed with a suppliant’s wreath, and he besought the Achaeans, but most of all the two sons of Atreus, who were their chiefs. “Sons of Atreus,” he cried, “and all other Achaeans, may the gods who dwell in Olympus grant you to sack the city of Priam, and to reach your homes in safety; but free my daughter, and accept a ransom for her, in reverence to Apollo, son of Jove.” On this the rest of the Achaeans with one voice were for respecting the priest and taking the ransom that he offered; but not so Agamemnon, who spoke fiercely to him and sent him roughly away. “Old man,” said he, “let me not find you tarrying about our ships, nor yet coming hereafter. Your sceptre of the god and your wreath shall profit you nothing. I will not free her. She shall grow old in my house at Argos far from her own home, busying herself with her loom and visiting my couch; so go, and do not provoke me or it shall be the worse for you.” The old man feared him and obeyed. Not a word he spoke, but went by the shore of the sounding sea and prayed apart to King Apollo whom lovely Leto had borne. “Hear me,” he cried, “O god of the silver bow, that protectest Chryse and holy Cilla and rulest Tenedos with thy might, hear me oh thou of Sminthe. If I have ever decked your temple with garlands, or burned your thigh-bones in fat of bulls or goats, grant my prayer, and let your arrows avenge these my tears upon the Danaans.”"
+          ],
+          "changed": ["2023-05-30T15:21:30+10:00"],
+          "created": ["2023-05-30T13:20:08+10:00"],
+          "field_event_intro_text": ["Intro"],
+          "field_landing_page_summary": ["Summary"],
+          "field_news_date": ["2023-05-30T11:15:46+10:00"],
+          "field_node_site": [9012],
+          "field_topic": [8994],
+          "field_topic_name": ["Topic b"],
+          "field_topic_path": ["/topic/topic-b"],
+          "field_topic_uuid": ["387a02bd-6d4b-4411-afdc-c2cfda53e101"],
+          "langcode": ["en"],
+          "nid": [97],
+          "status": [true],
+          "title": ["News 5- no tags, feature image, different topic"],
+          "type": ["news"],
+          "uid": [21],
+          "uuid": ["143a05dd-6afc-478a-9735-d79f690b6690"]
+        },
+        "sort": [1685409346000]
+      },
+      {
+        "_index": "b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_default_node",
+        "_id": "entity:node/99:en",
+        "_score": null,
+        "_ignored": ["body.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0", "node_access_all:0"],
+          "url": ["/site-9012/news-3-multiple-tags-feature-image"],
+          "body": [
+            "Sing, O goddess, the anger of Achilles son of Peleus, that brought countless ills upon the Achaeans. Many a brave soul did it send hurrying down to Hades, and many a hero did it yield a prey to dogs and vultures, for so were the counsels of Jove fulfilled from the day on which the son of Atreus, king of men, and great Achilles, first fell out with one another. And which of the gods was it that set them on to quarrel? It was the son of Jove and Leto; for he was angry with the king and sent a pestilence upon the host to plague the people, because the son of Atreus had dishonoured Chryses his priest. Now Chryses had come to the ships of the Achaeans to free his daughter, and had brought with him a great ransom: moreover he bore in his hand the sceptre of Apollo wreathed with a suppliant’s wreath, and he besought the Achaeans, but most of all the two sons of Atreus, who were their chiefs. “Sons of Atreus,” he cried, “and all other Achaeans, may the gods who dwell in Olympus grant you to sack the city of Priam, and to reach your homes in safety; but free my daughter, and accept a ransom for her, in reverence to Apollo, son of Jove.” On this the rest of the Achaeans with one voice were for respecting the priest and taking the ransom that he offered; but not so Agamemnon, who spoke fiercely to him and sent him roughly away. “Old man,” said he, “let me not find you tarrying about our ships, nor yet coming hereafter. Your sceptre of the god and your wreath shall profit you nothing. I will not free her. She shall grow old in my house at Argos far from her own home, busying herself with her loom and visiting my couch; so go, and do not provoke me or it shall be the worse for you.” The old man feared him and obeyed. Not a word he spoke, but went by the shore of the sounding sea and prayed apart to King Apollo whom lovely Leto had borne. “Hear me,” he cried, “O god of the silver bow, that protectest Chryse and holy Cilla and rulest Tenedos with thy might, hear me oh thou of Sminthe. If I have ever decked your temple with garlands, or burned your thigh-bones in fat of bulls or goats, grant my prayer, and let your arrows avenge these my tears upon the Danaans.”"
+          ],
+          "changed": ["2023-05-30T13:24:00+10:00"],
+          "created": ["2023-05-30T13:20:25+10:00"],
+          "field_event_intro_text": ["Intro"],
+          "field_landing_page_summary": ["Summary"],
+          "field_media_image_absolute_path": ["/cy/placeholder.png"],
+          "field_news_date": ["2023-05-30T11:15:46+10:00"],
+          "field_node_site": [9012],
+          "field_tags": [8993, 8992],
+          "field_tags_name": ["Capybara", "Beluga"],
+          "field_tags_path": ["/tags/capybara", "/tags/beluga"],
+          "field_tags_uuid": [
+            "e35c1c81-369d-478a-a72a-3a8f3d69f927",
+            "99fc600f-afcd-4e84-8700-edf1c2bf0fe5"
+          ],
+          "field_topic": [8996],
+          "field_topic_name": ["Topic c"],
+          "field_topic_path": ["/topic/topic-c"],
+          "field_topic_uuid": ["d6edb3df-e898-4b9b-9b74-8795946f0d43"],
+          "langcode": ["en"],
+          "nid": [99],
+          "status": [true],
+          "title": ["News 3 - multiple tags, feature image"],
+          "type": ["news"],
+          "uid": [21],
+          "uuid": ["a08b9e44-6d5b-4b74-9bdb-dc05af7b9698"]
+        },
+        "sort": [1685409346000]
+      }
+    ]
+  }
+}

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/CardSharedMeta.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/CardSharedMeta.vue
@@ -3,27 +3,36 @@
   <span v-if="!contentTypeLabel && meta.topic" class="rpl-card__topic">{{
     meta.topic
   }}</span>
-  <span v-if="isGrant && grantStatus" class="rpl-card__status">
-    <RplIcon
-      v-if="
-        grantStatus.status === 'open' || grantStatus.status === 'opening_soon'
-      "
-      class="rpl-icon--colour-success"
-      name="icon-check-circle-filled"
-    />
-    <RplIcon
-      v-else
-      class="rpl-icon--colour-error"
-      name="icon-cancel-circle-filled"
-    />
-    <span>{{ grantStatus.displayLabel }}</span>
-  </span>
+  <template v-if="isGrant && grantStatus">
+    <span class="rpl-card__status">
+      <RplIcon
+        v-if="
+          grantStatus.status === 'open' || grantStatus.status === 'opening_soon'
+        "
+        class="rpl-icon--colour-success"
+        name="icon-check-circle-filled"
+      />
+      <RplIcon
+        v-else
+        class="rpl-icon--colour-error"
+        name="icon-cancel-circle-filled"
+      />
+      <span>{{ grantStatus.displayLabel }}</span>
+    </span>
+  </template>
   <template v-else>
-    <span v-if="meta.fvRecommendationStatus">{{
-      meta.fvRecommendationStatus
-    }}</span>
-    <span v-if="formattedDate">{{ formattedDate }}</span>
-    <span v-if="meta.inductionYear">{{ meta.inductionYear }}</span>
+    <template v-if="meta.fvRecommendationStatus">
+      <span>{{ meta.fvRecommendationStatus }}</span>
+    </template>
+    <template v-if="meta.dateStart">
+      <span>{{ formattedDate }}</span>
+    </template>
+    <template v-if="meta.publishDate">
+      <span>{{ formattedPublishDate }}</span>
+    </template>
+    <template v-if="meta.inductionYear">
+      <span>{{ meta.inductionYear }}</span>
+    </template>
   </template>
 </template>
 
@@ -60,6 +69,12 @@ const formattedDate = computed(() => {
     return ''
   }
 })
+
+const formattedPublishDate = computed(() =>
+  new Intl.DateTimeFormat('en-AU', { month: 'long', day: 'numeric' }).format(
+    new Date(props.meta.publishDate)
+  )
+)
 
 const now = new Date()
 

--- a/packages/ripple-tide-search/components/global/TideSearchResultCard.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchResultCard.vue
@@ -33,6 +33,7 @@ const meta = computed(() => {
       'field_node_dates_start_value'
     ),
     dateEnd: getSearchResultValue(props.result, 'field_node_dates_end_value'),
+    publishDate: getSearchResultValue(props.result, 'field_news_date'),
     isGrantOngoing: getSearchResultValue(props.result, 'field_node_on_going')
     // @todo add profile and recommendation meta or a way to hook into this from other layers
     // fvRecommendationStatus

--- a/packages/ripple-ui-core/src/styles/utilities/_typography.css
+++ b/packages/ripple-ui-core/src/styles/utilities/_typography.css
@@ -280,6 +280,14 @@ html {
   font-weight: var(--rpl-type-weight-bold);
 }
 
+.rpl-type-weight-regular {
+  font-weight: var(--rpl-type-weight-regular);
+}
+
+.rpl-type-uppercase {
+  text-transform: uppercase;
+}
+
 /* Revert all highlights for print */
 .rpl-type-h1-highlight,
 .rpl-type-h1-highlight-fixed,


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1604

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add publish date to `TideSearchResultCard` by default where `field_news_date` exists
- Added sample fixture

### How to test
<!-- Summary of how to test  -->
- Cypress
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

