### PR TITLE
[SDPAP-9395] move external link check to grant result card

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/grants.feature
+++ b/examples/nuxt-app/test/features/search-listing/grants.feature
@@ -13,13 +13,14 @@ Feature: Grants collection
     And the search network request is stubbed with fixture "/search-listing/grants/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
     When I visit the page "/grants"
-    Then the search listing page should have 2 results
+    Then the search listing page should have 3 results
     And the search listing layout should be "list"
     And the search network request should be called with the "/search-listing/grants/request" fixture
     And the grant search listing results should have following items:
-      | title                                | url                                                       | updated             | content                                                                                                                                            | audience                          | amount            | status                    |
-      | THIS IS A TEST                       | /tc-9b-grant-page-closed            | Updated: 9 May 2023 | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. | Business                          | $11,326 - $26,494 | Closed                    |
-      | TC-9a Grant Simple Test - Date Range | /tc-9a-grant-simple-test-date-range | Updated: 9 May 2023 | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. | Not-for-profit groups, government | $11,326 - $26,494 | Open, closing in 163 days |
+      | title                                    | url                                                                        | updated               | content                                                                                                                                               | audience                                         | amount            | status                    |
+      | THIS IS A TEST                           | /tc-9b-grant-page-closed                                                   | Updated: 9 May 2023   | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus.    | Business                                         | $11,326 - $26,494 | Closed                    |
+      | TC-9a Grant Simple Test - Date Range     | /tc-9a-grant-simple-test-date-range                                        | Updated: 9 May 2023   | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus.    | Not-for-profit groups, government                | $11,326 - $26,494 | Open, closing in 163 days |
+      | 2023 Coastcare Victoria Community Grants | https://www.marineandcoasts.vic.gov.au/coastcare-victoria-community-grants | Updated: 8 March 2023 | This year, Coastcare Victoria has $210,000 available for grants of up to $10,000 each. Projects will fit into one of three streams on offer including | Who can apply:Individuals, not-for-profit groups | $1 - $10,000      | Closed                    |
 
   @mockserver
   Example: Grant status filter - Open
@@ -27,7 +28,7 @@ Feature: Grants collection
     And the search network request is stubbed with fixture "/search-listing/grants/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
     When I visit the page "/grants?status=open"
-    Then the search listing page should have 2 results
+    Then the search listing page should have 3 results
     And the search network request should be called with the "/search-listing/grants/request-status-open" fixture
 
   @mockserver
@@ -36,7 +37,7 @@ Feature: Grants collection
     And the search network request is stubbed with fixture "/search-listing/grants/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
     When I visit the page "/grants?status=closed"
-    Then the search listing page should have 2 results
+    Then the search listing page should have 3 results
     And the search network request should be called with the "/search-listing/grants/request-status-closed" fixture
 
   @mockserver
@@ -45,7 +46,7 @@ Feature: Grants collection
     And the search network request is stubbed with fixture "/search-listing/grants/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
     When I visit the page "/grants?status=ongoing"
-    Then the search listing page should have 2 results
+    Then the search listing page should have 3 results
     And the search network request should be called with the "/search-listing/grants/request-status-ongoing" fixture
 
   @mockserver
@@ -54,5 +55,5 @@ Feature: Grants collection
     And the search network request is stubbed with fixture "/search-listing/grants/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
     When I visit the page "/grants?status=opening_soon"
-    Then the search listing page should have 2 results
+    Then the search listing page should have 3 results
     And the search network request should be called with the "/search-listing/grants/request-status-opening-soon" fixture

--- a/examples/nuxt-app/test/fixtures/search-listing/grants/response.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/grants/response.json
@@ -140,6 +140,50 @@
           "uuid": ["244b27ce-634c-4721-b70a-fea107b2ba9f"]
         },
         "sort": [1.0, 3522]
+      },
+      {
+        "_index": "a83890f7a31dea14e1ae83c6f0afacca--elasticsearch_index_production_node",
+        "_id": "entity:node/31026:en",
+        "_score": null,
+        "_ignored": ["field_landing_page_summary.keyword"],
+        "_source": {
+          "_language": "en",
+          "node_grants": ["node_access_all:0"],
+          "url": ["/site-4/2023-coastcare-victoria-community-grants"],
+          "changed": ["2023-03-08T10:26:00+11:00"],
+          "created": ["2023-03-07T11:24:06+11:00"],
+          "field_audience": [80, 82],
+          "field_audience_name": ["Individual", "Not-for-profit groups"],
+          "field_audience_uuid": [
+            "f86a3a17-380b-4840-8d54-195260ac9db1",
+            "4038b20b-a519-4963-9cb6-04364cbe8eba"
+          ],
+          "field_landing_page_summary": [
+            "This year, Coastcare Victoria has $210,000 available for grants of up to $10,000 each. Projects will fit into one of three streams on offer including ‘Stewardship and Education; Strengthening our Volunteer Groups; and Supporting Traditional Owner Self-Determination’."
+          ],
+          "field_node_dates_end_value": ["2023-03-30T11:00:00+11:00"],
+          "field_node_dates_start_value": ["2023-02-20T11:00:00+11:00"],
+          "field_node_link": [
+            "https://www.marineandcoasts.vic.gov.au/coastcare-victoria-community-grants"
+          ],
+          "field_node_on_going": [false],
+          "field_node_primary_csite": [4],
+          "field_node_site": [4],
+          "field_topic": [11],
+          "field_topic_name": ["Environment, water \u0026 energy"],
+          "field_topic_path": ["/topic/environment-water-energy"],
+          "field_topic_uuid": ["56387cfe-be0a-4f5c-b3ca-f980a154699c"],
+          "funding_level_from": [1],
+          "funding_level_to": [10000],
+          "langcode": ["en"],
+          "nid": [31026],
+          "status": [true],
+          "title": ["2023 Coastcare Victoria Community Grants"],
+          "type": ["grant"],
+          "uid": [6087],
+          "uuid": ["e8022205-e15f-4231-ac38-49ed14328823"]
+        },
+        "sort": [1.0, 3522]
       }
     ]
   },

--- a/packages/ripple-tide-grant/components/global/TideGrantSearchResult.vue
+++ b/packages/ripple-tide-grant/components/global/TideGrantSearchResult.vue
@@ -40,13 +40,19 @@ const dateFrom = computed(() =>
 const dateTo = computed(() =>
   getSearchResultValue(props.result, 'field_node_dates_end_value')
 )
+
+const link = computed(() => {
+  const externalURL = getSearchResultValue(props.result, 'field_node_link')
+
+  return externalURL || url.value
+})
 </script>
 
 <template>
   <RplSearchResult
     class="tide-grant-search-result"
     :title="title"
-    :url="url"
+    :url="link"
     :content="summary"
     :updated="updated"
   >

--- a/packages/ripple-tide-search/composables/useSearchResult.ts
+++ b/packages/ripple-tide-search/composables/useSearchResult.ts
@@ -9,12 +9,6 @@ export default (result, options: ResultOptions = { summaryMaxLength: 150 }) => {
   const { $app_origin } = useNuxtApp()
   const title = computed(() => getSearchResultValue(result, 'title'))
   const url = computed(() => {
-    const externalURL = getSearchResultValue(result, 'field_node_link')
-
-    if (externalURL) {
-      return externalURL
-    }
-
     return stripSiteId(getSearchResultValue(result, 'url'), $app_origin || '')
   })
   const updated = computed(() => {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SDPAP-9395

_Decided to bring this one back after all, I was thinking of addressing it in the site search updates but as grants don't link directly to external sites in site search right now anyway this change if fine to just address search listings. There's no other listings expecting the generic `field_node_link` field to come back as the default URL? I couldn't see any._

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Remove "global" `field_node_link` check so results always link to result page itself, this will mean events link correctly to the event page
- Update grant result to check for external links so it continues to behave as expected

![Screenshot 2024-05-30 at 11 29 12 AM](https://github.com/dpc-sdp/ripple-framework/assets/287178/6d8ef858-4ff9-45d1-8879-183d8a0107ab)


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added cypress test to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

