### PR TITLE
[R20-1981] fix search listing dropdowns

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/aggregations.feature
+++ b/examples/nuxt-app/test/features/search-listing/aggregations.feature
@@ -11,7 +11,6 @@ Feature: Search listing - Aggregations
   Example: Aggregations and Taxonomies
     Given the page endpoint for path "/aggregations" returns fixture "/search-listing/aggregations/page" with status 200
     And the search network request is stubbed with fixture "/search-listing/aggregations/response" and status 200
-    And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
 
     When I visit the page "/aggregations"
     Then the search listing page should have 2 results
@@ -26,6 +25,7 @@ Feature: Search listing - Aggregations
       | Government            |
       | Individual            |
       | Not-for-profit groups |
+    And I click the option labelled "Business" in the selected dropdown
     # Close the dropdown
     When I click the search listing dropdown field labelled "Elastic aggregation test"
 
@@ -34,3 +34,11 @@ Feature: Search listing - Aggregations
     Then the selected dropdown field should have the items:
       | Arts     |
       | Business |
+    And I click the option labelled "Arts" in the selected dropdown
+    And I click the search listing dropdown field labelled "Taxonomy test"
+
+    When I submit the search filters
+    Then the URL should reflect that the current active filters are as follows:
+      | id       | value    |
+      | audience | Business |
+      | topic    | Arts     |

--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -169,9 +169,9 @@ onAggregationUpdateHook.value = (aggs: any) => {
       if (uiFilter.id === key) {
         const getDynamicOptions = () => {
           const mappedOptions = aggs[key].map((item: any) => ({
-            id: item,
-            label: item,
-            value: item
+            id: item.key,
+            label: item.key,
+            value: item.key
           }))
 
           if (uiFilters.value[idx].props?.hasOwnProperty('options')) {

--- a/packages/ripple-tide-search/composables/useTideSearch.ts
+++ b/packages/ripple-tide-search/composables/useTideSearch.ts
@@ -178,7 +178,7 @@ export default ({
                 field: currentFilter.aggregations.field,
                 order: { _key: 'asc' },
                 size: currentFilter.aggregations.size || 30,
-                min_doc_count: 0
+                min_doc_count: searchListingConfig?.dynamicAggregations ? 0 : 1
               }
             }
           }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1981

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Fix the search listing dropdowns that use elasticsearch, ref: https://www.v2.www.vic.gov.au/family-violence-recommendations
- Also updated the `min_doc_count` param so 'empty' results are only returned when using `dynamicAggregations`, this essentially reverts the default behavior back to how it was, i.e elastic aggregation only return items with docs

### Issue

![search-listing-dropdowns](https://github.com/dpc-sdp/ripple-framework/assets/287178/1d397327-1684-48c7-9134-a0bed3435b8c)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

