### PR TITLE
[R20-1644] added missing scroll wrapper for wysiwg tables

### DIFF
--- a/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
+++ b/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
@@ -19,7 +19,9 @@ const pluginTables = function (this: any) {
   // Wrap tables with a div.
   this.find('table').map((i: any, el: any) => {
     const $table = this.find(el)
-    return $table.wrap(`<div class="rpl-table"></div>`)
+    return $table
+      .wrap(`<div class="rpl-table"></div>`)
+      .wrap('<div class="rpl-table__scroll-container" tabindex="0"></div>')
   })
 }
 


### PR DESCRIPTION
Old
![Screenshot 2023-12-11 at 1 45 49 pm](https://github.com/dpc-sdp/ripple-framework/assets/5309152/14131477-3e35-473a-96da-dc5d8a31ff89)

New
![Screenshot 2023-12-11 at 1 45 56 pm](https://github.com/dpc-sdp/ripple-framework/assets/5309152/32f0db16-1a41-4ba9-b1ac-2a369c32dcc0)


<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1644

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

