### PR TITLE
[R20-1978] focus state for scrolling tables

### DIFF
--- a/packages/ripple-tide-api/src/utils/markup-transpiler/cheerio.test.ts
+++ b/packages/ripple-tide-api/src/utils/markup-transpiler/cheerio.test.ts
@@ -20,7 +20,7 @@ const markup = {
 }
 
 const fixed = {
-  table: `<div class="rpl-table"><div class="rpl-table__scroll-container" tabindex="0"><table>
+  table: `<div class="rpl-table"><div class="rpl-table__scroll-container rpl-u-focusable-outline--visible" tabindex="0"><table>
   <tbody>
     <tr><th>Fname</th><th>Lname</th></tr>
     <tr><td>Joe</td><td>Cool</td></tr>

--- a/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
+++ b/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
@@ -6,7 +6,9 @@ const pluginTables = function (this: any) {
     const $table = this.find(el)
     return $table
       .wrap(`<div class="rpl-table"></div>`)
-      .wrap('<div class="rpl-table__scroll-container" tabindex="0"></div>')
+      .wrap(
+        '<div class="rpl-table__scroll-container rpl-u-focusable-outline--visible" tabindex="0"></div>'
+      )
   })
 }
 

--- a/packages/ripple-ui-core/src/components/content/RplContent.stories.mdx
+++ b/packages/ripple-ui-core/src/components/content/RplContent.stories.mdx
@@ -399,7 +399,7 @@ export const SingleTemplate = (args) => ({
     play={a11yStoryCheck}
     args={{html: `
      <div class="rpl-storybook__page-content rpl-table">
-      <div class="rpl-table__scroll-container" tabindex="0">
+      <div class="rpl-table__scroll-container rpl-u-focusable-outline--visible" tabindex="0">
         <table>
           <caption>Optional table caption</caption>
           <thead>

--- a/packages/ripple-ui-core/src/components/content/fixtures/testcontent.html
+++ b/packages/ripple-ui-core/src/components/content/fixtures/testcontent.html
@@ -175,7 +175,7 @@
 </figure>
 
 <div class="rpl-table">
-  <div class="rpl-table__scroll-container" tabindex="0">
+  <div class="rpl-table__scroll-container rpl-u-focusable-outline--visible" tabindex="0">
     <table>
       <tbody>
         <tr>
@@ -208,7 +208,7 @@
 </div>
 
 <div class="rpl-table">
-  <div class="rpl-table__scroll-container" tabindex="0">
+  <div class="rpl-table__scroll-container rpl-u-focusable-outline--visible" tabindex="0">
     <table>
       <thead>
         <tr>
@@ -254,7 +254,7 @@
 </div>
 
 <div class="rpl-table">
-  <div class="rpl-table__scroll-container" tabindex="0">
+  <div class="rpl-table__scroll-container rpl-u-focusable-outline--visible" tabindex="0">
     <table>
       <caption>
         Optional table caption

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.vue
@@ -64,7 +64,10 @@ const displayMobileView: ComputedRef<boolean> = computed(() => {
       'rpl-data-table--mobile': displayMobileView
     }"
   >
-    <div class="rpl-table__scroll-container" tabindex="0">
+    <div
+      class="rpl-table__scroll-container rpl-u-focusable-outline--visible"
+      tabindex="0"
+    >
       <table>
         <caption v-if="caption">
           {{

--- a/packages/ripple-ui-core/src/styles/utilities/_focus.css
+++ b/packages/ripple-ui-core/src/styles/utilities/_focus.css
@@ -125,3 +125,19 @@
     }
   }
 }
+
+.rpl-u-focusable-outline--visible {
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 var(--rpl-border-1) var(--rpl-clr-dark) inset,
+    0 0 0 var(--rpl-border-3) var(--rpl-clr-focus);
+  }
+
+  &.rpl-u-focusable--alt-colour {
+    &:focus-visible {
+      box-shadow: 0 0 0 var(--rpl-border-1) var(--rpl-clr-type-primary-contrast)
+      inset,
+      0 0 0 var(--rpl-border-3) var(--rpl-clr-focus);
+    }
+  }
+}


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1978

### What I did
<!-- Summary of changes made in the Pull Request  -->
- add focus state for scrolling tables, needed a new class using focus-visible so the table isn't outline when click around

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

