### PR TITLE
[R20-1822] add a "stacked" version of the cta card

### DIFF
--- a/packages/ripple-tide-landing-page/mapping/components/call-to-action/call-to-action.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/call-to-action/call-to-action.ts
@@ -1,5 +1,6 @@
 import {
   getBody,
+  getField,
   getImageFromField,
   getLinkFromField
 } from '@dpc-sdp/ripple-tide-api'
@@ -25,16 +26,19 @@ export const callToActionMapping = (
   )
 
   const link = getLinkFromField(field, 'field_paragraph_cta')
+  const style = getField(field, 'field_paragraph_cta_style')
 
   return {
     component: 'TideLandingPageCallToAction',
     id: field.drupal_internal__id,
+    layout: style === 'card' ? 'card' : undefined,
     props: {
       title: field.field_paragraph_title,
       image: image,
       url: link?.url,
       ctaText: link?.text,
-      summary: getBody(field.field_paragraph_body?.processed)
+      summary: getBody(field.field_paragraph_body?.processed),
+      stacked: style === 'card'
     }
   }
 }

--- a/packages/ripple-ui-core/src/components/card/RplCallToActionCard.stories.mdx
+++ b/packages/ripple-ui-core/src/components/card/RplCallToActionCard.stories.mdx
@@ -6,6 +6,7 @@ import {
 } from '@storybook/addon-docs'
 import RplCallToAction from './RplCallToActionCard.vue'
 import { a11yStoryCheck } from './../../../stories/interactions.js'
+import { bpMin } from '../../lib/breakpoints'
 
 export const SingleTemplate = (args) => ({
   components: { RplCallToAction },
@@ -35,6 +36,12 @@ export const SingleTemplate = (args) => ({
 <Meta
   title='Core/Navigation/Card'
   component={RplCallToAction}
+  parameters={{
+    layout: 'fullscreen',
+    chromatic: {
+      viewports: [bpMin.s, bpMin.l]
+    }
+  }}
   argTypes={{
     number: {
       control: { type: 'select' },
@@ -80,6 +87,18 @@ export const SingleTemplate = (args) => ({
   <Story
     name='Call to action'
     play={a11yStoryCheck}
+  >
+    {SingleTemplate.bind()}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Call to action - Stacked'
+    play={a11yStoryCheck}
+    args={{
+      stacked: true
+    }}
   >
     {SingleTemplate.bind()}
   </Story>

--- a/packages/ripple-ui-core/src/components/card/RplCallToActionCard.vue
+++ b/packages/ripple-ui-core/src/components/card/RplCallToActionCard.vue
@@ -10,6 +10,7 @@ import {
   useRippleEvent,
   rplEventPayload
 } from '../../composables/useRippleEvent'
+import { computed } from 'vue'
 
 interface Props {
   el?: (typeof RplCardElements)[number]
@@ -18,6 +19,7 @@ interface Props {
   url?: string
   ctaText?: string
   variant?: (typeof RplButtonVariants)[number]
+  stacked?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -25,7 +27,8 @@ const props = withDefaults(defineProps<Props>(), {
   image: undefined,
   url: undefined,
   variant: 'filled',
-  ctaText: 'Call to action'
+  ctaText: 'Call to action',
+  stacked: false
 })
 
 const emit = defineEmits<{
@@ -49,13 +52,18 @@ const handleClick = () => {
     { global: true }
   )
 }
+
+const classes = computed(() => ({
+  'rpl-card--inset': true,
+  'rpl-card--call-to-action-stacked': props.stacked
+}))
 </script>
 
 <template>
   <RplCard
     ref="container"
     type="call-to-action"
-    class="rpl-card--inset"
+    :class="classes"
     :link="url"
     :el="el"
   >

--- a/packages/ripple-ui-core/src/components/card/RplCard.css
+++ b/packages/ripple-ui-core/src/components/card/RplCard.css
@@ -259,6 +259,26 @@
     }
   }
 
+  &--call-to-action-stacked {
+    @media (--rpl-bp-l) {
+      align-items: initial;
+      flex-direction: column;
+
+      .rpl-card__upper {
+        flex-basis: auto;
+      }
+
+      .rpl-card__media--inset {
+        margin-bottom: 0;
+        height: calc(100% - var(--rpl-sp-8));
+      }
+
+      .rpl-card__upper + .rpl-card__body {
+        margin-left: var(--rpl-sp-8);
+      }
+    }
+  }
+
   &--category-grid {
     background-color: transparent;
     border-radius: 0;


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1822

### What I did
<!-- Summary of changes made in the Pull Request  -->
- add a "stacked" version of the cta card


<img width="1081" alt="Screenshot 2024-03-18 at 4 21 17 PM" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/41b6dd84-80f2-4bd2-97c3-3a4228015114">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

