### PR TITLE
[R20-1665] update form submission events

### DIFF
--- a/packages/nuxt-ripple-analytics/lib/index.ts
+++ b/packages/nuxt-ripple-analytics/lib/index.ts
@@ -547,6 +547,32 @@ export default {
     }
   },
   // UI Forms components
+  'rpl-form/submit': () => {
+    return (payload: any) => {
+      trackEvent({
+        event: `form_${payload.action}`,
+        form_id: payload?.id,
+        form_name: payload?.name,
+        form_valid: true,
+        element_text: payload?.text,
+        component: 'rpl-form',
+        platform_event: 'submit'
+      })
+    }
+  },
+  'rpl-form/invalid': () => {
+    return (payload: any) => {
+      trackEvent({
+        event: `form_${payload.action}`,
+        form_id: payload?.id,
+        form_name: payload?.name,
+        form_valid: false,
+        element_text: payload?.text,
+        component: 'rpl-form',
+        platform_event: 'submit'
+      })
+    }
+  },
   'rpl-form/submitted': () => {
     return (payload: any) => {
       trackEvent({

--- a/packages/nuxt-ripple-analytics/lib/tracker.ts
+++ b/packages/nuxt-ripple-analytics/lib/tracker.ts
@@ -16,6 +16,7 @@ export interface IRplAnalyticsEventPayload {
   file_size?: string
   form_id?: string
   form_name?: string
+  form_valid?: boolean
   field_id?: string
   filters?: string
   type?: string


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1665

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Update form submission event, so instead of a single form submission event we now have two events (from the dataLayers point of view); form submit, for every time a submission attempt takes place and form complete that fires after a successfully submission.

### How to test
<!-- Summary of how to test  -->
- Submit a form with invalid/incomplete data, then again with valid/complete data and check the `window.dataLayer` variable in the console. REF: https://www.v2.reference.sdp.vic.gov.au/test-form

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [x] Any events are emitted on the event bus

