### PR TITLE
fix(@dpc-sdp/ripple-tide-api): allow the use of a single markup plugin

### DIFF
--- a/packages/ripple-tide-api/src/utils/markup-transpiler/index.ts
+++ b/packages/ripple-tide-api/src/utils/markup-transpiler/index.ts
@@ -14,7 +14,7 @@ const markupTranspiler = (
   const $body = $('body')
   let markupData = {}
 
-  if (Object.keys(plugins).length > 1) {
+  if (Object.keys(plugins).length) {
     // Load plugins to transpile embedded components
     for (const [index, plugin] of plugins.entries()) {
       $.prototype[`plugin${index}`] = plugin

--- a/packages/ripple-tide-api/types.d.ts
+++ b/packages/ripple-tide-api/types.d.ts
@@ -284,7 +284,7 @@ declare module 'nitropack' {
 
 // Mapping util interfaces
 export function getAddress(address: any): string
-export function getBody(body: any): string
+export function getBody(body: any, customPlugins?: (() => void)[]): string
 export function getBodyFromField(
   field: string,
   path: string | string[],


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Markup plugins current only run if you supply more than 1, however you should be able to use a single plugin if you want

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

