### PR TITLE
[R20-1719]: stop search firing when clearing filters without change

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/filters.feature
+++ b/examples/nuxt-app/test/features/search-listing/filters.feature
@@ -141,7 +141,7 @@ Feature: Search listing - Filter
     When I clear the search filters
 
     And the search network request should be called with the "/search-listing/filters/request-clear-empty" fixture
-    Then the URL should reflect that the current page number is 1
+    Then the URL should reflect that the current page has been reset
     Then the URL should reflect that the current search term is ""
     Then the URL should reflect that the current active filters are as follows:
       | id             |

--- a/examples/nuxt-app/test/features/search-listing/pagination.feature
+++ b/examples/nuxt-app/test/features/search-listing/pagination.feature
@@ -83,7 +83,7 @@ Feature: Searching listing - Pagination
     When I click the search button
     Given I wait 1 seconds
     Then the search network request should be called with the "/search-listing/pagination/request-page-1-with-term" fixture
-    And the URL should reflect that the current page number is 1
+    And the URL should reflect that the current page has been reset
     And the results counter should show 1 to 4 of 10 results
     And the search listing results should have following items:
       | title   |

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -36,6 +36,13 @@ Then(
   }
 )
 
+Then('the URL should reflect that the current page has been reset', () => {
+  cy.location().should((loc) => {
+    const params = new URLSearchParams(loc.search)
+    expect(params.get('page')).to.eq(null)
+  })
+})
+
 Then(
   'the URL should reflect that the current sort option is {string}',
   (sortId: string) => {

--- a/packages/ripple-tide-search/composables/useTideSearch.ts
+++ b/packages/ripple-tide-search/composables/useTideSearch.ts
@@ -78,9 +78,8 @@ export default ({
     return JSON.parse(JSON.stringify(obj).replace(re, escapedValue))
   }
 
-  const activeTab: TideSearchListingTabKey = ref(
-    searchListingConfig?.displayMapTab ? 'map' : null
-  )
+  const initialTab = searchListingConfig?.displayMapTab ? 'map' : null
+  const activeTab: TideSearchListingTabKey = ref(initialTab)
 
   const isBusy = ref(true)
   const searchError = ref(null)
@@ -564,9 +563,8 @@ export default ({
     await navigateTo({
       path: route.path,
       query: {
-        page: 1,
         q: searchTerm.value || undefined,
-        activeTab: activeTab.value,
+        activeTab: activeTab.value !== initialTab ? activeTab.value : undefined,
         ...locationParams,
         ...filterFormValues
       }
@@ -581,7 +579,7 @@ export default ({
       ...route,
       query: {
         ...route.query,
-        page: newPage
+        page: newPage > 1 ? newPage : undefined
       }
     })
   }
@@ -602,7 +600,7 @@ export default ({
       ...route,
       query: {
         ...route.query,
-        activeTab: newActiveTab
+        activeTab: newActiveTab !== initialTab ? newActiveTab : undefined
       }
     })
   }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1719

### What I did
<!-- Summary of changes made in the Pull Request  -->
- This update stops a search taking place even when the filters haven't changed 
- This also means we're resetting filters back to the initial URL now (i.e. no query params)

### How to test
<!-- Summary of how to test  -->
- Go to any current search listing (https://www.vic.gov.au/family-violence-recommendations/) and click clear filters, this fires off a search even though nothing has changed (from a users point of view). Contrast that to this PR and you should see the same action won't trigger an unneeded search.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

