### PR TITLE
feat(@dpc-sdp/ripple-ui-core): allow props to be passed to the main extraContent component

### DIFF
--- a/examples/nuxt-app/components/global/TableExtraContentComponentExample.vue
+++ b/examples/nuxt-app/components/global/TableExtraContentComponentExample.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="tide-extra-component-example">
+    <strong>{{ label }}: </strong>
     <RplTag
       v-if="item?.field_fv_recommendation_number"
       :label="item.field_fv_recommendation_number[0]"
@@ -13,6 +14,7 @@
 <script setup lang="ts">
 interface Props {
   item: any
+  label: string
 }
 
 defineProps<Props>()

--- a/examples/nuxt-app/test/features/search-listing/table.feature
+++ b/examples/nuxt-app/test/features/search-listing/table.feature
@@ -30,7 +30,7 @@ Feature: Search listing table layout
     And the table should have the caption "My Table"
     And the table should have the footer "Some notes about the table"
     When I toggle the tables extra content row
-    Then the tables extra content should contain the text "1 Implemented"
+    Then the tables extra content should contain the text "Details: 1 Implemented"
 
   @mockserver
   Example: Table shows extra structured content using object keys

--- a/examples/nuxt-app/test/fixtures/search-listing/table/page-extra-component.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/table/page-extra-component.json
@@ -49,7 +49,10 @@
             { "label": "Status", "objectKey": "fv_recommendation_status" }
           ],
           "extraContent": {
-            "component": "TableExtraContentComponentExample"
+            "component": "TableExtraContentComponentExample",
+            "props": {
+              "label": "Details"
+            }
           }
         }
       }

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTableRow.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTableRow.vue
@@ -30,6 +30,7 @@ export type extraRowContentItem = {
 
 export type extraRowContent = {
   component?: string
+  props?: string
   html?: string
   items?: extraRowContentItem[]
 }
@@ -140,6 +141,7 @@ const getCellText = (col?: number | string, value = '') => {
         <template v-if="hasComponent(extraContent)">
           <component
             :is="extraContent.component"
+            v-bind="extraContent?.props"
             class="rpl-data-table__details-content"
             :item="row"
           />


### PR DESCRIPTION
### What I did
<!-- Summary of changes made in the Pull Request  -->
-  Allow props to be passed to the main extraContent component, this will be especially useful for manage labels via config. 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

