### PR TITLE
[R20-1807][R20-1806]: allow single level only menu sections …

### DIFF
--- a/examples/nuxt-app/test/features/site/feature-flags.feature
+++ b/examples/nuxt-app/test/features/site/feature-flags.feature
@@ -34,7 +34,7 @@ Feature: Site feature flags
       | subject | Check out Demo Landing Page                              |
       | body    | I thought you might like this article Demo Landing Page. |
 
-  @mockserver @focus
+  @mockserver
   Scenario: Feature flags can set the footer to show only a single level
     Given the site endpoint returns fixture "/site/flags-footer-single.json" with status 200
     And the page endpoint for path "/" returns fixture "/landingpage/image-banner" with status 200

--- a/examples/nuxt-app/test/features/site/feature-flags.feature
+++ b/examples/nuxt-app/test/features/site/feature-flags.feature
@@ -33,3 +33,17 @@ Feature: Site feature flags
       | key     | value                                                    |
       | subject | Check out Demo Landing Page                              |
       | body    | I thought you might like this article Demo Landing Page. |
+
+  @mockserver @focus
+  Scenario: Feature flags can set the footer to show only a single level
+    Given the site endpoint returns fixture "/site/flags-footer-single.json" with status 200
+    And the page endpoint for path "/" returns fixture "/landingpage/image-banner" with status 200
+    Given I visit the page "/"
+    Then the footer nav should have the following single level items
+      | text   | url     |
+      | Events | /events |
+      | News   | /news   |
+    And the footer nav section with title "Connect with us" should have the following links
+      | text     | url                           |
+      | Facebook | https://facebook.com/VicGovAu |
+      | Twitter  | https://twitter.com/VicGovAu  |

--- a/examples/nuxt-app/test/fixtures/site/flags-footer-single.json
+++ b/examples/nuxt-app/test/fixtures/site/flags-footer-single.json
@@ -1,0 +1,92 @@
+{
+  "name": "Test site for social share flags",
+  "acknowledgementHeader": "Test hero acknowledgement",
+  "acknowledgementFooter": "Test footer acknowledgement",
+  "socialImages": {
+    "twitter": {},
+    "og": {}
+  },
+  "siteLogo": {
+    "href": "/",
+    "src": "https://placehold.co/140x40",
+    "altText": ""
+  },
+  "featureFlags": {
+    "footerMenuSingleLevel": true
+  },
+  "socialLinks": [
+    {
+      "id": "social_link-0",
+      "text": "Facebook",
+      "url": "https://facebook.com/VicGovAu",
+      "icon": "icon-facebook",
+      "iconColour": "currentColor"
+    },
+    {
+      "id": "social_link-1",
+      "text": "Twitter",
+      "url": "https://twitter.com/VicGovAu",
+      "icon": "icon-x",
+      "iconColour": "currentColor"
+    }
+  ],
+  "menus": {
+    "menuMain": [
+      {
+        "text": "Events",
+        "url": "/events",
+        "id": "c9b2419b-c89d-4a43-87de-f991291c4896",
+        "parent": null,
+        "weight": 0,
+        "items": [
+          {
+            "text": "Kensington Primary School",
+            "url": "/kensington-primary-school",
+            "id": "f1e6cbaf-46f2-4c2e-92b8-79d8b93f9c2a",
+            "parent": "c9b2419b-c89d-4a43-87de-f991291c4896",
+            "weight": 0
+          },
+          {
+            "text": "Aerial Display",
+            "url": "/aerial-display",
+            "id": "e05d729b-ffe3-4575-ab29-152cd3663679",
+            "parent": "c9b2419b-c89d-4a43-87de-f991291c4896",
+            "weight": 0
+          }
+        ]
+      },
+      {
+        "text": "News",
+        "url": "/news",
+        "id": "c9b2419b-c89d-4a43-87de-f991291c4895",
+        "parent": null,
+        "weight": 0,
+        "items": [
+          {
+            "text": "GovHack 2022",
+            "url": "/govhack-2022",
+            "id": "02246e7d-d759-4169-ae9d-5c432f925dc1",
+            "parent": "c9b2419b-c89d-4a43-87de-f991291c4895",
+            "weight": 0
+          },
+          {
+            "text": "Wage Inspectorate",
+            "url": "/wage-inspectorate",
+            "id": "0f9d04b1-1fb0-4864-a500-97033fe79491",
+            "parent": "c9b2419b-c89d-4a43-87de-f991291c4895",
+            "weight": 0
+          }
+        ]
+      }
+    ],
+    "menuFooter": [
+      {
+        "text": "Demo Landing Page",
+        "url": "/demo-landing-page",
+        "uuid": "04e44b77-20df-4a73-b0d1-cf2d3d614754",
+        "parent": null,
+        "weight": 0
+      }
+    ]
+  }
+}

--- a/packages/nuxt-ripple/components/TideBaseLayout.vue
+++ b/packages/nuxt-ripple/components/TideBaseLayout.vue
@@ -144,7 +144,11 @@ const showBreadcrumbs = computed(() => route.path !== '/')
 const showDraftAlert = computed(() => props.page?.status === 'draft')
 
 const footerNav = computed(() => {
-  const menuMain = props.site?.menus.menuMain || []
+  const menuMain = (props.site?.menus.menuMain || []).map((item) => {
+    return featureFlags.value?.footerMenuSingleLevel
+      ? { ...item, single: true }
+      : item
+  })
 
   if (props.site?.socialLinks?.length) {
     return [

--- a/packages/ripple-test-utils/step_definitions/common/shared-elements.ts
+++ b/packages/ripple-test-utils/step_definitions/common/shared-elements.ts
@@ -103,6 +103,28 @@ Then(
     })
   }
 )
+Then(
+  'the footer nav should have the following single level items',
+  (dataTable: DataTable) => {
+    const table = dataTable.hashes()
+
+    cy.get(`.rpl-footer-nav-section__title`).as('items')
+
+    table.forEach((row, i: number) => {
+      cy.get('@items')
+        .eq(i)
+        .then((item) => {
+          cy.wrap(item).as('item')
+          cy.get('@item').should('contain', row.text)
+          cy.get('@item').find('a').should('have.attr', 'href', row.url)
+          cy.get('@item')
+            .parents('.rpl-footer-nav-section')
+            .find('.rpl-list__items')
+            .should('not.exist')
+        })
+    })
+  }
+)
 
 Then('the footer should have the following links', (dataTable: DataTable) => {
   const table = dataTable.hashes()

--- a/packages/ripple-tide-api/types.d.ts
+++ b/packages/ripple-tide-api/types.d.ts
@@ -221,6 +221,10 @@ export interface IRplFeatureFlags {
    */
   footerTheme?: 'neutral' | 'default'
   /**
+   * @description Sets the display of the footer menu to one single level i.e. no children
+   */
+  footerMenuSingleLevel?: boolean
+  /**
    * @description Disable the primary vic.gov.au logo for sites that are not co-branded
    */
   disablePrimaryLogo?: boolean

--- a/packages/ripple-ui-core/src/components/footer/RplFooter.stories.mdx
+++ b/packages/ripple-ui-core/src/components/footer/RplFooter.stories.mdx
@@ -6,7 +6,7 @@ import {
 } from '@storybook/addon-docs'
 import RplFooter from './RplFooter.vue'
 import { RplFooterVariants } from './constants'
-import { RplFooterLinks } from './fixtures/sample'
+import { RplFooterLinks, RplFooterLinksSingleLevel } from './fixtures/sample'
 import { a11yStoryCheck } from './../../../stories/interactions.js'
 import { bpMin } from '../../lib/breakpoints'
 
@@ -96,6 +96,21 @@ export const SingleTemplate = (args) => ({
     }}
     args={{
       variant: 'neutral'
+    }}
+  >
+    {SingleTemplate.bind()}
+  </Story>
+  <Story
+    name='Single level'
+    play={a11yStoryCheck}
+    parameters={{
+      layout: 'fullscreen',
+      chromatic: {
+        viewports: [bpMin.s - 100, bpMin.s, bpMin.m, bpMin.l, bpMin.xl]
+      }
+    }}
+    args={{
+      nav: RplFooterLinksSingleLevel
     }}
   >
     {SingleTemplate.bind()}

--- a/packages/ripple-ui-core/src/components/footer/RplNavSection.vue
+++ b/packages/ripple-ui-core/src/components/footer/RplNavSection.vue
@@ -9,6 +9,7 @@ import {
   useRippleEvent,
   rplEventPayload
 } from '../../composables/useRippleEvent'
+import RplTextLink from '../text-link/RplTextLink.vue'
 
 interface Props {
   id: string
@@ -50,7 +51,12 @@ const items = computed(() => {
   }
 })
 
+const singleLevel = computed(() => props.section?.single)
+const canExpand = computed(() => props.isExpandable && !singleLevel.value)
+
 const handleToggle = () => {
+  if (!canExpand.value) return
+
   isExpanded.value = !isExpanded.value
 
   emitRplEvent(
@@ -70,6 +76,7 @@ const handleClick = (event) => {
     'navigate',
     {
       ...event,
+      action: 'click',
       label: props.section.text,
       index: props?.index + 1
     },
@@ -91,22 +98,31 @@ const handleClick = (event) => {
       }"
     >
       <component
-        :is="isExpandable ? 'button' : 'div'"
+        :is="canExpand ? 'button' : 'div'"
         :class="{
           'rpl-footer-nav-section__header-inner': true,
-          'rpl-footer-nav-section__header-inner-button': isExpandable,
-          'rpl-u-focusable-block': isExpandable
+          'rpl-footer-nav-section__header-inner-button': canExpand,
+          'rpl-u-focusable-block': canExpand
         }"
-        v-bind="isExpandable ? toggleProps : {}"
+        v-bind="canExpand ? toggleProps : {}"
         @click="handleToggle"
       >
         <h3
           class="rpl-footer-nav-section__title rpl-type-label rpl-type-weight-bold"
         >
-          {{ section.text }}
-
+          <RplTextLink
+            v-if="singleLevel && section?.url"
+            :url="section.url"
+            class="rpl-list__link"
+            @click="
+              () => handleClick({ value: section.url, text: section?.text })
+            "
+          >
+            {{ section.text }}
+          </RplTextLink>
+          <template v-else>{{ section.text }}</template>
           <RplIcon
-            v-if="isExpandable"
+            v-if="canExpand"
             role="presentation"
             name="icon-chevron-down"
             size="xs"
@@ -117,9 +133,10 @@ const handleClick = (event) => {
     </div>
 
     <component
-      :is="isExpandable ? RplExpandable : 'div'"
-      :expanded="isExpandable ? isExpanded : undefined"
-      v-bind="isExpandable ? triggerProps : null"
+      :is="canExpand ? RplExpandable : 'div'"
+      v-if="!singleLevel"
+      :expanded="canExpand ? isExpanded : undefined"
+      v-bind="canExpand ? triggerProps : null"
     >
       <RplList
         :items="items"

--- a/packages/ripple-ui-core/src/components/footer/constants.ts
+++ b/packages/ripple-ui-core/src/components/footer/constants.ts
@@ -6,6 +6,7 @@ export const RplFooterVariants = ['default', 'neutral'] as const
 export interface INavSectionItem {
   text: string
   url?: string
+  single?: boolean
   items?: {
     text: string
     url: string

--- a/packages/ripple-ui-core/src/components/footer/fixtures/sample.ts
+++ b/packages/ripple-ui-core/src/components/footer/fixtures/sample.ts
@@ -1,7 +1,7 @@
 export const RplFooterLinks = [
   {
     text: 'Your Services',
-    url: '#',
+    url: '#services',
     items: [
       {
         text: 'Grants awards and assistance',
@@ -51,11 +51,11 @@ export const RplFooterLinks = [
   },
   {
     text: 'News',
-    url: '#'
+    url: '#news'
   },
   {
     text: 'About VIC Government - A very long title to test wrapping behaviour',
-    url: '#',
+    url: '#about',
     items: [
       {
         text: 'Grants awards and assistance',
@@ -105,7 +105,7 @@ export const RplFooterLinks = [
   },
   {
     text: 'Events',
-    url: '#'
+    url: '#events'
   },
   {
     text: 'Connect with us',
@@ -135,6 +135,56 @@ export const RplFooterLinks = [
         text: 'Youtube',
         url: '#',
         icon: 'icon-youtube'
+      }
+    ]
+  }
+]
+
+export const RplFooterLinksSingleLevel = [
+  {
+    text: 'Your Services',
+    url: '#services',
+    single: true,
+    items: [
+      {
+        text: 'Law and safety',
+        url: '#'
+      }
+    ]
+  },
+  {
+    text: 'About us',
+    url: '#about',
+    single: true
+  },
+  {
+    text: 'Latest News',
+    url: '#news',
+    single: true
+  },
+  {
+    text: 'Upcoming Events',
+    url: '#events',
+    single: true
+  },
+  {
+    text: 'Connect with us',
+    url: '',
+    items: [
+      {
+        text: 'DH Twitter',
+        url: '#',
+        icon: 'icon-x'
+      },
+      {
+        text: 'DFFH LinkedIn',
+        url: '#',
+        icon: 'icon-linkedin'
+      },
+      {
+        text: 'DFFH Facebook',
+        url: '#',
+        icon: 'icon-facebook'
       }
     ]
   }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: 
https://digital-vic.atlassian.net/browse/R20-1807
https://digital-vic.atlassian.net/browse/R20-1806

### What I did
<!-- Summary of changes made in the Pull Request  -->
- allow single level only menu sections in footer nav (no repeating links)
- this also includes a fetaureFlag to see this per site

<img width="1101" alt="Screenshot 2024-03-06 at 9 21 31 am" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/261471f8-63b4-42ce-bbcd-fd89bc2aa0b9">
<img width="409" alt="Screenshot 2024-03-06 at 9 21 44 am" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/3493aed0-0669-4f27-9b97-02784df74029">

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added cypress tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

