### PR TITLE
[R20-1740] Update keyword in `noResults` component

### DIFF
--- a/packages/ripple-tide-search/components/TideSearchPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchPage.vue
@@ -301,6 +301,7 @@ watch(
               <TideSearchError v-if="searchState.error" />
               <TideSearchNoResults
                 v-else-if="!searchState.isLoading && !searchState.totalResults"
+                :query="searchState.searchTerm"
               />
               <RplResultListing v-else>
                 <RplResultListingItem

--- a/packages/ripple-tide-search/components/global/TideSearchNoResults.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchNoResults.vue
@@ -17,15 +17,15 @@
 </template>
 
 <script setup lang="ts">
-import { useRoute, computed } from '#imports'
+import { useRoute, ref } from '#imports'
 
 interface Props {
-  query?: string | undefined
+  query?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   query: undefined
 })
 
-const displayQuery = computed(() => props.query || useRoute().query?.q)
+const displayQuery = ref<string>(props.query || (useRoute().query?.q as string))
 </script>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1740

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Pass current keyword through to `noResults` when refetching after initial load (currently uses initial page load `useRoute().query` which never updates)
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

