### PR TITLE
[R20-1813] make custom collection expanded config the same as search listings

### DIFF
--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -17,7 +17,6 @@ interface Props {
   introText?: string
   autocompleteQuery?: boolean
   searchListingConfig?: TideSearchListingConfig['searchListingConfig']
-  showFiltersOnLoad?: boolean
   sortOptions?: TideSearchListingConfig['sortOptions']
   queryConfig: TideSearchListingConfig['queryConfig']
   globalFilters?: TideSearchListingConfig['globalFilters']
@@ -64,7 +63,8 @@ const props = withDefaults(defineProps<Props>(), {
       key: 'title',
       enabled: false
     },
-    formTheme: 'default'
+    formTheme: 'default',
+    showFiltersOnLoad: false
   }),
   tabs: () => [
     {
@@ -78,7 +78,6 @@ const props = withDefaults(defineProps<Props>(), {
       icon: 'list'
     }
   ],
-  showFiltersOnLoad: false,
   resultsConfig: () => ({
     layout: {
       component: 'TideSearchResultsList'
@@ -155,7 +154,7 @@ const mapResultsMappingFn = (result) => {
   }
 }
 
-const filtersExpanded = ref(props.showFiltersOnLoad)
+const filtersExpanded = ref(props.searchListingConfig?.showFiltersOnLoad)
 
 const {
   isBusy,

--- a/packages/ripple-tide-search/components/global/TideTideSearchListing.vue
+++ b/packages/ripple-tide-search/components/global/TideTideSearchListing.vue
@@ -60,6 +60,5 @@ const searchResultsMappingFn = (item: any): TideSearchListingResultItem => {
     :belowFilterComponent="page.config?.layoutConfig?.belowFilter"
     :searchResultsMappingFn="(searchResultsMappingFn as any)"
     :sortOptions="page.config.sortOptions"
-    :showFiltersOnLoad="page.config.showFiltersOnLoad"
   />
 </template>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1813

### What I did
<!-- Summary of changes made in the Pull Request  -->
- make custom collection expanded config the same as search listings
- remove unused showFiltersOnLoad prop from search listing

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

