### PR TITLE
Use single field for maps location data

### DIFF
--- a/examples/nuxt-app/app.config.ts
+++ b/examples/nuxt-app/app.config.ts
@@ -67,25 +67,6 @@ export default defineAppConfig({
               return '#333333'
           }
         }
-      },
-      mapResultsMappingFn: {
-        vsba: (result) => {
-          const hasLocation = get(result, props.mapConfig.props.latObjPath)
-          if (hasLocation && props.mapConfig && result._source) {
-            return {
-              ...result._source,
-              lat: parseFloat(get(result, props.mapConfig.props.latObjPath)),
-              lng: parseFloat(get(result, props.mapConfig.props.lngObjPath)),
-              id: result._id
-            }
-          } else {
-            return {
-              ...result._source,
-              isArea: true,
-              id: result._id
-            }
-          }
-        }
       }
     }
   }

--- a/examples/nuxt-app/test/fixtures/map-table/vsba/custom-collection-config.json
+++ b/examples/nuxt-app/test/fixtures/map-table/vsba/custom-collection-config.json
@@ -26,8 +26,7 @@
         }
       },
       "pinIconFn": "vsbaPinIcons",
-      "latObjPath": "_source.field_latitude[0]",
-      "lngObjPath": "_source.field_longitude[0]",
+      "locationObjPath": "_source.field_latitude_longitude_value[0]",
       "titleObjPath": "title[0]",
       "vectorLayerComponent": "VSBAProjectAreaLayer",
       "legendExpanded": true,

--- a/examples/nuxt-app/test/fixtures/map-table/vsba/page.json
+++ b/examples/nuxt-app/test/fixtures/map-table/vsba/page.json
@@ -201,8 +201,7 @@
               }
             },
             "pinIconFn": "vsbaPinIcons",
-            "latObjPath": "_source.field_latitude[0]",
-            "lngObjPath": "_source.field_longitude[0]",
+            "locationObjPath": "_source.field_latitude_longitude_value[0]",
             "titleObjPath": "title[0]",
             "vectorLayerComponent": "VSBAProjectAreaLayer",
             "legendItems": [

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -116,12 +116,13 @@ const searchResultsMappingFn = (item): TideSearchListingResultItem => {
 }
 
 const mapResultsMappingFn = (result) => {
-  const hasLocation = get(result, props.mapConfig.props.latObjPath)
-  if (hasLocation && props.mapConfig && result._source) {
+  const location = get(result, props.mapConfig.props.locationObjPath)
+  if (location && props.mapConfig && result._source) {
+    const locationLatLng = location.split(',')
     return {
       ...result._source,
-      lat: parseFloat(get(result, props.mapConfig.props.latObjPath)),
-      lng: parseFloat(get(result, props.mapConfig.props.lngObjPath)),
+      lat: parseFloat(locationLatLng[0]),
+      lng: parseFloat(locationLatLng[1]),
       id: result._id
     }
   } else {

--- a/packages/ripple-tide-search/components/global/TideSearchListingResultsMap.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchListingResultsMap.vue
@@ -82,8 +82,6 @@ interface Props {
       component?: string
     }
   }
-  latObjPath: string
-  lngObjPath: string
   titleObjPath: string
   results: TideSearchListingMapFeature[]
   vectorLayerComponent?: string
@@ -98,8 +96,6 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  latObjPath: '_source.lat[0]',
-  lngObjPath: '_source.lng[0]',
   titleObjPath: '_source.title[0]',
   vectorLayerComponent: undefined,
   pinIconFn: 'defaultPinStyleFn',


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Instead of using the seperate fields for lat and long, we use the single geo_point field. This is required to support vicpol map and should be the pattern going forward for all maps.
- 

### How to test
<!-- Summary of how to test  -->
- Need to update custom collection config in develop.content.vic for the school buildings test fixture. See https://github.com/dpc-sdp/ripple-framework/pull/965/files#diff-f32ccc387334966d5bdc68becc99b0ee9816feddecb6fda0d0520824a1fc8e0aL29 for example
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

