### PR TITLE
feat(@dpc-sdp/ripple-tide-api): allow the merging of page and site mapping

### DIFF
--- a/packages/ripple-tide-api/src/services/__test__/tide-api-base.test.ts
+++ b/packages/ripple-tide-api/src/services/__test__/tide-api-base.test.ts
@@ -1,47 +1,13 @@
 import { expect, describe, it } from '@jest/globals'
 import TideApiBase from './../tide-api-base'
+import { exampleConfig, exampleApiConfig, mockLogger } from './tide-config'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 const mockClient = new MockAdapter(axios)
 
-const mockLogger = {
-  log: jest.fn(),
-  debug: jest.fn(),
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn()
-}
-
-const exampleMapping = {
-  includes: [],
-  mapping: {
-    test: 'field'
-  }
-}
-
-const exampleApiConnection = {
-  site: '123',
-  baseUrl: ''
-}
-
-const exampleApiConfig = {
-  apiPrefix: '/api/v1'
-}
-
 describe('TideApiBase', () => {
   describe('getMappedData', () => {
-    const tideApiBase = new TideApiBase(
-      {
-        ...exampleApiConnection,
-        debug: false,
-        mapping: {
-          site: exampleMapping,
-          event: exampleMapping
-        },
-        ...exampleApiConfig
-      },
-      mockLogger
-    )
+    const tideApiBase = new TideApiBase(exampleConfig, mockLogger)
     it('should return mapped data', async () => {
       const mapping = {
         stringField: 'title',
@@ -76,18 +42,7 @@ describe('TideApiBase', () => {
     })
   })
   describe('get', () => {
-    const tideApiBase = new TideApiBase(
-      {
-        ...exampleApiConnection,
-        debug: false,
-        mapping: {
-          site: exampleMapping,
-          event: exampleMapping
-        },
-        ...exampleApiConfig
-      },
-      mockLogger
-    )
+    const tideApiBase = new TideApiBase(exampleConfig, mockLogger)
     it('should call http client get method', async () => {
       mockClient.onGet(`${exampleApiConfig.apiPrefix}/site`).reply(
         200,

--- a/packages/ripple-tide-api/src/services/__test__/tide-config.ts
+++ b/packages/ripple-tide-api/src/services/__test__/tide-config.ts
@@ -1,0 +1,33 @@
+export const mockLogger = {
+  log: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}
+
+export const exampleMapping = {
+  includes: [],
+  mapping: {
+    test: 'field'
+  }
+}
+
+export const exampleApiConnection = {
+  site: '123',
+  baseUrl: ''
+}
+
+export const exampleApiConfig = {
+  apiPrefix: '/api/v1'
+}
+
+export const exampleConfig = {
+  ...exampleApiConnection,
+  mapping: {
+    site: exampleMapping,
+    event: exampleMapping
+  },
+  ...exampleApiConfig,
+  debug: false
+}

--- a/packages/ripple-tide-api/src/services/__test__/tide-page.test.ts
+++ b/packages/ripple-tide-api/src/services/__test__/tide-page.test.ts
@@ -1,0 +1,36 @@
+import { expect, describe, it } from '@jest/globals'
+import TidePageApi from './../tide-page'
+import { exampleConfig, mockLogger } from './tide-config'
+
+describe('TidePageApi', () => {
+  describe('setContentMapping', () => {
+    const tidePageApi = new TidePageApi(exampleConfig, mockLogger)
+
+    it('should allow extending content type mapping', async () => {
+      const type = 'landing_page'
+
+      tidePageApi.setContentType(type, {
+        mapping: {
+          testSoloPageMappingItem: 'test_solo_page_mapping_item'
+        }
+      })
+      tidePageApi.setContentType(type, {
+        includes: ['test_solo_page_include_item']
+      })
+      tidePageApi.setContentType(type, {
+        mapping: {
+          testPageMappingItem: 'test_page_mapping_item'
+        },
+        includes: ['test_page_include_item']
+      })
+
+      expect(tidePageApi.contentTypes[type]).toEqual({
+        mapping: {
+          testPageMappingItem: 'test_page_mapping_item',
+          testSoloPageMappingItem: 'test_solo_page_mapping_item'
+        },
+        includes: ['test_page_include_item', 'test_solo_page_include_item']
+      })
+    })
+  })
+})

--- a/packages/ripple-tide-api/src/services/__test__/tide-site.test.ts
+++ b/packages/ripple-tide-api/src/services/__test__/tide-site.test.ts
@@ -1,0 +1,34 @@
+import { expect, describe, it } from '@jest/globals'
+import TideSiteApi from './../tide-site'
+import { exampleConfig, mockLogger } from './tide-config'
+
+describe('TideSiteApi', () => {
+  describe('setSiteMapping', () => {
+    const tideSiteApi = new TideSiteApi(exampleConfig, mockLogger)
+
+    it('should allow extending site mapping', async () => {
+      tideSiteApi.setSiteMapping({
+        mapping: {
+          testSoloSiteMappingItem: 'test_solo_site_mapping_item'
+        }
+      })
+      tideSiteApi.setSiteMapping({
+        includes: ['test_solo_site_include_item']
+      })
+      tideSiteApi.setSiteMapping({
+        mapping: {
+          testSiteMappingItem: 'test_site_mapping_item'
+        },
+        includes: ['test_site_include_item']
+      })
+
+      expect(tideSiteApi.siteMapping).toEqual({
+        mapping: {
+          testSiteMappingItem: 'test_site_mapping_item',
+          testSoloSiteMappingItem: 'test_solo_site_mapping_item'
+        },
+        includes: ['test_site_include_item', 'test_solo_site_include_item']
+      })
+    })
+  })
+})

--- a/packages/ripple-tide-api/src/services/tide-page.ts
+++ b/packages/ripple-tide-api/src/services/tide-page.ts
@@ -8,6 +8,7 @@ import type {
 } from './../../types'
 import { ApplicationError, NotFoundError } from '../errors/errors.js'
 import { ILogger } from '../logger/logger'
+import { defu as defuMerge } from 'defu'
 
 export default class TidePageApi extends TideApiBase {
   contentTypes: {
@@ -31,6 +32,8 @@ export default class TidePageApi extends TideApiBase {
   setContentType(key, value) {
     if (!this.contentTypes[key]) {
       this.contentTypes[key] = value
+    } else {
+      this.contentTypes[key] = defuMerge(value, this.contentTypes[key])
     }
   }
 

--- a/packages/ripple-tide-api/src/services/tide-site.ts
+++ b/packages/ripple-tide-api/src/services/tide-site.ts
@@ -3,6 +3,7 @@ import TideApiBase from './tide-api-base.js'
 import type { RplTideModuleConfig, IRplTideModuleMapping } from './../../types'
 import { ApplicationError } from '../errors/errors.js'
 import { ILogger } from '../logger/logger'
+import { defu as defuMerge } from 'defu'
 
 export default class TideSite extends TideApiBase {
   site: string
@@ -16,7 +17,11 @@ export default class TideSite extends TideApiBase {
   }
 
   setSiteMapping(siteMapping) {
-    this.siteMapping = siteMapping
+    if (!this.siteMapping) {
+      this.siteMapping = siteMapping
+    } else {
+      this.siteMapping = defuMerge(siteMapping, this.siteMapping)
+    }
   }
 
   async getSiteData(siteid, logId?: string) {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- This adds support for merging site mapping and content type mapping, for the motivation see: https://github.com/dpc-sdp/ripple-framework/issues/1098 with this change sites wanting to add extra mapping for the site or content types can do so, without having to remember to import the core types and then spread them with their own, making it a nicer/easier experience. 

Note: I had a look and VLA is the only site currently extending site mapping and it's still in development so we can easily switch it over.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

