### PR TITLE
[R20-1615] don't show no-results message before searching

### DIFF
--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -4,7 +4,7 @@
     <RplContent v-if="searchState.error">
       <p>Sorry! Something went wrong. Please try again later.</p>
     </RplContent>
-    <RplContent v-else-if="!searchState.isLoading && !searchState.totalResults">
+    <RplContent v-else-if="searchComplete && !searchState.totalResults">
       <p>Sorry! We couldn't find any matches.</p>
     </RplContent>
     <div v-else>
@@ -149,7 +149,7 @@ const searchDriverOptions = {
   }
 }
 
-const { results, searchState } = await useSearchUI(
+const { results, searchState, searchComplete } = await useSearchUI(
   apiConnectorOptions,
   searchDriverOptions,
   [],

--- a/packages/ripple-tide-search/components/TideSearchPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchPage.vue
@@ -91,7 +91,8 @@ const {
   searchTermSuggestions,
   results,
   staticFacetOptions,
-  filterFormValues
+  filterFormValues,
+  searchComplete
 } = await useSearchUI(
   apiConnectorOptions,
   props.searchDriverOptions,
@@ -300,7 +301,7 @@ watch(
             >
               <TideSearchError v-if="searchState.error" />
               <TideSearchNoResults
-                v-else-if="!searchState.isLoading && !searchState.totalResults"
+                v-else-if="searchComplete && !searchState.totalResults"
               />
               <RplResultListing v-else>
                 <RplResultListingItem

--- a/packages/ripple-tide-search/components/TideSearchPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchPage.vue
@@ -301,7 +301,11 @@ watch(
             >
               <TideSearchError v-if="searchState.error" />
               <TideSearchNoResults
-                v-else-if="searchComplete && !searchState.totalResults"
+                v-else-if="
+                  searchComplete &&
+                  !searchState.isLoading &&
+                  !searchState.totalResults
+                "
                 :query="searchState.searchTerm"
               />
               <RplResultListing v-else>

--- a/packages/ripple-tide-search/composables/useSearchUI.ts
+++ b/packages/ripple-tide-search/composables/useSearchUI.ts
@@ -43,6 +43,7 @@ export default async (
       }, {})
     }
   })
+  const searchComplete = ref(false)
   const searchDriver = getSearchDriver(apiConnectorOptions, config)
   const searchState = ref(searchDriver.getState())
   const urlManager = ref(searchDriver.URLManager)
@@ -72,6 +73,10 @@ export default async (
   )
 
   searchDriver.subscribeToStateChanges((state: SearchState) => {
+    if (!state.isLoading && searchState.value.isLoading) {
+      searchComplete.value = true
+    }
+
     searchState.value = state
   })
 
@@ -140,6 +145,7 @@ export default async (
     searchTermSuggestions,
     results,
     staticFacetOptions,
-    filterFormValues
+    filterFormValues,
+    searchComplete
   }
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1615

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Don't show no-results message before searching, this applies to the main search page and content collections

![search-loading](https://github.com/dpc-sdp/ripple-framework/assets/287178/bff20d92-3710-41b5-913f-e6c891b610c4)


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

