### PR TITLE
[R20-1701] show deeply nested children in filters

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/filters.feature
+++ b/examples/nuxt-app/test/features/search-listing/filters.feature
@@ -196,8 +196,9 @@ Feature: Search listing - Filter
       | Birds   |
     When I click the search listing dropdown field labelled "Terms dependent child example"
     Then the selected dropdown field should have the items:
-      | Dogs |
-      | Cats |
+      | Dogs    |
+      | Cats    |
+      | Canines |
 
   @mockserver
   Example: Dependent filter - Child options should update on parent selection

--- a/examples/nuxt-app/test/fixtures/search-listing/dependent-filters/page.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/dependent-filters/page.json
@@ -161,6 +161,13 @@
               "label": "Cockatoo",
               "value": "Cockatoo",
               "parent": "3"
+            },
+            {
+              "id": "2",
+              "label": "Canines",
+              "value": "Canines",
+              "parent": "2",
+              "ancestor": "1"
             }
           ]
         }

--- a/packages/ripple-tide-search/components/global/TideSearchFilterDependent.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchFilterDependent.vue
@@ -32,7 +32,10 @@ const childOptions = computed(() => {
     (option) => option.value === selectedParent.value
   )
 
-  return props.options.filter((opt) => opt.parent === selectedOption?.id)
+  return props.options.filter(
+    (opt) =>
+      opt.parent === selectedOption?.id || opt.ancestor === selectedOption?.id
+  )
 })
 
 const handleSelect = (value: string) => {

--- a/packages/ripple-tide-search/composables/useTideSearch.ts
+++ b/packages/ripple-tide-search/composables/useTideSearch.ts
@@ -290,7 +290,9 @@ export default ({
                 [itm?.filter?.value]: itm.props.options
                   ?.filter(
                     (option) =>
-                      option.parent === parentID || option.id === parentID
+                      option.parent === parentID ||
+                      option.ancestor === parentID ||
+                      option.id === parentID
                   )
                   .map((i) => i.value)
               }

--- a/packages/ripple-tide-search/mapping/utils/index.ts
+++ b/packages/ripple-tide-search/mapping/utils/index.ts
@@ -1,3 +1,5 @@
+import { getTermAncestor, getTermMap } from './term-ancestor'
+
 export const getSearchListingConfig = (src) =>
   src.hasOwnProperty('field_search_configuration') &&
   JSON.parse(src.field_search_configuration)
@@ -17,6 +19,7 @@ export const processConfig = async (config, tidePageApi) => {
         const taxonomyResults = await tidePageApi.getTaxonomy(
           uiFilter.aggregations?.field
         )
+        const termMap = getTermMap(taxonomyResults)
         // Taxonomies can be disabled, only return active ones
         // sort taxonomy values by weight value to control order in dropdown
         const activeTaxonomies = taxonomyResults
@@ -26,7 +29,8 @@ export const processConfig = async (config, tidePageApi) => {
             id: item.drupal_internal__tid,
             label: item.name,
             value: item.name,
-            parent: item?.parent?.[0]?.meta.drupal_internal__target_id || null
+            parent: item?.parent?.[0]?.meta.drupal_internal__target_id || null,
+            ancestor: getTermAncestor(termMap, item)
           }))
 
         if (activeTaxonomies && activeTaxonomies.length > 0) {

--- a/packages/ripple-tide-search/mapping/utils/term-ancestor.test.ts
+++ b/packages/ripple-tide-search/mapping/utils/term-ancestor.test.ts
@@ -1,0 +1,83 @@
+import { expect, describe, it } from '@jest/globals'
+import { getTermAncestor, getTermMap } from './term-ancestor'
+import { termSample } from './term-sample'
+
+const result = [
+  {
+    id: 1,
+    ancestor: 8995
+  },
+  {
+    id: 2,
+    ancestor: 8995
+  },
+  {
+    id: 8994,
+    ancestor: 8995
+  },
+  {
+    id: 9128,
+    ancestor: 9127
+  },
+  {
+    id: 9130,
+    ancestor: 9127
+  },
+  {
+    id: 9131,
+    ancestor: 9126
+  },
+  {
+    id: 9135,
+    ancestor: 9126
+  },
+  {
+    id: 8996,
+    ancestor: 8995
+  },
+  {
+    id: 9129,
+    ancestor: 9127
+  },
+  {
+    id: 9133,
+    ancestor: 9126
+  },
+  {
+    id: 9134,
+    ancestor: 9126
+  },
+  {
+    id: 3,
+    ancestor: 8995
+  },
+  {
+    id: 9132,
+    ancestor: 9126
+  },
+  {
+    id: 9127,
+    ancestor: null
+  },
+  {
+    id: 9126,
+    ancestor: null
+  },
+  {
+    id: 8995,
+    ancestor: null
+  }
+]
+
+describe('getTermAncestor', () => {
+  it('gets a terms top level ancestor', () => {
+    const termMap = getTermMap(termSample)
+
+    const output = termSample.map((item) => ({
+      id: item?.drupal_internal__tid,
+      ancestor: getTermAncestor(termMap, item)
+    }))
+
+    expect(output).toEqual(result)
+  })
+})

--- a/packages/ripple-tide-search/mapping/utils/term-ancestor.ts
+++ b/packages/ripple-tide-search/mapping/utils/term-ancestor.ts
@@ -1,0 +1,22 @@
+/**
+ * Creates a convenience map of terms.
+ */
+export const getTermMap = (taxonomy) => {
+  return taxonomy.reduce((acc, curr) => {
+    acc[curr.drupal_internal__tid] = curr
+    return acc
+  }, {})
+}
+
+/**
+ * Recursively walks through a taxonomy to get a terms ancestry.
+ */
+export const getTermAncestor = (items, item, prev = null) => {
+  let ancestor = item?.parent?.[0]?.meta.drupal_internal__target_id
+
+  if (!ancestor || !items?.[ancestor]) {
+    return prev
+  }
+
+  return getTermAncestor(items, items[ancestor], ancestor)
+}

--- a/packages/ripple-tide-search/mapping/utils/term-sample.ts
+++ b/packages/ripple-tide-search/mapping/utils/term-sample.ts
@@ -1,0 +1,1128 @@
+export const termSample = [
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/d8c4e09e-675b-47f5-be72-fd9b80eb325f?resourceVersion=id%3A1'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 1,
+    drupal_internal__revision_id: 1,
+    langcode: 'en',
+    revision_created: '2022-07-25T09:05:31+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Topic d',
+    description: null,
+    weight: 0,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content: 'Topic d | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/topic-d'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/topic-d',
+      pid: 34,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '387a02bd-6d4b-4411-afdc-c2cfda53e101',
+        meta: {
+          drupal_internal__target_id: 8994
+        }
+      }
+    ],
+    id: 'd8c4e09e-675b-47f5-be72-fd9b80eb325f',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/8291bb69-e4dd-4ceb-8209-0cffc4dff865?resourceVersion=id%3A2'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 2,
+    drupal_internal__revision_id: 2,
+    langcode: 'en',
+    revision_created: '2022-07-25T09:05:31+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Topic e',
+    description: null,
+    weight: 0,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content: 'Topic e | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/topic-e'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/topic-e',
+      pid: 35,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: 'd8c4e09e-675b-47f5-be72-fd9b80eb325f',
+        meta: {
+          drupal_internal__target_id: 1
+        }
+      }
+    ],
+    id: '8291bb69-e4dd-4ceb-8209-0cffc4dff865',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/387a02bd-6d4b-4411-afdc-c2cfda53e101?resourceVersion=id%3A133'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 8994,
+    drupal_internal__revision_id: 133,
+    langcode: 'en',
+    revision_created: '2023-05-29T03:51:37+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Topic b',
+    description: {
+      value:
+        '<table>\r\n\t<tbody>\r\n\t\t<tr>\r\n\t\t\t<td><span><span><span><span><span><span>Arachnid</span></span></span></span></span></span></td>\r\n\t\t</tr>\r\n\t</tbody>\r\n</table>\r\n',
+      format: 'rich_text',
+      processed:
+        '<table><tbody><tr><td><span><span><span><span><span><span>Arachnid</span></span></span></span></span></span></td>\n\t\t</tr></tbody></table>'
+    },
+    weight: 0,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content: 'Topic b | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'description',
+          content: 'Arachnid'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/topic-b'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/topic-b',
+      pid: 668,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '8ffd097d-686d-430b-b0d7-e7ea6ecf3185',
+        meta: {
+          drupal_internal__target_id: 8995
+        }
+      }
+    ],
+    id: '387a02bd-6d4b-4411-afdc-c2cfda53e101',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000022?resourceVersion=id%3A267'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9128,
+    drupal_internal__revision_id: 267,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Content Collection Topic 1',
+    description: null,
+    weight: 0,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Content Collection Topic 1 | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/content-collection-topic-1'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/content-collection-topic-1',
+      pid: 937,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '11dede11-10c0-111e1-1102-000000000024',
+        meta: {
+          drupal_internal__target_id: 9130
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000022',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000024?resourceVersion=id%3A269'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9130,
+    drupal_internal__revision_id: 269,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Content Collection Empty Topic',
+    description: null,
+    weight: 0,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Content Collection Empty Topic | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/content-collection-empty-topic'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/content-collection-empty-topic',
+      pid: 939,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '11dede11-10c0-111e1-1102-000000000021',
+        meta: {
+          drupal_internal__target_id: 9127
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000024',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000025?resourceVersion=id%3A270'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9131,
+    drupal_internal__revision_id: 270,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Flinders topic demo',
+    description: null,
+    weight: 0,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Flinders topic demo | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/flinders-topic-demo'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/flinders-topic-demo',
+      pid: 940,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '11dede11-10c0-111e1-1102-000000000020',
+        meta: {
+          drupal_internal__target_id: 9126
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000025',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000029?resourceVersion=id%3A274'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9135,
+    drupal_internal__revision_id: 274,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Collins topic demo',
+    description: null,
+    weight: 0,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Collins topic demo | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/collins-topic-demo'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/collins-topic-demo',
+      pid: 944,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '11dede11-10c0-111e1-1102-000000000027',
+        meta: {
+          drupal_internal__target_id: 9133
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000029',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/d6edb3df-e898-4b9b-9b74-8795946f0d43?resourceVersion=id%3A135'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 8996,
+    drupal_internal__revision_id: 135,
+    langcode: 'en',
+    revision_created: '2023-05-29T03:52:04+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Topic c',
+    description: {
+      value:
+        '<table>\r\n\t<tbody>\r\n\t\t<tr>\r\n\t\t\t<td class="xl65"><span><span><span><span><span><span>Addax</span></span></span></span></span></span></td>\r\n\t\t</tr>\r\n\t</tbody>\r\n</table>\r\n',
+      format: 'rich_text',
+      processed:
+        '<table><tbody><tr><td class="xl65"><span><span><span><span><span><span>Addax</span></span></span></span></span></span></td>\n\t\t</tr></tbody></table>'
+    },
+    weight: 1,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content: 'Topic c | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'description',
+          content: 'Addax'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/topic-c'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/topic-c',
+      pid: 670,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '8ffd097d-686d-430b-b0d7-e7ea6ecf3185',
+        meta: {
+          drupal_internal__target_id: 8995
+        }
+      }
+    ],
+    id: 'd6edb3df-e898-4b9b-9b74-8795946f0d43',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000023?resourceVersion=id%3A268'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9129,
+    drupal_internal__revision_id: 268,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Content Collection Topic 2',
+    description: null,
+    weight: 1,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Content Collection Topic 2 | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/content-collection-topic-2'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/content-collection-topic-2',
+      pid: 938,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '11dede11-10c0-111e1-1102-000000000024',
+        meta: {
+          drupal_internal__target_id: 9130
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000023',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000027?resourceVersion=id%3A272'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9133,
+    drupal_internal__revision_id: 272,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'King topic demo',
+    description: null,
+    weight: 1,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'King topic demo | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/king-topic-demo'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/king-topic-demo',
+      pid: 942,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '11dede11-10c0-111e1-1102-000000000020',
+        meta: {
+          drupal_internal__target_id: 9126
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000027',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000028?resourceVersion=id%3A273'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9134,
+    drupal_internal__revision_id: 273,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Bourke topic demo',
+    description: null,
+    weight: 1,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Bourke topic demo | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/bourke-topic-demo'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/bourke-topic-demo',
+      pid: 943,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '11dede11-10c0-111e1-1102-000000000027',
+        meta: {
+          drupal_internal__target_id: 9133
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000028',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/54784f6b-809b-49b4-a749-606cf5fb9901?resourceVersion=id%3A3'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 3,
+    drupal_internal__revision_id: 3,
+    langcode: 'en',
+    revision_created: '2022-07-25T09:05:31+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Topic f',
+    description: null,
+    weight: 2,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content: 'Topic f | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/topic-f'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/topic-f',
+      pid: 36,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '8ffd097d-686d-430b-b0d7-e7ea6ecf3185',
+        meta: {
+          drupal_internal__target_id: 8995
+        }
+      }
+    ],
+    id: '54784f6b-809b-49b4-a749-606cf5fb9901',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000026?resourceVersion=id%3A271'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9132,
+    drupal_internal__revision_id: 271,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Spencer topic demo',
+    description: null,
+    weight: 2,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Spencer topic demo | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/spencer-topic-demo'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/spencer-topic-demo',
+      pid: 941,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: '11dede11-10c0-111e1-1102-000000000020',
+        meta: {
+          drupal_internal__target_id: 9126
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000026',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000021?resourceVersion=id%3A266'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9127,
+    drupal_internal__revision_id: 266,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Another Demo Topic',
+    description: null,
+    weight: 13,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Another Demo Topic | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/another-demo-topic'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/another-demo-topic',
+      pid: 936,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: 'virtual',
+        meta: {
+          links: {
+            help: {
+              href: 'https://www.drupal.org/docs/8/modules/json-api/core-concepts#virtual',
+              meta: {
+                about: "Usage and meaning of the 'virtual' resource identifier."
+              }
+            }
+          }
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000021',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/11dede11-10c0-111e1-1102-000000000020?resourceVersion=id%3A265'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 9126,
+    drupal_internal__revision_id: 265,
+    langcode: 'en',
+    revision_created: '2024-01-15T21:52:03+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Demo Topic',
+    description: null,
+    weight: 14,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content:
+            'Demo Topic | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/demo-topic'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/demo-topic',
+      pid: 935,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: 'virtual',
+        meta: {
+          links: {
+            help: {
+              href: 'https://www.drupal.org/docs/8/modules/json-api/core-concepts#virtual',
+              meta: {
+                about: "Usage and meaning of the 'virtual' resource identifier."
+              }
+            }
+          }
+        }
+      }
+    ],
+    id: '11dede11-10c0-111e1-1102-000000000020',
+    type: 'taxonomy_term--topic'
+  },
+  {
+    links: {
+      self: {
+        href: 'https://develop.content.reference.sdp.vic.gov.au/api/v1/taxonomy_term/topic/8ffd097d-686d-430b-b0d7-e7ea6ecf3185?resourceVersion=id%3A134'
+      }
+    },
+    meta: {},
+    drupal_internal__tid: 8995,
+    drupal_internal__revision_id: 134,
+    langcode: 'en',
+    revision_created: '2023-05-29T03:51:51+00:00',
+    revision_log_message: null,
+    status: true,
+    name: 'Topic a',
+    description: {
+      value:
+        '<table>\r\n\t<tbody>\r\n\t\t<tr>\r\n\t\t\t<td class="xl65"><span><span><span><span><span><span><span><span><span><span>Achrioptera Manga</span></span></span></span></span></span></span></span></span></span></td>\r\n\t\t</tr>\r\n\t</tbody>\r\n</table>\r\n',
+      format: 'rich_text',
+      processed:
+        '<table><tbody><tr><td class="xl65"><span><span><span><span><span><span><span><span><span><span>Achrioptera Manga</span></span></span></span></span></span></span></span></span></span></td>\n\t\t</tr></tbody></table>'
+    },
+    weight: 15,
+    changed: '2024-01-15T22:24:59+00:00',
+    default_langcode: true,
+    revision_translation_affected: true,
+    metatag: [
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'title',
+          content: 'Topic a | Single Digital Presence Content Management System'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          name: 'description',
+          content: 'Achrioptera Manga'
+        }
+      },
+      {
+        tag: 'link',
+        attributes: {
+          rel: 'canonical',
+          href: 'https://develop.content.reference.sdp.vic.gov.au/topic/topic'
+        }
+      },
+      {
+        tag: 'meta',
+        attributes: {
+          property: 'og:locale',
+          content: 'en-AU'
+        }
+      }
+    ],
+    path: {
+      alias: '/topic/topic',
+      pid: 669,
+      langcode: 'en'
+    },
+    vid: {
+      type: 'taxonomy_vocabulary--taxonomy_vocabulary',
+      id: '4b949eaa-401e-48a0-802f-da2496743e6d',
+      meta: {
+        drupal_internal__target_id: 'topic'
+      }
+    },
+    parent: [
+      {
+        type: 'taxonomy_term--topic',
+        id: 'virtual',
+        meta: {
+          links: {
+            help: {
+              href: 'https://www.drupal.org/docs/8/modules/json-api/core-concepts#virtual',
+              meta: {
+                about: "Usage and meaning of the 'virtual' resource identifier."
+              }
+            }
+          }
+        }
+      }
+    ],
+    id: '8ffd097d-686d-430b-b0d7-e7ea6ecf3185',
+    type: 'taxonomy_term--topic'
+  }
+]


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1701

### What I did
<!-- Summary of changes made in the Pull Request  -->
- This will show nested children within the child dropdown for the dependent filter, i.e. if someone accidentally drags an option too deep it can still be displayed and used on the frontend.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

