### PR TITLE
[R20-1699] remove unused vars and padding from data table

### DIFF
--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.css
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.css
@@ -73,10 +73,6 @@
 
   --local-table-row-background: rgb(0 0 0 / 4%);
 
-  background-color: var(--rpl-data-table-bg-clr);
-  color: var(--rpl-data-table-clr);
-  padding: var(--rpl-sp-2);
-
   .rpl-data-table__details {
     display: none;
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1699

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Remove unused vars and padding from data table

The main RplTable background was being set to nothing for data tables, @waitingallday do you happen to remember what these lines were for? https://github.com/dpc-sdp/ripple-framework/pull/382/files#diff-cf57cdb1728ef5fce7d68c7a7403c06915828b7e023defdfa2500efda55bc23dR70

<img width="1266" alt="Screenshot 2024-01-30 at 9 29 57 am" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/25822551-6d66-4cd7-8658-9d47d29af6c6">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

