### PR TITLE
[R20-1733] Added ability to configure default tab in custom collection and fixed fullscreen view

### DIFF
--- a/packages/ripple-tide-search/composables/useTideSearch.ts
+++ b/packages/ripple-tide-search/composables/useTideSearch.ts
@@ -78,7 +78,9 @@ export default ({
     return JSON.parse(JSON.stringify(obj).replace(re, escapedValue))
   }
 
-  const initialTab = searchListingConfig?.displayMapTab ? 'map' : null
+  const initialTab = searchListingConfig?.displayMapTab
+    ? searchListingConfig?.defaultTab || 'map'
+    : null
   const activeTab: TideSearchListingTabKey = ref(initialTab)
 
   const isBusy = ref(true)
@@ -735,7 +737,7 @@ export default ({
    */
   const searchFromRoute = (newRoute: RouteLocation, isFirstRun = false) => {
     activeTab.value = searchListingConfig?.displayMapTab
-      ? getSingleQueryStringValue(newRoute.query, 'activeTab') || 'map'
+      ? getSingleQueryStringValue(newRoute.query, 'activeTab') || initialTab
       : null
 
     searchTerm.value = getSingleQueryStringValue(newRoute.query, 'q') || ''

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -160,6 +160,10 @@ export type TideSearchListingConfig = {
      */
     displayMapTab?: boolean
     /**
+     * @description which tab to display by default if not specified in URL
+     */
+    defaultTab?: 'map' | 'listing'
+    /**
      * @description optionally hide the search form
      */
     hideSearchForm?: boolean

--- a/packages/ripple-ui-maps/src/components/map/RplMap.vue
+++ b/packages/ripple-ui-maps/src/components/map/RplMap.vue
@@ -201,33 +201,6 @@ const noResultsRef = ref(null)
 
 <template>
   <div class="rpl-map">
-    <slot
-      v-if="popupType === 'sidebar'"
-      name="sidebar"
-      :popupIsOpen="popup.isOpen"
-      :mapHeight="mapHeight"
-    >
-      <RplMapPopUp
-        :is-open="popup.isOpen"
-        :is-area="popup.isArea"
-        :type="popupType"
-        :pinColor="popup.color"
-        :mapHeight="mapHeight"
-        @close="onPopUpClose"
-      >
-        <template #header>
-          <slot name="popupTitle" :selectedFeatures="popup.feature">
-            {{ popup.feature[0].title }}
-          </slot>
-        </template>
-        <slot name="popupContent" :selectedFeatures="popup.feature">
-          {{ popup.feature }}
-          <p class="rpl-type-p-small">
-            {{ popup.feature[0].description }}
-          </p>
-        </slot>
-      </RplMapPopUp>
-    </slot>
     <div
       v-if="noresults && !hideNoResults"
       class="rpl-map__noresults"
@@ -352,6 +325,34 @@ const noResultsRef = ref(null)
           <RplIcon name="icon-map-zoom-out" size="s"></RplIcon>
         </button>
       </div>
+
+      <slot
+        v-if="popupType === 'sidebar'"
+        name="sidebar"
+        :popupIsOpen="popup.isOpen"
+        :mapHeight="mapHeight"
+      >
+        <RplMapPopUp
+          :is-open="popup.isOpen"
+          :is-area="popup.isArea"
+          :type="popupType"
+          :pinColor="popup.color"
+          :mapHeight="mapHeight"
+          @close="onPopUpClose"
+        >
+          <template #header>
+            <slot name="popupTitle" :selectedFeatures="popup.feature">
+              {{ popup.feature[0].title }}
+            </slot>
+          </template>
+          <slot name="popupContent" :selectedFeatures="popup.feature">
+            {{ popup.feature }}
+            <p class="rpl-type-p-small">
+              {{ popup.feature[0].description }}
+            </p>
+          </slot>
+        </RplMapPopUp>
+      </slot>
     </ol-map>
   </div>
 </template>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1733

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Added `defaultTab` option to searchListingConfig, can be set to 'map' or 'listing
- If not provided, it defaults to 'map' if there is a map tab, or 'listing' if there is no map tab
- Ensured that the 'infobox' popup still shows up in fullscreen mode

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

