### PR TITLE
[R20-1742] add support for content 'before' results

### DIFF
--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -21,6 +21,7 @@ import type { rplEventPayload } from '@dpc-sdp/ripple-ui-core'
 import { watch } from 'vue'
 
 interface TideContentPage extends TidePageBase {
+  beforeResults: string
   afterResults: string
   secondaryCampaign: ITideSecondaryCampaign
 }
@@ -383,6 +384,11 @@ watch(
       </RplHeroHeader>
     </template>
     <template #body>
+      <RplContent
+        v-if="contentPage.beforeResults"
+        class="tide-content-before-results"
+        :html="contentPage.beforeResults"
+      />
       <TideSearchAboveResults
         v-if="results?.length || (sortOptions && sortOptions.length)"
       >

--- a/packages/ripple-tide-search/mapping/index.ts
+++ b/packages/ripple-tide-search/mapping/index.ts
@@ -148,6 +148,8 @@ const tideCollectionModule: IRplTideModuleMapping = {
       withSidebarSocialShare: false
     }),
     summary: 'field_landing_page_summary',
+    beforeResults: (src: string) =>
+      getBodyFromField(src, 'field_above_results_content'),
     afterResults: (src: string) =>
       getBodyFromField(src, 'field_below_results_content'),
     introText: 'field_landing_page_intro_text',


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1742

### What I did
<!-- Summary of changes made in the Pull Request  -->
- add support for displaying content 'before' results (exactly the same as the afterResults section)

NOTE: this is a a draft for now, just waiting on the BE to give the A OK on the field name: `field_above_results_content`, ref: https://digital-vic.atlassian.net/browse/R20-1742?focusedCommentId=320770

<img width="1167" alt="Screenshot 2024-01-29 at 3 28 49 pm" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/c10852f2-6af4-4720-bfcc-b2ba07794553">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

