### PR TITLE
[R20-1546] update promo card content margin

### DIFF
--- a/packages/ripple-ui-core/src/components/card/RplCard.css
+++ b/packages/ripple-ui-core/src/components/card/RplCard.css
@@ -303,3 +303,8 @@
     flex-grow: 1;
   }
 }
+
+.rpl-card--promo .rpl-card__content {
+  margin-top: var(--rpl-sp-3);
+}
+


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1546

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Update promo card content margin as per feedback: "Spacing should be consistent across all promo cards across all breakpoints. Token that should be used is rpl-sp-3 (12px) promo cards ONLY"


### How to test
<!-- Summary of how to test  -->
- See storybook

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

