### PR TITLE
[R20-1767] Move key, add initial state for `RplExpandable`

### DIFF
--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -32,7 +32,6 @@ interface Props {
   autocompleteQuery?: boolean
   autocompleteMinimumCharacters?: number
   searchListingConfig?: TideSearchListingConfig['searchListingConfig']
-  showFiltersOnLoad?: boolean
   sortOptions?: TideSearchListingConfig['sortOptions']
   queryConfig: TideSearchListingConfig['queryConfig']
   globalFilters?: TideSearchListingConfig['globalFilters']
@@ -65,20 +64,21 @@ const props = withDefaults(defineProps<Props>(), {
       ]
     }
   }),
-  searchListingConfig: () => ({
-    hideSearchForm: false,
-    resultsPerPage: 9,
-    labels: {
-      submit: 'Submit',
-      reset: 'Reset',
-      placeholder: 'Enter a search term'
-    },
-    suggestions: {
-      key: 'title',
-      enabled: true
-    }
-  }),
-  showFiltersOnLoad: false,
+  searchListingConfig: () =>
+    ({
+      hideSearchForm: false,
+      resultsPerPage: 9,
+      labels: {
+        submit: 'Submit',
+        reset: 'Reset',
+        placeholder: 'Enter a search term'
+      },
+      suggestions: {
+        key: 'title',
+        enabled: true
+      },
+      showFiltersOnLoad: false
+    } as any),
   resultsLayout: () => ({
     component: 'TideSearchResultsList'
   }),
@@ -86,7 +86,7 @@ const props = withDefaults(defineProps<Props>(), {
     component: 'TideSearchNoResults'
   }),
   belowFilterComponent: undefined,
-  searchResultsMappingFn: (item): MappedSearchResult<any> => {
+  searchResultsMappingFn: (item: any): MappedSearchResult<any> => {
     return {
       id: item._id,
       component: 'TideSearchResult',
@@ -114,7 +114,7 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('tide-search', emit)
 
-const filtersExpanded = ref(props.showFiltersOnLoad)
+const filtersExpanded = ref(props.searchListingConfig?.showFiltersOnLoad)
 
 const {
   isBusy,
@@ -161,22 +161,22 @@ const baseEvent = () => ({
 })
 
 // Updates filter options with aggregation value
-onAggregationUpdateHook.value = (aggs) => {
+onAggregationUpdateHook.value = (aggs: any) => {
   const updateTimestamp = Date.now()
 
   Object.keys(aggs).forEach((key) => {
     uiFilters.value.forEach((uiFilter, idx) => {
       if (uiFilter.id === key) {
         const getDynamicOptions = () => {
-          const mappedOptions = aggs[key].map((item) => ({
+          const mappedOptions = aggs[key].map((item: any) => ({
             id: item,
             label: item,
             value: item
           }))
 
-          if (uiFilters.value[idx].props.hasOwnProperty('options')) {
+          if (uiFilters.value[idx].props?.hasOwnProperty('options')) {
             return [
-              ...toRaw(uiFilters.value[idx].props.options),
+              ...toRaw(uiFilters.value[idx].props?.options as unknown as any),
               ...mappedOptions
             ]
           }
@@ -197,7 +197,7 @@ onAggregationUpdateHook.value = (aggs) => {
   })
 }
 
-const emitSearchEvent = (event) => {
+const emitSearchEvent = (event: any) => {
   emitRplEvent(
     'submit',
     {
@@ -209,7 +209,7 @@ const emitSearchEvent = (event) => {
   )
 }
 
-const handleSearchSubmit = (event) => {
+const handleSearchSubmit = (event: any) => {
   if (props.userFilters && props.userFilters.length) {
     cachedSubmitEvent.value = event
     // Submitting the search term should also 'apply' the filters, but the filters live in a seperate form.
@@ -224,7 +224,7 @@ const handleSearchSubmit = (event) => {
   }
 }
 
-const handleFilterSubmit = (event) => {
+const handleFilterSubmit = (event: any) => {
   filterForm.value = event.value
   submitSearch()
 
@@ -249,7 +249,7 @@ const handleFilterReset = (event: rplEventPayload) => {
   submitSearch()
 }
 
-const handleUpdateSearchTerm = (term) => {
+const handleUpdateSearchTerm = (term: string) => {
   searchTerm.value = term
 
   if (
@@ -264,7 +264,7 @@ const handleUpdateSearchTerm = (term) => {
   }
 }
 
-const handlePageChange = (event) => {
+const handlePageChange = (event: any) => {
   goToPage(event.value)
   emitRplEvent(
     'paginate',
@@ -277,7 +277,7 @@ const handlePageChange = (event) => {
   )
 }
 
-const handleSortChange = (sortId) => {
+const handleSortChange = (sortId: any) => {
   changeSortOrder(sortId)
 }
 
@@ -351,15 +351,15 @@ watch(
       >
         <p v-if="introText" class="rpl-type-p-large">{{ introText }}</p>
         <div
-          v-if="!searchListingConfig.hideSearchForm"
+          v-if="!searchListingConfig?.hideSearchForm"
           class="tide-search-header"
         >
           <RplSearchBar
             id="tide-search-bar"
             variant="default"
-            :input-label="searchListingConfig.labels?.submit"
+            :input-label="searchListingConfig?.labels?.submit"
             :inputValue="searchTerm"
-            :placeholder="searchListingConfig.labels?.placeholder"
+            :placeholder="searchListingConfig?.labels?.placeholder"
             :suggestions="suggestions"
             :global-events="false"
             @submit="handleSearchSubmit"
@@ -382,7 +382,7 @@ watch(
             <TideSearchFilters
               :title="title"
               :filter-form-values="filterForm"
-              :filterInputs="userFilters"
+              :filterInputs="userFilters as any"
               @reset="handleFilterReset"
               @submit="handleFilterSubmit"
             >
@@ -479,7 +479,7 @@ watch(
     </template>
     <template #belowBody>
       <RplPageComponent v-if="contentPage.secondaryCampaign">
-        <RplSecondaryCampaign v-bind="contentPage.secondaryCampaign" />
+        <RplSecondaryCampaign v-bind="contentPage.secondaryCampaign as any" />
       </RplPageComponent>
     </template>
   </TideBaseLayout>

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -198,11 +198,11 @@ export type TideSearchListingConfig = {
      * @description The theme to use for the display of form section and fields
      */
     formTheme: 'default' | 'reverse'
+    /**
+     * @description Filter panel open on page load
+     */
+    showFiltersOnLoad: boolean
   }
-  /**
-   * @description Filter panel open on page load
-   */
-  showFiltersOnLoad: boolean
   /**
    * @description Elastic Query DSL for query clause
    */

--- a/packages/ripple-ui-core/src/components/expandable/RplExpandable.vue
+++ b/packages/ripple-ui-core/src/components/expandable/RplExpandable.vue
@@ -13,33 +13,33 @@ const props = withDefaults(defineProps<Props>(), {
 const containerRef = ref(null)
 const duration = useComputedSpeed(containerRef, '--rpl-motion-speed-9', 420)
 
-function onBeforeEnter(el) {
-  el.style.height = `0px`
+function onBeforeEnter(el: any) {
+  el.style.height = '0px'
 }
 
 // called one frame after the element is inserted.
 // use this to start the entering animation.
-function onEnter(el, done) {
+function onEnter(el: any, done: Function): void {
   el.style.height = `${el.scrollHeight}px`
 
   // call the done callback to indicate transition end
   setTimeout(done, duration.value)
 }
 
-function onAfterEnter(el) {
+function onAfterEnter(el: any) {
   el.style.height = 'auto'
   el.style.overflow = 'initial'
 }
 
-function onBeforeLeave(el) {
+function onBeforeLeave(el: any) {
   el.style.height = `${el.getBoundingClientRect().height}px`
   el.style.overflow = 'hidden'
 }
 
 // called when the leave transition starts.
 // use this to start the leaving animation.
-function onLeave(el, done) {
-  el.style.height = `0px`
+function onLeave(el: any, done: Function) {
+  el.style.height = '0px'
 
   // call the done callback to indicate transition end
   setTimeout(done, duration.value)
@@ -47,7 +47,7 @@ function onLeave(el, done) {
 
 const classes = computed(() => ({
   'rpl-expandable': true,
-  [`rpl-expandable--open`]: props.expanded
+  'rpl-expandable--open': props.expanded
 }))
 </script>
 
@@ -59,12 +59,7 @@ const classes = computed(() => ({
     @before-leave="onBeforeLeave"
     @leave="onLeave"
   >
-    <div
-      v-show="expanded"
-      ref="containerRef"
-      :class="classes"
-      role="region"
-    >
+    <div v-show="expanded" ref="containerRef" :class="classes" role="region">
       <slot />
     </div>
   </Transition>
@@ -80,5 +75,10 @@ const classes = computed(() => ({
     display: block !important;
     height: auto !important;
   }
+}
+
+.rpl-expandable--open {
+  height: auto;
+  overflow: initial;
 }
 </style>

--- a/packages/ripple-ui-core/src/composables/useComputedSpeed.ts
+++ b/packages/ripple-ui-core/src/composables/useComputedSpeed.ts
@@ -4,7 +4,7 @@ import { ref, onMounted, Ref } from 'vue'
 export function useComputedSpeed(
   container: Ref,
   property: string,
-  fallback = null
+  fallback: any = null
 ): Ref {
   const duration = ref(fallback)
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1767

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Moved `showFiltersOnLoad` into `searchListingConfig`
- Added initial open state state CSS to `RplExpandable` to allow overflow where needeed
- A bunch of tslint

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

