### PR TITLE
fix(nuxt-ripple): :bug: filter incomplete related links

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/sidebar.feature
+++ b/examples/nuxt-app/test/features/landingpage/sidebar.feature
@@ -14,8 +14,6 @@ Feature: Sidebar
     Then the sidebar component with ID "tide-sidebar-social-share" should exist
     Then the sidebar component with ID "tide-sidebar-related-links" should exist
 
-  This specific scenario tests the filter on incomplete related links
-
   @mockserver
   Scenario: Sidebar components
     When I visit the page "/sub2"

--- a/examples/nuxt-app/test/features/landingpage/sidebar.feature
+++ b/examples/nuxt-app/test/features/landingpage/sidebar.feature
@@ -1,13 +1,22 @@
 Feature: Sidebar
 
-  Example of mocked page
+  Example of mocked page sidebar
+
   Background:
     Given the page endpoint for path "/sub" returns fixture "/landingpage/sub" with status 200
+    And the page endpoint for path "/sub2" returns fixture "/landingpage/sub-faulty" with status 200
     And the site endpoint returns fixture "/site/reference" with status 200
-    Given I visit the page "/sub"
 
   @mockserver
   Scenario: Sidebar components
+    When I visit the page "/sub"
     Then the sidebar component with ID "26146cba-f307-449e-885c-7446efb3f315" should exist
     Then the sidebar component with ID "tide-sidebar-social-share" should exist
     Then the sidebar component with ID "tide-sidebar-related-links" should exist
+
+  This specific scenario tests the filter on incomplete related links
+
+  @mockserver
+  Scenario: Sidebar components
+    When I visit the page "/sub2"
+    Then the sidebar component with ID "tide-sidebar-related-links" should not exist

--- a/examples/nuxt-app/test/fixtures/landingpage/sub-faulty.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/sub-faulty.json
@@ -1,0 +1,292 @@
+{
+  "title": "Demo Landing Subpage (faulty related links example)",
+  "changed": "2022-11-02T12:47:29+11:00",
+  "created": "2022-11-02T12:47:29+11:00",
+  "type": "landing_page",
+  "nid": "11dede11-10c0-111e1-1100-000000000330",
+  "showTopicTags": true,
+  "topicTags": [
+    {
+      "text": "Demo Topic",
+      "url": "/topic/demo-topic"
+    },
+    {
+      "text": "Demo Tag",
+      "url": "/tags/demo-tag"
+    }
+  ],
+  "sidebar": {
+    "contacts": [
+      {
+        "id": "26146cba-f307-449e-885c-7446efb3f315",
+        "contactTitle": "Victorian Government",
+        "contactName": "Victorian Government",
+        "department": "Department of Premier and Cabinet",
+        "email": "no-reply@vic.gov.au",
+        "locationAddress": {
+          "countryCode": "AU",
+          "administrativeArea": "VIC",
+          "locality": "Melbourne",
+          "postalCode": "3001",
+          "addressLine1": "Department of Premier and Cabinet",
+          "addressLine2": "GPO Box 4509"
+        },
+        "postalAddress": {
+          "countryCode": "AU",
+          "administrativeArea": "VIC",
+          "locality": "Melbourne",
+          "postalCode": "3001",
+          "addressLine1": "Department of Premier and Cabinet",
+          "addressLine2": "GPO Box 4509"
+        },
+        "phones": [
+          {
+            "id": "8a6d0e28-3d34-40b7-a97b-ef980f0f6f49",
+            "title": "Calls in Australia",
+            "number": "1300 366 356"
+          },
+          {
+            "id": "798566cf-2e8c-48eb-bc89-38a6486cb06a",
+            "title": "Calls from overseas",
+            "number": "+61 3 9603 8804"
+          }
+        ],
+        "socialMedia": [
+          {
+            "id": "0b58c974-05bd-4379-8947-12c4959b992c",
+            "type": "twitter",
+            "text": "Twitter",
+            "url": "https://twitter.com/VicGovAu"
+          },
+          {
+            "id": "0b58c974-05bd-4379-8947-12c4959b992d",
+            "type": "instagram",
+            "text": "Instagram",
+            "url": "https://i"
+          },
+          {
+            "id": "0b58c974-05bd-4379-8947-12c4959b992e",
+            "type": "website",
+            "text": "Some website",
+            "url": "https://w"
+          }
+        ]
+      }
+    ],
+    "relatedLinks": [
+      {
+        "id": "33133902-1f57-4283-9f6b-48dd76297c69"
+      }
+    ],
+    "socialShareNetworks": ["Facebook", "Twitter", "LinkedIn"],
+    "siteSectionNav": {
+      "title": "Site-section Navigation",
+      "items": [
+        {
+          "text": "Demo Landing Page",
+          "url": "route:entity.node.canonical;node=65",
+          "id": "683e718c-f024-41f5-aea3-3036155ef4c8",
+          "parent": null,
+          "weight": 0
+        }
+      ]
+    }
+  },
+  "summary": "Page summary",
+  "showHeroAcknowledgement": false,
+  "showInPageNav": true,
+  "inPageNavHeadingLevel": "h3",
+  "background": "default",
+  "header": {
+    "title": "Demo Landing Subpage",
+    "summary": "Page summary",
+    "cta": {
+      "text": "Test CTA text",
+      "url": "/demo-cta-destination"
+    }
+  },
+  "bodyComponents": [
+    {
+      "uuid": "a99aa287-7fac-430b-864e-3a1b044460b1",
+      "component": "TideLandingPageContent",
+      "id": "969",
+      "internalAnchors": [
+        {
+          "text": "Content Anchor 1",
+          "id": "content-anchor-1",
+          "type": "h2"
+        },
+        {
+          "text": "Content Anchor 2",
+          "id": "content-anchor-2",
+          "type": "h3"
+        }
+      ],
+      "props": {
+        "html": "<p>Here is <em>some</em> sample <strong>rich</strong> text content</p>"
+      }
+    },
+    {
+      "uuid": "c83c8494-1cb9-429c-af8f-9a4fa3a1fc94",
+      "component": "TideLandingPageTimeline",
+      "id": "992",
+      "title": "Test timeline title",
+      "props": {
+        "items": [
+          {
+            "id": "989",
+            "title": "Milestone 1 title",
+            "subtitle": "Milestone 1 text",
+            "url": "/test-destination-1",
+            "description": "<p>Milestone 1 <strong>summary</strong> <em>field</em></p>",
+            "image": {
+              "src": "https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/VicFleet-Police-car-on-road.jpg"
+            },
+            "current": false,
+            "dateStart": "2022-06-02T04:53:53+10:00",
+            "dateEnd": "2022-11-11T21:58:55+11:00"
+          },
+          {
+            "id": "990",
+            "title": "Milestone 2 title",
+            "subtitle": "Milestone 1 text",
+            "url": "/test-destination-2",
+            "description": "<p>Milestone 2 <strong>summary</strong> <em>field</em></p>",
+            "image": null,
+            "current": true,
+            "dateStart": "2022-10-04T04:54:11+11:00",
+            "dateEnd": "2022-11-17T16:59:14+11:00"
+          },
+          {
+            "id": "991",
+            "title": "Milestone 3 title",
+            "subtitle": "Milestone 3 text",
+            "url": "",
+            "description": "",
+            "image": null,
+            "current": false,
+            "dateStart": null,
+            "dateEnd": null
+          }
+        ]
+      }
+    },
+    {
+      "uuid": "96d21d9a-f5c2-4ae5-8b0f-54664945bcf9",
+      "component": "TideLandingPageStatsGrid",
+      "id": "1028",
+      "props": {
+        "variant": "onLight",
+        "items": [
+          {
+            "id": "1026",
+            "label": "Label 1",
+            "value": "Value 1"
+          },
+          {
+            "id": "1027",
+            "label": "Label 2",
+            "value": "Value 2"
+          }
+        ]
+      }
+    },
+    {
+      "component": "TideLandingPageDataTable",
+      "id": "1936",
+      "props": {
+        "caption": "",
+        "headingType": {
+          "horizontal": true,
+          "vertical": false
+        },
+        "orientation": "row",
+        "columns": [
+          "Row One Column One",
+          "Row One Column Two",
+          "Row One Column Three"
+        ],
+        "items": [
+          ["Row Two Column One", "Row Two Column Two", "Row Two Column Three"],
+          [
+            "Row Three Column One",
+            "Row Three Column Two",
+            "Row Three Column Three"
+          ]
+        ]
+      }
+    },
+    {
+      "component": "TideLandingPageCategoryGrid",
+      "id": "7052",
+      "title": "Category Grid",
+      "props": {
+        "items": [
+          {
+            "title": "Card one",
+            "summary": "Card one summary",
+            "image": {
+              "src": "https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/Aerial-shot-of-new-housing-development.jpg",
+              "alt": "",
+              "focalPoint": null,
+              "height": 667,
+              "title": "",
+              "width": 1000
+            },
+            "url": "/landing-page-cc-2"
+          },
+          {
+            "title": "Card two",
+            "summary": "Card two summary",
+            "image": {
+              "src": "https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/2018-19-State-Budget.jpg",
+              "alt": "",
+              "focalPoint": null,
+              "height": 667,
+              "title": "",
+              "width": 1000
+            },
+            "url": "https://google.com/"
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "url": "/demo-landing-page",
+    "langcode": "en",
+    "description": "Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae",
+    "additional": [
+      {
+        "tag": "link",
+        "attributes": {
+          "rel": "canonical",
+          "href": "https://develop.content.reference.sdp.vic.gov.au/demo-landing-page"
+        }
+      },
+      {
+        "tag": "meta",
+        "attributes": {
+          "name": "title",
+          "content": "Demo Landing Page | Single Digital Presence Content Management System"
+        }
+      },
+      {
+        "tag": "meta",
+        "attributes": {
+          "property": "og:image",
+          "content": "https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/Melbourne-tram.jpg"
+        }
+      }
+    ],
+    "keywords": "",
+    "image": {
+      "src": "https://develop.content.reference.sdp.vic.gov.au/sites/default/files/tide_demo_content/Melbourne-tram.jpg",
+      "alt": "Demo: Melbourne tram",
+      "title": "Demo: Melbourne tram",
+      "width": 1413,
+      "height": 785,
+      "drupal_internal__target_id": 46
+    }
+  }
+}

--- a/packages/nuxt-ripple/components/TideSidebarRelatedLinks.vue
+++ b/packages/nuxt-ripple/components/TideSidebarRelatedLinks.vue
@@ -1,13 +1,14 @@
 <template>
   <RplSidebarComponent
-    v-if="items && items.length"
+    v-if="items && filteredItems.length"
     data-sidebar-component-id="tide-sidebar-related-links"
   >
-    <RplRelatedLinks :title="title" :items="items" />
+    <RplRelatedLinks :title="title" :items="filteredItems" />
   </RplSidebarComponent>
 </template>
 
 <script setup lang="ts">
+import { computed } from '#imports'
 import { TideLink } from '../../../../types'
 
 interface Props {
@@ -15,7 +16,9 @@ interface Props {
   items: TideLink[]
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   items: () => []
 })
+
+const filteredItems = computed(() => props.items.filter((i) => i.text && i.url))
 </script>

--- a/packages/ripple-test-utils/step_definitions/content-types/landing-page.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/landing-page.ts
@@ -11,6 +11,14 @@ Then('the landing page component {string} should exist', (type: string) => {
 Then('the sidebar component with ID {string} should exist', (id: string) => {
   cy.get(`[data-sidebar-component-id="${id}"]`).should('exist')
 })
+
+Then(
+  'the sidebar component with ID {string} should not exist',
+  (id: string) => {
+    cy.get(`[data-sidebar-component-id="${id}"]`).should('not.exist')
+  }
+)
+
 Then('the hero title should be {string}', (title: string) => {
   cy.get('[data-cy="hero-title"]').should('have.text', title)
 })


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- The BE can sometimes return related links that have no title or URL, these should be filtered out to prevent the component render and associated "Related links" heading
- e.g. this is from a vicpol news page: 

![Screenshot 2024-01-18 at 12 05 26 pm](https://github.com/dpc-sdp/ripple-framework/assets/863542/9904a180-b6f0-4c31-9746-c79fad4039de)

Appears on page like this:
![Screenshot 2024-01-18 at 12 06 38 pm](https://github.com/dpc-sdp/ripple-framework/assets/863542/4483293b-56f2-4ab5-9131-e0bdae8e0524)


### How to test
<!-- Summary of how to test  -->
- Cypress test added with faulty fixture
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

