### PR TITLE
[R20-1692] fix(@dpc-sdp/ripple-tide-search): :bug: fix dropdown option sort order from taxonomy weight

### DIFF
--- a/packages/ripple-tide-search/mapping/utils/index.ts
+++ b/packages/ripple-tide-search/mapping/utils/index.ts
@@ -21,12 +21,12 @@ export const processConfig = async (config, tidePageApi) => {
         // sort taxonomy values by weight value to control order in dropdown
         const activeTaxonomies = taxonomyResults
           .filter((tax) => tax.status === true)
+          .sort((a, b) => a.weight - b.weight)
           .map((item) => ({
             id: item.drupal_internal__tid,
             label: item.name,
             value: item.name
           }))
-          .sort((a, b) => a.weight - b.weight)
 
         if (activeTaxonomies && activeTaxonomies.length > 0) {
           const test = {


### PR DESCRIPTION
resolves R20-1692

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- 
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

