### PR TITLE
[R20-1825] bring content collection inline with search etc.

### DIFF
--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -88,6 +88,7 @@ const cardClasses = computed(() =>
 )
 
 const searchResultsMappingFn = (item): any => {
+  const { $app_origin } = useNuxtApp()
   const rawUpdated = item.changed?.raw?.[0]
   const rawImage = item.field_media_image_absolute_path?.raw?.[0]
 
@@ -96,7 +97,7 @@ const searchResultsMappingFn = (item): any => {
     props: {
       el: 'li',
       title: item.title?.raw?.[0],
-      url: item.url?.raw?.[0].replace(/\/site-(\d+)/, ''),
+      url: item.url?.raw?.[0].replace(/\/site-(\d+)/, $app_origin || ''),
       image:
         props.display.style === 'thumbnail' && rawImage
           ? { src: rawImage }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1825

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Bring content collection inline with search/search listings/topics etc, by this I mean display the full URL instead or the relative one in the search result.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

