### PR TITLE
[R20-1780] use getBodyFromField for grant accordion content

### DIFF
--- a/packages/ripple-tide-api/types.d.ts
+++ b/packages/ripple-tide-api/types.d.ts
@@ -259,7 +259,11 @@ declare module 'nitropack' {
 // Mapping util interfaces
 export function getAddress(address: any): string
 export function getBody(body: any): string
-export function getBodyFromField(field: string, path: string | string[]): string
+export function getBodyFromField(
+  field: string,
+  path: string | string[],
+  fallback: any
+): string
 export function getField(
   field: string,
   path: string | string[],

--- a/packages/ripple-tide-grant/mapping/index.ts
+++ b/packages/ripple-tide-grant/mapping/index.ts
@@ -81,10 +81,10 @@ const tideGrantModule: IRplTideModuleMapping = {
           src,
           'field_node_guidelines.field_paragraph_accordion',
           []
-        ).map((acc: string) => ({
+        ).map((acc: any) => ({
           id: getField(acc, 'id'),
           title: getField(acc, 'field_paragraph_accordion_name'),
-          content: getField(acc, 'field_paragraph_accordion_body.processed', '')
+          content: getBodyFromField(acc, 'field_paragraph_accordion_body', '')
         }))
     },
     documents: (src: string) =>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1780

### What I did
<!-- Summary of changes made in the Pull Request  -->
- use getBodyFromField for grant accordion content

<img width="1013" alt="Screenshot 2024-02-13 at 5 09 31 pm" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/45177611-6fb0-4ac6-b531-599f9a843364">



### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

