### PR TITLE
[SDPAP-9395] remove external link check

### DIFF
--- a/packages/ripple-tide-search/composables/useSearchResult.ts
+++ b/packages/ripple-tide-search/composables/useSearchResult.ts
@@ -9,12 +9,6 @@ export default (result, options: ResultOptions = { summaryMaxLength: 150 }) => {
   const { $app_origin } = useNuxtApp()
   const title = computed(() => getSearchResultValue(result, 'title'))
   const url = computed(() => {
-    const externalURL = getSearchResultValue(result, 'field_node_link')
-
-    if (externalURL) {
-      return externalURL
-    }
-
     return stripSiteId(getSearchResultValue(result, 'url'), $app_origin || '')
   })
   const updated = computed(() => {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SDPAP-9395

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Remove external link check so results always link to result page, currently events search results (with a website link) don't link the event itself

Q: Can anyone think of a search listing/custom collection that links search results directly to an external URL and not the result page itself?

<img width="885" alt="Screenshot 2024-05-29 at 1 12 00 PM" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/4819423c-4478-44af-b6fa-ea78134a8e09">

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

