### PR TITLE
[R20-1834] add styles only for initially open sections

### DIFF
--- a/packages/ripple-ui-core/src/components/expandable/RplExpandable.vue
+++ b/packages/ripple-ui-core/src/components/expandable/RplExpandable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useComputedSpeed } from '../../composables/useComputedSpeed'
 
 interface Props {
@@ -11,6 +11,7 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const containerRef = ref(null)
+const startExpanded = ref(false)
 const duration = useComputedSpeed(containerRef, '--rpl-motion-speed-9', 420)
 
 function onBeforeEnter(el: any) {
@@ -47,8 +48,15 @@ function onLeave(el: any, done: Function) {
 
 const classes = computed(() => ({
   'rpl-expandable': true,
-  'rpl-expandable--open': props.expanded
+  'rpl-expandable--open': props.expanded,
+  'rpl-expandable--start-expanded': startExpanded.value
 }))
+
+onMounted(() => {
+  if (props.expanded) {
+    startExpanded.value = true
+  }
+})
 </script>
 
 <template>
@@ -77,7 +85,7 @@ const classes = computed(() => ({
   }
 }
 
-.rpl-expandable--open {
+.rpl-expandable--start-expanded {
   height: auto;
   overflow: initial;
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1834

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add styles only for initially open sections so content doesn't overflow on first open

![refine-search](https://github.com/dpc-sdp/ripple-framework/assets/287178/622057b3-a88b-440e-9396-c66ae5c7c405)

- This still works for the search listings that start with the filters open

![open-by-default](https://github.com/dpc-sdp/ripple-framework/assets/287178/cdfc3f61-1b0d-4554-aa67-60f21cc2ed68)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

