### PR TITLE
[R20-1712] Number input with buttons

### DIFF
--- a/packages/ripple-ui-forms/src/components/RplForm/RplForm.stories.mdx
+++ b/packages/ripple-ui-forms/src/components/RplForm/RplForm.stories.mdx
@@ -328,6 +328,7 @@ export const SlotTemplate = (args) => ({
           help: "How many do you need?",
           min: 0,
           max: 5,
+          mode: "alt",
           value: 1,
           validation: 'between:0,5',
           validationMessages: {

--- a/packages/ripple-ui-forms/src/components/RplForm/RplForm.stories.mdx
+++ b/packages/ripple-ui-forms/src/components/RplForm/RplForm.stories.mdx
@@ -320,6 +320,21 @@ export const SlotTemplate = (args) => ({
           }
         },
         {
+          $formkit: "RplFormNumber",
+          name: "qty",
+          label: "Quantity",
+          columnClasses: 'rpl-col-12 rpl-col-5-m',
+          id: "qty",
+          help: "How many do you need?",
+          min: 0,
+          max: 5,
+          value: 1,
+          validation: 'between:0,5',
+          validationMessages: {
+            between: "Please choose between 0 and 5"
+          }
+        },
+        {
           $formkit: 'RplFormActions',
           label: 'Submit form',
           id: '123'

--- a/packages/ripple-ui-forms/src/components/RplFormNumber/RplFormNumber.stories.mdx
+++ b/packages/ripple-ui-forms/src/components/RplFormNumber/RplFormNumber.stories.mdx
@@ -36,11 +36,20 @@ export const FormElementTemplate = (args) => ({
 <Canvas>
   <Story
     name='Number'
+  >
+    {FormElementTemplate.bind()}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Number with buttons'
     args={{
       value: "1",
       min: 0,
       max: 10,
-      step: 1
+      step: 1,
+      mode: 'alt'
     }}
   >
     {FormElementTemplate.bind()}

--- a/packages/ripple-ui-forms/src/components/RplFormNumber/RplFormNumber.stories.mdx
+++ b/packages/ripple-ui-forms/src/components/RplFormNumber/RplFormNumber.stories.mdx
@@ -1,0 +1,49 @@
+import {
+  Canvas,
+  Meta,
+  Story,
+  ArgsTable
+} from '@storybook/addon-docs'
+import RplForm from '../RplForm/RplForm.vue'
+import RplFormElement from './../RplFormElement/RplFormElement.vue'
+import '@dpc-sdp/ripple-ui-core/style/components'
+
+export const FormElementTemplate = (args) => ({
+  components: { RplFormElement, RplForm },
+  setup() {
+    return { args }
+  },
+  template: `
+    <RplForm
+      id="storybook-form-number-sample"
+      :style="{
+        '--local-max-width': '595px'
+      }"
+    >
+      <RplFormElement type="RplFormNumber" v-bind="args" />
+      <template #belowForm="{ value }">
+        <div class="rpl-storybook-form-values">
+          <h2 class="rpl-type-h4">Internal form values</h2>
+          <pre wrap>{{ value }}</pre>
+        </div>
+      </template>
+    </RplForm>
+`
+})
+
+<Meta title='Forms/Input' component={RplFormElement} />
+
+<Canvas>
+  <Story
+    name='Number'
+    args={{
+      value: "1",
+      min: 0,
+      max: 10,
+      step: 1
+    }}
+  >
+    {FormElementTemplate.bind()}
+  </Story>
+</Canvas>
+

--- a/packages/ripple-ui-forms/src/components/RplFormNumber/RplFormNumber.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormNumber/RplFormNumber.vue
@@ -1,0 +1,210 @@
+<script lang="ts">
+export default {
+  inheritAttrs: false
+}
+</script>
+
+<script setup lang="ts">
+import { computed, inject, ref, watch } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
+// @ts-expect-error vue SFC
+import { RplIcon } from '@dpc-sdp/ripple-ui-core/vue'
+import useFormkitFriendlyEventEmitter from '../../composables/useFormkitFriendlyEventEmitter.js'
+import { useRippleEvent } from '@dpc-sdp/ripple-ui-core'
+import type { rplEventPayload } from '@dpc-sdp/ripple-ui-core'
+import { sanitisePIIField } from '../../lib/sanitisePII'
+
+interface Props {
+  id: string
+  disabled?: boolean
+  className?: string
+  value: string
+  onChange: (value: string | string[]) => void
+  type?: string
+  name: string
+  label?: string
+  min?: number
+  max?: number
+  step?: number
+  variant?: 'default' | 'reverse'
+  invalid?: boolean
+  required?: boolean
+  globalEvents?: boolean
+  throttle?: number
+  pii?: boolean
+  onInput?: (payload: Event) => void
+  onBlur?: (payload: Event) => void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  type: 'number',
+  value: '0',
+  className: 'rpl-form__input',
+  onChange: () => undefined,
+  label: undefined,
+  min: undefined,
+  max: undefined,
+  step: 1,
+  disabled: false,
+  required: false,
+  invalid: false,
+  variant: 'default',
+  globalEvents: true,
+  throttle: 500,
+  pii: true,
+  onInput: () => null,
+  onBlur: () => null
+})
+
+const emit = defineEmits<{
+  (e: 'onChange', value: string[]): void
+  (e: 'update', payload: rplEventPayload & { action: 'update' }): void
+}>()
+
+const { emitRplEvent } = useRippleEvent('rpl-form-number', emit)
+
+const form: any = inject('form')
+
+const classes = computed(() => {
+  return {
+    [`${props.className}`]: true,
+    [`${props.className}--with-prefix-icon`]: true,
+    [`${props.className}--with-suffix-icon`]: true,
+    [`${props.className}--${props.variant}`]: true,
+    [`${props.className}--type-${props.type}`]: props.type,
+    [`${props.className}--disabled`]: props.disabled,
+    [`${props.className}--invalid`]: props.invalid
+  }
+})
+
+const current = ref<number>(parseInt(props.value || '0'))
+
+watch(
+  () => props.value,
+  (newValue) => {
+    current.value = parseInt(newValue)
+  }
+)
+
+const commitValue = (val: number) => {
+  emitRplEvent(
+    'update',
+    {
+      action: 'update',
+      id: props.id,
+      type: props.type,
+      label: props?.label,
+      contextId: form?.id,
+      contextName: form?.name,
+      value: sanitisePIIField(props.pii, val)
+    },
+    { global: props.globalEvents }
+  )
+}
+
+const handleDecrement = () => {
+  props.min !== undefined && current.value - 1 < props.min
+    ? (current.value = props.min)
+    : (current.value -= props.step)
+  useFormkitFriendlyEventEmitter(props, emit, 'onChange', current.value)
+  commitValue(current.value)
+}
+
+const handleChange = useDebounceFn(() => {
+  commitValue(parseInt(props.value))
+}, props.throttle)
+
+const handleIncrement = () => {
+  props.max !== undefined && current.value + 1 > props.max
+    ? (current.value = props.max)
+    : (current.value += props.step)
+  useFormkitFriendlyEventEmitter(props, emit, 'onChange', current.value)
+  commitValue(current.value)
+}
+</script>
+
+<template>
+  <div :class="classes">
+    <div class="rpl-form__input-wrap">
+      <button class="rpl-form__input-dec" @click.prevent="handleDecrement">
+        <span class="rpl-u-visually-hidden">Decrease value</span>
+        <RplIcon
+          name="icon-map-zoom-out"
+          :class="`${props.className}-icon ${props.className}-icon__prefix`"
+          size="s"
+        />
+      </button>
+      <input
+        :id="id"
+        type="number"
+        :value="value"
+        class="rpl-u-focusable-outline"
+        :disabled="disabled"
+        :required="required"
+        :aria-required="required"
+        :aria-invalid="invalid"
+        v-bind="$attrs"
+        :name="name"
+        :min="min"
+        :max="max"
+        @blur="onBlur"
+        @input="onInput"
+        @change="handleChange"
+        @focus=";($event.target as HTMLInputElement).select()"
+      />
+      <button class="rpl-form__input-inc" @click.prevent="handleIncrement">
+        <span class="rpl-u-visually-hidden">Increase value</span>
+        <RplIcon
+          name="icon-map-zoom-in"
+          :class="`${props.className}-icon ${props.className}-icon__suffix`"
+          size="s"
+        />
+      </button>
+    </div>
+  </div>
+</template>
+
+<style src="../RplFormInput/RplFormInput.css" />
+
+<style>
+.rpl-form__input--type-number {
+  .rpl-form__input-icon {
+    color: var(--rpl-clr-type-default);
+  }
+
+  input[type='number'] {
+    padding-left: 4.75rem;
+    padding-right: 4.75rem;
+    text-align: center;
+  }
+
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    margin: 0;
+  }
+
+  .rpl-form__input-inc,
+  .rpl-form__input-dec {
+    cursor: pointer;
+    height: 4.75rem;
+    width: 4.75rem;
+    display: flex;
+    z-index: 1;
+
+    &:hover .rpl-icon {
+      color: var(--rpl-clr-primary);
+    }
+  }
+
+  .rpl-form__input-inc {
+    margin-left: -4.75rem;
+  }
+
+  .rpl-form__input-dec {
+    margin-right: -4.75rem;
+  }
+}
+</style>

--- a/packages/ripple-ui-forms/src/index.ts
+++ b/packages/ripple-ui-forms/src/index.ts
@@ -1,5 +1,8 @@
+// @ts-expect-error vue SFC
 export { default as RplForm } from './components/RplForm/RplForm.vue'
+// @ts-expect-error vue SFC
 export { default as RplFormElement } from './components/RplFormElement/RplFormElement.vue'
+// @ts-expect-error vue SFC
 export { default as RplFormAlert } from './components/RplFormAlert/RplFormAlert.vue'
 
 export { default as registerRplFormPlugin } from './register.js'

--- a/packages/ripple-ui-forms/src/inputs/input-utils.ts
+++ b/packages/ripple-ui-forms/src/inputs/input-utils.ts
@@ -1,20 +1,4 @@
 import { markRaw } from 'vue'
-import RplFormInput from './../components/RplFormInput/RplFormInput.vue'
-import RplFormTextarea from './../components/RplFormTextarea/RplFormTextarea.vue'
-import RplFormOption from '../components/RplFormOptions/RplFormOption.vue'
-import RplFormCheckboxGroup from './../components/RplFormOptions/RplFormCheckboxGroup.vue'
-import RplFormRadioGroup from './../components/RplFormOptions/RplFormRadioGroup.vue'
-import RplFormOptionButtons from './../components/RplFormOptionButtons/RplFormOptionButtons.vue'
-import RplFormDropdown from './../components/RplFormDropdown/RplFormDropdown.vue'
-import RplFormDate from './../components/RplFormDate/RplFormDate.vue'
-import RplFormValidationError from './../components/RplFormValidationError/RplFormValidationError.vue'
-import RplFormHelpText from './../components/RplFormHelpText/RplFormHelpText.vue'
-import RplFormLabel from './../components/RplFormLabel/RplFormLabel.vue'
-import RplFormInputGrid from './../components/RplFormInputGrid/RplFormInputGrid.vue'
-import RplFormContent from '../components/RplFormContent/RplFormContent.vue'
-import RplFormFieldset from '../components/RplFormFieldset/RplFormFieldset.vue'
-import RplFormDivider from '../components/RplFormDivider/RplFormDivider.vue'
-import RplFormActions from '../components/RplFormActions/RplFormActions.vue'
 import {
   inner,
   wrapper,
@@ -39,8 +23,44 @@ import {
   hasNoLabel
 } from '../formkit-features'
 import { rplInputGrid } from '../sections/rplInputGrid'
+// @ts-expect-error vue SFC
+import RplFormInput from './../components/RplFormInput/RplFormInput.vue'
+// @ts-expect-error vue SFC
+import RplFormTextarea from './../components/RplFormTextarea/RplFormTextarea.vue'
+// @ts-expect-error vue SFC
+import RplFormOption from '../components/RplFormOptions/RplFormOption.vue'
+// @ts-expect-error vue SFC
+import RplFormCheckboxGroup from './../components/RplFormOptions/RplFormCheckboxGroup.vue'
+// @ts-expect-error vue SFC
+import RplFormRadioGroup from './../components/RplFormOptions/RplFormRadioGroup.vue'
+// @ts-expect-error vue SFC
+import RplFormOptionButtons from './../components/RplFormOptionButtons/RplFormOptionButtons.vue'
+// @ts-expect-error vue SFC
+import RplFormDropdown from './../components/RplFormDropdown/RplFormDropdown.vue'
+// @ts-expect-error vue SFC
+import RplFormDate from './../components/RplFormDate/RplFormDate.vue'
+// @ts-expect-error vue SFC
+import RplFormValidationError from './../components/RplFormValidationError/RplFormValidationError.vue'
+// @ts-expect-error vue SFC
+import RplFormHelpText from './../components/RplFormHelpText/RplFormHelpText.vue'
+// @ts-expect-error vue SFC
+import RplFormLabel from './../components/RplFormLabel/RplFormLabel.vue'
+// @ts-expect-error vue SFC
+import RplFormInputGrid from './../components/RplFormInputGrid/RplFormInputGrid.vue'
+// @ts-expect-error vue SFC
+import RplFormContent from '../components/RplFormContent/RplFormContent.vue'
+// @ts-expect-error vue SFC
+import RplFormFieldset from '../components/RplFormFieldset/RplFormFieldset.vue'
+// @ts-expect-error vue SFC
+import RplFormDivider from '../components/RplFormDivider/RplFormDivider.vue'
+// @ts-expect-error vue SFC
+import RplFormActions from '../components/RplFormActions/RplFormActions.vue'
+// @ts-expect-error vue SFC
 import FormkitInputError from '../components/RplForm/FormkitInputError.vue'
+// @ts-expect-error vue SFC
 import FormkitOuter from '../components/RplForm/FormkitOuter.vue'
+// @ts-expect-error vue SFC
+import RplFormNumber from '../components/RplFormNumber/RplFormNumber.vue'
 
 export const inputLibrary = {
   RplFormInput: markRaw(RplFormInput),
@@ -60,7 +80,8 @@ export const inputLibrary = {
   RplFormDivider: markRaw(RplFormDivider),
   RplFormActions: markRaw(RplFormActions),
   FormkitInputError: markRaw(FormkitInputError),
-  FormkitOuter: markRaw(FormkitOuter)
+  FormkitOuter: markRaw(FormkitOuter),
+  RplFormNumber: markRaw(RplFormNumber)
 }
 
 export const rplFeatures = [
@@ -98,7 +119,7 @@ export const createRplFormInput = (
         )
       )
     )
-  )
+  ) as unknown as FormKitExtendableSchemaRoot
 }
 
 /*
@@ -121,7 +142,7 @@ export const createRplFormGroup = (
       }))(),
       rplInputGrid(createSection('input', () => cmp)())
     )
-  )
+  ) as unknown as FormKitExtendableSchemaRoot
 }
 
 export const defaultRplFormInputProps = {

--- a/packages/ripple-ui-forms/src/inputs/number.ts
+++ b/packages/ripple-ui-forms/src/inputs/number.ts
@@ -19,6 +19,7 @@ export const number: FormKitTypeDefinition = {
     props: {
       ...defaultRplFormInputProps,
       type: 'number',
+      mode: '$node.props.mode',
       onChange: '$node.input',
       min: '$node.props.min',
       max: '$node.props.max',
@@ -45,7 +46,8 @@ export const number: FormKitTypeDefinition = {
     'placeholder',
     'validationMeta',
     'columnClasses',
-    'pii'
+    'pii',
+    'mode'
   ],
   /**
    * Forces node.props.type to be this explicit value.

--- a/packages/ripple-ui-forms/src/inputs/number.ts
+++ b/packages/ripple-ui-forms/src/inputs/number.ts
@@ -15,10 +15,11 @@ export const number: FormKitTypeDefinition = {
    * The actual schema of the input, or a function that returns the schema.
    */
   schema: createRplFormInput({
-    $cmp: 'RplFormInput',
+    $cmp: 'RplFormNumber',
     props: {
       ...defaultRplFormInputProps,
       type: 'number',
+      onChange: '$node.input',
       min: '$node.props.min',
       max: '$node.props.max',
       step: '$node.props.step'


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1712

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Refactor existing number input in `rpl-ui-forms` to include +/- buttons
- Set up as a `RplFormElement` to support schema usage
- Browser number control will be used by default, add `mode="alt"` to enable +/- buttons

### How to test
<!-- Summary of how to test  -->
- Storybook
![Screenshot 2024-02-29 at 1 23 50 pm](https://github.com/dpc-sdp/ripple-framework/assets/863542/ad4be044-004a-430e-b84c-778109f38945)

- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

