### PR TITLE
fix(@dpc-sdp/nuxt-ripple): :bug: fallback to default if unspecified

### DIFF
--- a/examples/nuxt-app/pages/_layout.vue
+++ b/examples/nuxt-app/pages/_layout.vue
@@ -1,0 +1,14 @@
+<template>
+  <TideLandingPage :site="site as any" :page="page as any">
+    <template #sidebar>
+      <TideSidebarSocialShare :page-title="page.title" />
+    </template>
+  </TideLandingPage>
+</template>
+
+<script setup lang="ts">
+import page from '../test/fixtures/case/accordions-inpage-nav.json'
+import { useTideSite } from '#imports'
+
+const site = await useTideSite()
+</script>

--- a/packages/nuxt-ripple/components/TideSidebarSocialShare.vue
+++ b/packages/nuxt-ripple/components/TideSidebarSocialShare.vue
@@ -30,13 +30,14 @@ const url = computed(() => `${$app_origin}${route?.path}`)
 const { socialShare: flags }: IRplFeatureFlags = inject('featureFlags', {})
 
 const activeNetworks = computed(() => {
-  const items = props.networks?.filter(
-    (item: any) => flags?.[item as keyof TideSocialShare] ?? true
-  )
+  const items =
+    props.networks?.filter(
+      (item: any) => flags?.[item as keyof TideSocialShare] ?? true
+    ) || []
   if (flags?.WhatsApp) {
     items.push('WhatsApp')
   }
-  return items
+  return items.length > 0 ? items : undefined
 })
 
 const parseText = (text: string): string => {

--- a/packages/nuxt-ripple/components/TideSidebarSocialShare.vue
+++ b/packages/nuxt-ripple/components/TideSidebarSocialShare.vue
@@ -30,7 +30,7 @@ const url = computed(() => `${$app_origin}${route?.path}`)
 const { socialShare: flags }: IRplFeatureFlags = inject('featureFlags', {})
 
 const activeNetworks = computed(() => {
-  let items = props.networks.filter(
+  const items = props.networks?.filter(
     (item: any) => flags?.[item as keyof TideSocialShare] ?? true
   )
   if (flags?.WhatsApp) {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- If `props.network` is not present, pass `undefined` to fallback to component's default networks (matching previous behaviour)
-

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

