### PR TITLE
[R20-1767]Flag to display filters on page load

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/filters.feature
+++ b/examples/nuxt-app/test/features/search-listing/filters.feature
@@ -8,13 +8,22 @@ Feature: Search listing - Filter
     And I am using a "macbook-16" device
 
   @mockserver
+  Example: Filter open on page load
+    Given the page endpoint for path "/filters" returns fixture "/search-listing/filters/filters-open" with status 200
+    And the search network request is stubbed with fixture "/search-listing/filters/response" and status 200
+
+    When I visit the page "/filters"
+    Then the search listing filters section should be open
+
+  @mockserver
   Example: Raw filter - Should reflect the value from the URL
     Given the page endpoint for path "/filters" returns fixture "/search-listing/filters/page" with status 200
     And the search network request is stubbed with fixture "/search-listing/filters/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
 
     When I visit the page "/filters?rawFilter=Birds&rawFilter=Dogs"
-    Then the search listing page should have 2 results
+    Then the search listing filters section should not be open
+    And the search listing page should have 2 results
     And the search network request should be called with the "/search-listing/filters/request-raw" fixture
 
     Then the filters toggle should show 1 applied filters

--- a/examples/nuxt-app/test/fixtures/search-listing/filters/filters-open.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/filters/filters-open.json
@@ -1,0 +1,225 @@
+{
+  "title": "Grants and programs",
+  "changed": "2022-11-02T12:47:29+11:00",
+  "created": "2022-11-02T12:47:29+11:00",
+  "type": "tide_search_listing",
+  "nid": "11dede11-10c0-111e1-1100-000000000330",
+  "showTopicTags": true,
+  "summary": "",
+  "config": {
+    "searchListingConfig": {
+      "resultsPerPage": 10
+    },
+    "showFiltersOnLoad": true,
+    "queryConfig": {
+      "multi_match": {
+        "query": "{{query}}",
+        "fields": [
+          "title^3",
+          "field_landing_page_summary^2",
+          "body",
+          "field_paragraph_body",
+          "summary_processed"
+        ]
+      }
+    },
+    "results": {
+      "layout": {
+        "component": "TideSearchResultsList"
+      },
+      "item": {
+        "grant": {
+          "component": "TideGrantSearchResult"
+        }
+      }
+    },
+    "globalFilters": [
+      { "terms": { "type": ["grant"] } },
+      { "terms": { "field_node_site": [8888] } }
+    ],
+    "userFilters": [
+      {
+        "id": "termFilter",
+        "component": "TideSearchFilterDropdown",
+        "filter": {
+          "type": "term",
+          "value": "termFilter.keyword"
+        },
+        "aggregations": {
+          "field": "termFilter",
+          "source": "taxonomy"
+        },
+        "props": {
+          "id": "termFilter",
+          "label": "Term filter example",
+          "placeholder": "Select a colour",
+          "multiple": true,
+          "options": [
+            {
+              "id": "1",
+              "label": "Red",
+              "value": "Red"
+            },
+            {
+              "id": "2",
+              "label": "Green",
+              "value": "Green"
+            },
+            {
+              "id": "3",
+              "label": "Blue",
+              "value": "Blue"
+            }
+          ]
+        }
+      },
+      {
+        "id": "singleTermFilter",
+        "component": "TideSearchFilterDropdown",
+        "filter": {
+          "type": "term",
+          "value": "singleTermFilter.keyword",
+          "multiple": false
+        },
+        "aggregations": {
+          "field": "termFilter",
+          "source": "taxonomy"
+        },
+        "props": {
+          "id": "singleTermFilter",
+          "label": "Single term filter example",
+          "placeholder": "Select a single colour",
+          "multiple": false,
+          "options": [
+            {
+              "id": "1",
+              "label": "Aqua",
+              "value": "Aqua"
+            },
+            {
+              "id": "2",
+              "label": "Burgundy",
+              "value": "Burgundy"
+            },
+            {
+              "id": "3",
+              "label": "Violet",
+              "value": "Violet"
+            }
+          ]
+        }
+      },
+      {
+        "id": "termsFilter",
+        "component": "TideSearchFilterDropdown",
+        "filter": {
+          "type": "terms",
+          "value": "termsFilter.keyword"
+        },
+        "aggregations": {
+          "field": "termsFilter",
+          "source": "taxonomy"
+        },
+        "props": {
+          "id": "termsFilter",
+          "label": "Terms filter example",
+          "placeholder": "Select a colour",
+          "multiple": true,
+          "options": [
+            {
+              "id": "1",
+              "label": "Orange",
+              "value": "Orange"
+            },
+            {
+              "id": "2",
+              "label": "Purple",
+              "value": "Purple"
+            },
+            {
+              "id": "3",
+              "label": "Yellow",
+              "value": "Yellow"
+            }
+          ]
+        }
+      },
+      {
+        "id": "rawFilter",
+        "component": "TideSearchFilterDropdown",
+        "filter": {
+          "type": "raw",
+          "value": "{\"ids\":{\"values\":{{value}}}}"
+        },
+        "aggregations": {
+          "field": "rawFilter",
+          "source": "taxonomy"
+        },
+        "props": {
+          "id": "rawFilter",
+          "label": "Raw filter example",
+          "placeholder": "Select a pet",
+          "multiple": true,
+          "options": [
+            {
+              "id": "1",
+              "label": "Cats",
+              "value": "Cats"
+            },
+            {
+              "id": "2",
+              "label": "Dogs",
+              "value": "Dogs"
+            },
+            {
+              "id": "3",
+              "label": "Birds",
+              "value": "Birds"
+            }
+          ]
+        }
+      },
+      {
+        "id": "functionFilter",
+        "component": "TideSearchFilterDropdown",
+        "filter": {
+          "type": "function",
+          "value": "dummyFunctionFilter"
+        },
+        "props": {
+          "id": "functionFilter",
+          "label": "Custom function filter example",
+          "placeholder": "Select a status",
+          "multiple": true,
+          "options": [
+            {
+              "id": "open",
+              "label": "Open",
+              "value": "open"
+            },
+            {
+              "id": "closed",
+              "label": "Closed",
+              "value": "closed"
+            }
+          ]
+        }
+      },
+      {
+        "id": "checkboxFilter",
+        "component": "TideSearchFilterCheckbox",
+        "filter": {
+          "type": "terms",
+          "value": "checkboxFilter.keyword",
+          "multiple": false
+        },
+        "props": {
+          "id": "checkboxFilter",
+          "label": "Checkbox example",
+          "checkboxLabel": "Show archived content",
+          "onValue": "Archived"
+        }
+      }
+    ]
+  }
+}

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -218,6 +218,14 @@ When(
   }
 )
 
+Then(
+  `the search listing filters section should {}be open`,
+  (clause: string) => {
+    const not = clause.trim().length > 0 ? `${clause.trim()}.` : ''
+    cy.get(`#tide-search-listing-filters`).should(`${not}be.visible`)
+  }
+)
+
 When(`I toggle the search listing filters section`, () => {
   cy.get(`button`).contains('Refine search').as('refineBtn')
   cy.wait(300)

--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -32,6 +32,7 @@ interface Props {
   autocompleteQuery?: boolean
   autocompleteMinimumCharacters?: number
   searchListingConfig?: TideSearchListingConfig['searchListingConfig']
+  showFiltersOnLoad?: boolean
   sortOptions?: TideSearchListingConfig['sortOptions']
   queryConfig: TideSearchListingConfig['queryConfig']
   globalFilters?: TideSearchListingConfig['globalFilters']
@@ -76,6 +77,7 @@ const props = withDefaults(defineProps<Props>(), {
       enabled: true
     }
   }),
+  showFiltersOnLoad: false,
   resultsLayout: () => ({
     component: 'TideSearchResultsList'
   }),
@@ -110,7 +112,7 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('tide-search', emit)
 
-const filtersExpanded = ref(false)
+const filtersExpanded = ref(props.showFiltersOnLoad)
 
 const {
   isBusy,

--- a/packages/ripple-tide-search/components/global/TideTideSearchListing.vue
+++ b/packages/ripple-tide-search/components/global/TideTideSearchListing.vue
@@ -59,5 +59,6 @@ const searchResultsMappingFn = (item: any): TideSearchListingResultItem => {
     :noResultsLayout="resultsConfig?.empty"
     :searchResultsMappingFn="(searchResultsMappingFn as any)"
     :sortOptions="page.config.sortOptions"
+    :showFiltersOnLoad="page.config.showFiltersOnLoad"
   />
 </template>

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -170,6 +170,10 @@ export type TideSearchListingConfig = {
     formTheme: 'default' | 'reverse'
   }
   /**
+   * @description Filter panel open on page load
+   */
+  showFiltersOnLoad: boolean
+  /**
    * @description Elastic Query DSL for query clause
    */
   queryConfig: Record<string, any>


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1767

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Added flag in search listing config to display filter panel on page load - `"showFiltersOnLoad": true`
- 

### How to test
<!-- Summary of how to test  -->
- Cypress
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

