### PR TITLE
fix(@dpc-sdp/ripple-ui-core): fix svg sprite breaking in svgo 3.2.0

### DIFF
--- a/packages/ripple-ui-core/src/vite.plugins.ts
+++ b/packages/ripple-ui-core/src/vite.plugins.ts
@@ -9,7 +9,9 @@ export default [
         {
           name: 'preset-default',
           params: {
-            overrides: {}
+            overrides: {
+              removeHiddenElems: false
+            }
           }
         },
         {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Looks like an update to SVGO https://github.com/svg/svgo/pull/1879 has fixed a long standing issue where unused defs weren't removed properly. This just means in SVG0 `3.2.0` our sprint sheet gets  wiped and all `<defs>` in the file removed.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

