### PR TITLE
feat: make links relative to avoid full refresh

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/home.feature
+++ b/examples/nuxt-app/test/features/landingpage/home.feature
@@ -1,6 +1,7 @@
 Feature: Home page
 
   Example of mocked page
+
   Background:
     Given the page endpoint for path "/" returns fixture "/landingpage/home" with status 200
     And the site endpoint returns fixture "/site/reference" with status 200
@@ -15,6 +16,12 @@ Feature: Home page
   Scenario: Hero header
     Then the hero title should be "Test landing page title"
     Then the hero intro text should be "Test landing page title introduction text"
+    And the hero should display the following items
+      | text               | url                                               |
+      | Test link 1        | /embedded-video-test                              |
+      | Test link 2        | /sdpta-statistics-grid-eight-landing-page-fixture |
+      | Test link 3        | /sdpta-accordion-landing-page-fixture             |
+      | Test link external | https://www.vic.gov.au/                           |
 
   @mockserver
   Scenario: Hero acknowledgement

--- a/examples/nuxt-app/test/features/search-listing/grants.feature
+++ b/examples/nuxt-app/test/features/search-listing/grants.feature
@@ -18,8 +18,8 @@ Feature: Grants collection
     And the search network request should be called with the "/search-listing/grants/request" fixture
     And the grant search listing results should have following items:
       | title                                | url                                                       | updated             | content                                                                                                                                            | audience                          | amount            | status                    |
-      | THIS IS A TEST                       | https://localhost:3000/tc-9b-grant-page-closed            | Updated: 9 May 2023 | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. | Business                          | $11,326 - $26,494 | Closed                    |
-      | TC-9a Grant Simple Test - Date Range | https://localhost:3000/tc-9a-grant-simple-test-date-range | Updated: 9 May 2023 | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. | Not-for-profit groups, government | $11,326 - $26,494 | Open, closing in 163 days |
+      | THIS IS A TEST                       | /tc-9b-grant-page-closed            | Updated: 9 May 2023 | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. | Business                          | $11,326 - $26,494 | Closed                    |
+      | TC-9a Grant Simple Test - Date Range | /tc-9a-grant-simple-test-date-range | Updated: 9 May 2023 | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. | Not-for-profit groups, government | $11,326 - $26,494 | Open, closing in 163 days |
 
   @mockserver
   Example: Grant status filter - Open

--- a/examples/nuxt-app/test/fixtures/landingpage/home.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/home.json
@@ -109,6 +109,10 @@
         {
           "text": "Test link 3",
           "url": "/sdpta-accordion-landing-page-fixture"
+        },
+        {
+          "text": "Test link external",
+          "url": "https://www.vic.gov.au/"
         }
       ],
       "more": {

--- a/packages/nuxt-ripple/components/global/RplLink.vue
+++ b/packages/nuxt-ripple/components/global/RplLink.vue
@@ -3,11 +3,21 @@ interface IRplLinkProps {
   url: string
 }
 
-withDefaults(defineProps<IRplLinkProps>(), {})
+const props = withDefaults(defineProps<IRplLinkProps>(), {})
+
+const { $app_origin } = useNuxtApp()
+
+const link = computed(() => {
+  if ($app_origin && props.url?.startsWith($app_origin)) {
+    return props.url.replace($app_origin, '')
+  }
+
+  return props.url
+})
 </script>
 
 <template>
-  <NuxtLink ref="link" :href="url">
+  <NuxtLink ref="link" :href="link">
     <slot />
   </NuxtLink>
 </template>

--- a/packages/ripple-test-utils/step_definitions/content-types/landing-page.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/landing-page.ts
@@ -1,4 +1,4 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor'
+import { Then, DataTable } from '@badeball/cypress-cucumber-preprocessor'
 
 Then('the landing page component with ID {int} should exist', (id: number) => {
   cy.get(`[data-component-id="${id}"]`).should('exist')
@@ -25,6 +25,22 @@ Then('the hero title should be {string}', (title: string) => {
 
 Then('the hero intro text should be {string}', (introText: string) => {
   cy.get('[data-cy="hero-summary"]').should('have.text', introText)
+})
+
+Then('the hero should display the following items', (dataTable: DataTable) => {
+  const table = dataTable.hashes()
+
+  cy.get(`.rpl-header-links__list a`).as('links')
+
+  table.forEach((row, i: number) => {
+    cy.get('@links')
+      .eq(i)
+      .then((item) => {
+        cy.wrap(item).as('item')
+        cy.get('@item').should('contain', row.text)
+        cy.get('@item').should('have.attr', 'href', row.url)
+      })
+  })
 })
 
 Then(


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- **TO DISCUSS**: This is a simple change but potentially controversial as it's effects all links, the upside of this method is we get client side routing for search results, search listings, custom collections, content collections, topic tags, etc.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

