### PR TITLE
[SRM-1284] use tide version of secondary campaign

### DIFF
--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -479,7 +479,9 @@ watch(
     </template>
     <template #belowBody>
       <RplPageComponent v-if="contentPage.secondaryCampaign">
-        <RplSecondaryCampaign v-bind="contentPage.secondaryCampaign as any" />
+        <TideLandingPageSecondaryCampaignBanner
+          :campaign="contentPage.secondaryCampaign"
+        />
       </RplPageComponent>
     </template>
   </TideBaseLayout>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SRM-1284

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Use TideSecondaryCampaign so secondary banner works 

<img width="926" alt="Screenshot 2024-03-21 at 10 51 17 AM" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/adb65972-aa7e-4e17-a526-8de34da69591">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

