### PR TITLE
[R20-1699] make tables full width

### DIFF
--- a/packages/ripple-ui-core/src/styles/components/_table.css
+++ b/packages/ripple-ui-core/src/styles/components/_table.css
@@ -25,6 +25,7 @@
   }
 
   table {
+    width: 100%;
     border-collapse: collapse;
 
     &,


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1699

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Make tables full width; the ticket mentions removing the background from the table but that impacts our JS-less scroll indicators. Making the table full width resolves the tickets issue and arguably looks better.

<img width="1387" alt="Screenshot 2024-01-29 at 9 23 49 am" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/d1c08463-0c04-44b7-97ab-b39333ad5a07">


### How to test
<!-- Summary of how to test  -->
- See storybook

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

