### PR TITLE
[R20-1828] make popup section props the same

### DIFF
--- a/packages/ripple-tide-search/components/global/TideSearchListingResultsMap.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchListingResultsMap.vue
@@ -24,7 +24,7 @@
           <component
             :is="popup.title.component"
             v-if="popup.title.component"
-            :selectedFeature="selectedFeatures[0]"
+            :feature="selectedFeatures[0]"
           ></component>
           <span v-else-if="popup.title.objKey">
             {{ getTitle(selectedFeatures[0]) }}


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1828

### What I did
<!-- Summary of changes made in the Pull Request  -->
- I don't believe this has been used yet, so I'm just making the props for the popupTitle and popupContent components the same, i.e. they're both take a `feature` props now instead of one being `feature` and the other being `selectedFeature`

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

