### PR TITLE
[R20-1519] Hide page updated date for topic/tag/search listing pages

### DIFF
--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -43,6 +43,7 @@ interface Props {
   searchResultsMappingFn?: (item: any) => MappedSearchResult<any>
   contentPage: TideContentPage
   site: TideSiteData
+  showUpdatedDate?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -98,7 +99,8 @@ const props = withDefaults(defineProps<Props>(), {
       }
     }
   },
-  sortOptions: () => []
+  sortOptions: () => [],
+  showUpdatedDate: false
 })
 
 const emit = defineEmits<{
@@ -349,7 +351,9 @@ watch(
     :background="contentPage.background"
     :pageTitle="contentPage.title"
     :pageLanguage="contentPage.lang"
-    :updatedDate="contentPage.changed || contentPage.created"
+    :updatedDate="
+      showUpdatedDate ? contentPage.changed || contentPage.created : null
+    "
     :showContentRating="contentPage.showContentRating"
   >
     <template #breadcrumbs>


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1519

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Hid updated date on search listings and topic/tag listing pages
- Kept it as a prop for future options

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

