### PR TITLE
feat(@dpc-sdp/ripple-tide-search): allow multiple result items types

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/result-items.feature
+++ b/examples/nuxt-app/test/features/search-listing/result-items.feature
@@ -1,0 +1,19 @@
+Feature: Result items
+
+  Background:
+    Given the site endpoint returns fixture "/site/reference" with status 200
+    And I am using a "macbook-16" device
+
+  @mockserver
+  Example: Result item type can be set per result
+    Given the page endpoint for path "/search-results" returns fixture "/search-listing/result-items/page" with status 200
+    And the search network request is stubbed with fixture "/search-listing/result-items/response" and status 200
+
+    When I visit the page "/search-results"
+    Then the search listing page should have 4 results
+    Then the search listing results should have following items:
+      | title                    | component                |
+      | International conference | tide-event-search-result |
+      | Accessibility guidelines | tide-search-result-card  |
+      | Small business grant     | tide-grant-search-result |
+      | GovHack 2022 is coming   | tide-search-result       |

--- a/examples/nuxt-app/test/fixtures/search-listing/result-items/page.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/result-items/page.json
@@ -1,0 +1,151 @@
+{
+  "title": "Search results",
+  "changed": "2024-06-03T01:12:18+00:00",
+  "created": "2024-06-02T23:33:24+00:00",
+  "type": "tide_search_listing",
+  "nid": "fbcaaa5d-1635-40ac-8e44-2ed826177e77",
+  "_sectionId": "4",
+  "sidebar": {},
+  "status": "published",
+  "topicTags": [],
+  "siteSection": null,
+  "meta": {
+    "langcode": "en",
+    "description": "",
+    "additional": [
+      {
+        "tag": "meta",
+        "attributes": {
+          "name": "title",
+          "content": "Search results | Victorian Government"
+        }
+      },
+      {
+        "tag": "link",
+        "attributes": {
+          "rel": "canonical",
+          "href": "https://develop.content.vic.gov.au/test-sl"
+        }
+      },
+      {
+        "tag": "meta",
+        "attributes": {
+          "property": "og:locale",
+          "content": "en-AU"
+        }
+      }
+    ],
+    "keywords": "",
+    "image": null
+  },
+  "showContentRating": true,
+  "summary": null,
+  "beforeResults": "",
+  "afterResults": "",
+  "introText": null,
+  "config": {
+    "searchListingConfig": {
+      "hideSearchForm": false,
+      "resultsPerPage": 20,
+      "labels": {
+        "submit": "Submit search",
+        "placeholder": "Start typing search term..."
+      },
+      "customSort": [
+        {
+          "title.keyword": "asc"
+        }
+      ],
+      "formTheme": "default"
+    },
+    "queryConfig": {
+      "multi_match": {
+        "query": "{{query}}",
+        "fields": [
+          "title^3",
+          "field_landing_page_summary^2",
+          "body",
+          "field_paragraph_body",
+          "summary_processed"
+        ]
+      }
+    },
+    "globalFilters": [
+      {
+        "terms": {
+          "type": [
+            "news",
+            "grant",
+            "event",
+            "landing_page"
+          ]
+        }
+      },
+      {
+        "terms": {
+          "field_node_site": [
+            8888
+          ]
+        }
+      }
+    ],
+    "userFilters": [
+      {
+        "id": "type",
+        "component": "TideSearchFilterDropdown",
+        "filter": {
+          "type": "terms",
+          "value": "type"
+        },
+        "props": {
+          "id": "type",
+          "label": "Type",
+          "placeholder": "Select a type",
+          "type": "RplFormDropdown",
+          "multiple": true,
+          "options": [
+            {
+              "id": "news",
+              "label": "News",
+              "value": "news"
+            },
+            {
+              "id": "grant",
+              "label": "Grant",
+              "value": "grant"
+            },
+            {
+              "id": "event",
+              "label": "Event",
+              "value": "event"
+            },
+            {
+              "id": "landing_page",
+              "label": "Landing Page",
+              "value": "landing_page"
+            }
+          ]
+        }
+      }
+    ],
+    "resultsConfig": {
+      "layout": {
+        "component": "TideSearchResultsList"
+      },
+      "item": {
+        "news": {
+          "component": "TideSearchResult"
+        },
+        "event": {
+          "component": "TideEventSearchResult"
+        },
+        "grant": {
+          "component": "TideGrantSearchResult"
+        },
+        "*": {
+          "component": "TideSearchResultCard"
+        }
+      }
+    }
+  }
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/result-items/response.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/result-items/response.json
@@ -1,0 +1,723 @@
+{
+  "took": 11,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 4,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "a83890f7a31dea14e1ae83c6f0afacca--elasticsearch_index_develop_node",
+        "_id": "entity:node/39686:en",
+        "_score": null,
+        "_ignored": [
+          "field_event_description.keyword",
+          "body.keyword"
+        ],
+        "_source": {
+          "_language": "en",
+          "node_grants": [
+            "node_access_all:0"
+          ],
+          "url": [
+            "/site-8888/2-be-event-1",
+            "/site-57/2-be-event-1",
+            "/site-56/2-be-event-1",
+            "/site-129/2-be-event-1",
+            "/site-157/2-be-event-1",
+            "/site-283/2-be-event-1",
+            "/site-125/2-be-event-1",
+            "/site-281/2-be-event-1",
+            "/site-290/2-be-event-1",
+            "/site-287/2-be-event-1",
+            "/site-4/2-be-event-1",
+            "/site-224/2-be-event-1",
+            "/site-408/2-be-event-1",
+            "/site-507/2-be-event-1",
+            "/site-509/2-be-event-1",
+            "/site-515/2-be-event-1",
+            "/site-581/2-be-event-1",
+            "/site-582/2-be-event-1",
+            "/site-622/2-be-event-1",
+            "/site-679/2-be-event-1",
+            "/site-1285/2-be-event-1",
+            "/site-1287/2-be-event-1",
+            "/site-1481/2-be-event-1",
+            "/site-1488/2-be-event-1",
+            "/site-1522/2-be-event-1",
+            "/site-1523/2-be-event-1",
+            "/site-2063/2-be-event-1",
+            "/site-2069/2-be-event-1",
+            "/site-2075/2-be-event-1",
+            "/site-2076/2-be-event-1",
+            "/site-8891/2-be-event-1",
+            "/site-8896/2-be-event-1"
+          ],
+          "body": [
+            "So now all who escaped death in battle or by shipwreck had got safely home except Ulysses, and he, though he was longing to return to his wife and country, was detained by the goddess Calypso, who had got him into a large cave and wanted to marry him. But as years went by, there came a time when the gods settled that he should go back to Ithaca; even then, however, when he was among his own people, his troubles were not yet over; nevertheless all the gods had now begun to pity him except Neptune, who still persecuted him without ceasing and would not let him get home."
+          ],
+          "changed": [
+            "2024-05-30T15:37:27+10:00"
+          ],
+          "created": [
+            "2024-05-30T15:37:27+10:00"
+          ],
+          "field_content_category": [
+            1339
+          ],
+          "field_content_category_name": [
+            "Event"
+          ],
+          "field_event_category_name": [
+            "Film and cinema"
+          ],
+          "field_event_category_tid": [
+            78
+          ],
+          "field_event_category_uuid": [
+            "faeabea7-af8d-4d85-96c8-aff746aa501f"
+          ],
+          "field_event_date_end_value": [
+            "2019-05-20T21:11:01+10:00"
+          ],
+          "field_event_date_start_value": [
+            "2019-05-20T21:02:20+10:00"
+          ],
+          "field_event_description": [
+            "So now all who escaped death in battle or by shipwreck had got safely home except Ulysses, and he, though he was longing to return to his wife and country, was detained by the goddess Calypso, who had got him into a large cave and wanted to marry him. But as years went by, there came a time when the gods settled that he should go back to Ithaca; even then, however, when he was among his own people, his troubles were not yet over; nevertheless all the gods had now begun to pity him except Neptune, who still persecuted him without ceasing and would not let him get home."
+          ],
+          "field_event_details_event_address_1": [
+            "45 Collins St"
+          ],
+          "field_event_details_event_address_line2": [
+            ""
+          ],
+          "field_event_details_event_administrative_area": [
+            "VIC"
+          ],
+          "field_event_details_event_locality": [
+            "Melbourne"
+          ],
+          "field_event_details_event_postal_code": [
+            "3000"
+          ],
+          "field_event_details_event_price_from": [
+            "34.33"
+          ],
+          "field_event_details_event_price_to": [
+            "89.95"
+          ],
+          "field_event_details_event_requirements_name": [
+            "Accessible venue"
+          ],
+          "field_event_details_event_requirements_tid": [
+            84
+          ],
+          "field_event_details_event_requirements_uuid": [
+            "d378d5ae-a90e-4370-8399-4b135a66e1f1"
+          ],
+          "field_event_intro_text": [
+            "Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae"
+          ],
+          "field_landing_page_contact_name": [
+            "Victorian Government"
+          ],
+          "field_landing_page_summary": [
+            "Tell me, O muse, of that ingenious hero who travelled far and wide after he had sacked the famous town of Troy. Many cities did he visit, and many were the nations with whose manners and customs END"
+          ],
+          "field_media_image_absolute_path": [
+            "https://develop.content.vic.gov.au/sites/default/files/tide_demo_content/Melbourne-tram.jpg"
+          ],
+          "field_node_link": [
+            "http://www.weatherzone.com.au/vic/central/healesville"
+          ],
+          "field_node_primary_csite": [
+            8888
+          ],
+          "field_node_site": [
+            8888,
+            57,
+            56,
+            129,
+            157,
+            283,
+            125,
+            281,
+            290,
+            287,
+            4,
+            224,
+            408,
+            507,
+            509,
+            515,
+            581,
+            582,
+            622,
+            679,
+            1285,
+            1287,
+            1481,
+            1488,
+            1522,
+            1523,
+            2063,
+            2069,
+            2075,
+            2076,
+            8891,
+            8896
+          ],
+          "field_paragraph_link": [
+            "http://examplebook.com"
+          ],
+          "field_paragraph_link_text": [
+            "Booking URL"
+          ],
+          "field_tags": [
+            2089
+          ],
+          "field_tags_name": [
+            "Demo Tag"
+          ],
+          "field_tags_path": [
+            "/tags/demo-tag"
+          ],
+          "field_tags_uuid": [
+            "11dede11-10c0-111e1-1101-000000000010"
+          ],
+          "field_topic": [
+            2101
+          ],
+          "field_topic_name": [
+            "Demo Topic"
+          ],
+          "field_topic_path": [
+            "/topic/demo-topic"
+          ],
+          "field_topic_uuid": [
+            "11dede11-10c0-111e1-1102-000000000020"
+          ],
+          "langcode": [
+            "en"
+          ],
+          "nid": [
+            39686
+          ],
+          "status": [
+            true
+          ],
+          "summary_processed": [
+            ""
+          ],
+          "title": [
+            "International conference"
+          ],
+          "type": [
+            "event"
+          ],
+          "uid": [
+            1
+          ],
+          "uuid": [
+            "6f238f60-ce49-4cf0-8e4b-15d71f580509"
+          ]
+        },
+        "sort": [
+          "2-BE-event-1"
+        ]
+      },
+      {
+        "_index": "a83890f7a31dea14e1ae83c6f0afacca--elasticsearch_index_develop_node",
+        "_id": "entity:node/39700:en",
+        "_score": null,
+        "_ignored": [
+          "field_paragraph_body.keyword"
+        ],
+        "_source": {
+          "_language": "en",
+          "node_grants": [
+            "node_access_all:0"
+          ],
+          "url": [
+            "/site-8896/accessibility-demo",
+            "/site-4/accessibility-demo",
+            "/site-56/accessibility-demo",
+            "/site-57/accessibility-demo",
+            "/site-125/accessibility-demo",
+            "/site-129/accessibility-demo",
+            "/site-157/accessibility-demo",
+            "/site-224/accessibility-demo",
+            "/site-281/accessibility-demo",
+            "/site-283/accessibility-demo",
+            "/site-287/accessibility-demo",
+            "/site-290/accessibility-demo",
+            "/site-408/accessibility-demo",
+            "/site-507/accessibility-demo",
+            "/site-509/accessibility-demo",
+            "/site-515/accessibility-demo",
+            "/site-581/accessibility-demo",
+            "/site-582/accessibility-demo",
+            "/site-622/accessibility-demo",
+            "/site-679/accessibility-demo",
+            "/site-1285/accessibility-demo",
+            "/site-1287/accessibility-demo",
+            "/site-1481/accessibility-demo",
+            "/site-1488/accessibility-demo",
+            "/site-1522/accessibility-demo",
+            "/site-1523/accessibility-demo",
+            "/site-2063/accessibility-demo",
+            "/site-2069/accessibility-demo",
+            "/site-2075/accessibility-demo",
+            "/site-2076/accessibility-demo",
+            "/site-8888/accessibility-demo",
+            "/site-8891/accessibility-demo"
+          ],
+          "changed": [
+            "2024-05-30T15:37:27+10:00"
+          ],
+          "created": [
+            "2024-05-30T15:37:27+10:00"
+          ],
+          "field_landing_page_intro_text": [
+            "Accessibility information about this website"
+          ],
+          "field_landing_page_summary": [
+            "Accessibility information about this website. We endeavour to conform to level AA of the W3C Web Content Accessibility Guidelines 2.0."
+          ],
+          "field_node_primary_csite": [
+            8896
+          ],
+          "field_node_site": [
+            8896,
+            4,
+            56,
+            57,
+            125,
+            129,
+            157,
+            224,
+            281,
+            283,
+            287,
+            290,
+            408,
+            507,
+            509,
+            515,
+            581,
+            582,
+            622,
+            679,
+            1285,
+            1287,
+            1481,
+            1488,
+            1522,
+            1523,
+            2063,
+            2069,
+            2075,
+            2076,
+            8888,
+            8891
+          ],
+          "field_paragraph_body": [
+            "The Department of Premier and Cabinet, as owner of this website on behalf of the Victorian Government, is committed to providing a website that is accessible to the widest possible audience, regardless of technology or ability.  This website aims to meet level AA of the Web Content Accessibility Guidelines (WCAG) 2.1 World Wide Web Consortium (W3C) Web Content Accessibility Guidelines 2.0 . If there is information on this website that you can\u0027t access, or have any suggestions on how we can improve the accessibility of this website, please email us via  digital@dpc.vic.gov.au digital@dpc.vic.gov.au  or contact us by mail to: Department of Premier and Cabinet 1 Treasury Place East Melbourne VIC 3002 All constructive feedback regarding the accessibility or usability of this website is welcome and will be carefully considered. Assistance If you are a TTY user, phone 133 677 133 677 then ask for 1300 366 356 If you are a Speak and Listen user, phone 1300 555 727 1300 555 727 then ask for 1300 366 356 For SMS relay, use 0423 677 767 0423 677 767 If you are an internet relay user, visit the Internet Relay call page Make an Internet Relay call page and use this number: 1300 366 356"
+          ],
+          "field_tags": [
+            2095,
+            2096
+          ],
+          "field_tags_name": [
+            "Boomers tag demo",
+            "Gen X tag demo"
+          ],
+          "field_tags_path": [
+            "/tags/boomers-tag-demo",
+            "/tags/gen-x-tag-demo"
+          ],
+          "field_tags_uuid": [
+            "11dede11-10c0-111e1-1101-000000000016",
+            "11dede11-10c0-111e1-1101-000000000017"
+          ],
+          "field_topic": [
+            2109
+          ],
+          "field_topic_name": [
+            "Bourke topic demo"
+          ],
+          "field_topic_path": [
+            "/topic/bourke-topic-demo"
+          ],
+          "field_topic_uuid": [
+            "11dede11-10c0-111e1-1102-000000000028"
+          ],
+          "langcode": [
+            "en"
+          ],
+          "nid": [
+            39700
+          ],
+          "status": [
+            true
+          ],
+          "title": [
+            "Accessibility guidelines"
+          ],
+          "type": [
+            "landing_page"
+          ],
+          "uid": [
+            1
+          ],
+          "uuid": [
+            "1fb67040-e301-4265-b227-85c040506b3c"
+          ]
+        },
+        "sort": [
+          "Accessibility - demo"
+        ]
+      },
+      {
+        "_index": "a83890f7a31dea14e1ae83c6f0afacca--elasticsearch_index_develop_node",
+        "_id": "entity:node/39826:en",
+        "_score": null,
+        "_source": {
+          "_language": "en",
+          "node_grants": [
+            "node_access_all:0"
+          ],
+          "url": [
+            "/site-8891/clone-tav2-grant-content-type-fixture",
+            "/site-8888/clone-tav2-grant-content-type-fixture",
+            "/site-8896/clone-tav2-grant-content-type-fixture",
+            "/site-4/clone-tav2-grant-content-type-fixture",
+            "/site-57/clone-tav2-grant-content-type-fixture",
+            "/site-2076/clone-tav2-grant-content-type-fixture",
+            "/site-2063/clone-tav2-grant-content-type-fixture",
+            "/site-2069/clone-tav2-grant-content-type-fixture",
+            "/site-582/clone-tav2-grant-content-type-fixture",
+            "/site-56/clone-tav2-grant-content-type-fixture",
+            "/site-129/clone-tav2-grant-content-type-fixture",
+            "/site-1523/clone-tav2-grant-content-type-fixture",
+            "/site-224/clone-tav2-grant-content-type-fixture",
+            "/site-157/clone-tav2-grant-content-type-fixture",
+            "/site-509/clone-tav2-grant-content-type-fixture",
+            "/site-283/clone-tav2-grant-content-type-fixture",
+            "/site-581/clone-tav2-grant-content-type-fixture",
+            "/site-125/clone-tav2-grant-content-type-fixture",
+            "/site-2075/clone-tav2-grant-content-type-fixture",
+            "/site-281/clone-tav2-grant-content-type-fixture",
+            "/site-408/clone-tav2-grant-content-type-fixture",
+            "/site-622/clone-tav2-grant-content-type-fixture",
+            "/site-1285/clone-tav2-grant-content-type-fixture",
+            "/site-290/clone-tav2-grant-content-type-fixture",
+            "/site-1287/clone-tav2-grant-content-type-fixture",
+            "/site-1522/clone-tav2-grant-content-type-fixture",
+            "/site-515/clone-tav2-grant-content-type-fixture",
+            "/site-287/clone-tav2-grant-content-type-fixture",
+            "/site-1481/clone-tav2-grant-content-type-fixture",
+            "/site-679/clone-tav2-grant-content-type-fixture",
+            "/site-1488/clone-tav2-grant-content-type-fixture",
+            "/site-507/clone-tav2-grant-content-type-fixture"
+          ],
+          "changed": [
+            "2024-06-03T09:42:38+10:00"
+          ],
+          "created": [
+            "2024-06-03T09:41:56+10:00"
+          ],
+          "field_audience": [
+            8919
+          ],
+          "field_audience_name": [
+            "Business"
+          ],
+          "field_audience_uuid": [
+            "11dede11-10c0-111e1-1100-000000000071"
+          ],
+          "field_content_category": [
+            2071,
+            1340
+          ],
+          "field_content_category_name": [
+            "Other",
+            "Grant"
+          ],
+          "field_landing_page_summary": [
+            "Test creation of Grant Content Type"
+          ],
+          "field_node_dates_end_value": [
+            "2050-12-20T00:00:00+11:00"
+          ],
+          "field_node_dates_start_value": [
+            "2018-12-03T00:00:00+11:00"
+          ],
+          "field_node_link": [
+            "https://www.marineandcoasts.vic.gov.au/coastal-programs/coastcare-victoria/coastcare-victoria-community-grants"
+          ],
+          "field_node_on_going": [
+            false
+          ],
+          "field_node_primary_csite": [
+            8891
+          ],
+          "field_node_site": [
+            8891,
+            8888,
+            8896,
+            4,
+            57,
+            2076,
+            2063,
+            2069,
+            582,
+            56,
+            129,
+            1523,
+            224,
+            157,
+            509,
+            283,
+            581,
+            125,
+            2075,
+            281,
+            408,
+            622,
+            1285,
+            290,
+            1287,
+            1522,
+            515,
+            287,
+            1481,
+            679,
+            1488,
+            507
+          ],
+          "field_topic": [
+            10
+          ],
+          "field_topic_name": [
+            "Education"
+          ],
+          "field_topic_path": [
+            "/topic/education"
+          ],
+          "field_topic_uuid": [
+            "3764c1dc-9475-43cc-a483-96bec239c4f7"
+          ],
+          "funding_level_from": [
+            500
+          ],
+          "funding_level_to": [
+            1000000
+          ],
+          "langcode": [
+            "en"
+          ],
+          "nid": [
+            39826
+          ],
+          "status": [
+            true
+          ],
+          "title": [
+            "Small business grant"
+          ],
+          "type": [
+            "grant"
+          ],
+          "uid": [
+            11648
+          ],
+          "uuid": [
+            "ddbed746-74cf-4d95-802d-a60bf6fb7568"
+          ]
+        },
+        "sort": [
+          "Clone of TAV2: Grant Content Type - fixture"
+        ]
+      },
+      {
+        "_index": "a83890f7a31dea14e1ae83c6f0afacca--elasticsearch_index_develop_node",
+        "_id": "entity:node/39680:en",
+        "_score": null,
+        "_ignored": [
+          "body.keyword"
+        ],
+        "_source": {
+          "_language": "en",
+          "node_grants": [
+            "node_access_all:0"
+          ],
+          "url": [
+            "/site-8896/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-4/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-56/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-57/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-125/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-129/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-157/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-224/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-281/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-283/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-287/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-290/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-408/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-507/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-509/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-515/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-581/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-582/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-622/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-679/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-1285/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-1287/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-1481/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-1488/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-1522/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-1523/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-2063/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-2069/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-2075/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-2076/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-8888/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo",
+            "/site-8891/govhack-2022-coming-soon-connections-event-and-hack-weekend-demo"
+          ],
+          "body": [
+            "What is GovHack? GovHack is Australia\u0027s largest open government and open data hackathon, attracting over 1,000 participants each year (includes NZ). Challenges are submitted by federal, state and local governments and agencies across Australia and New Zealand GovHack is an event that attracts forward-thinking people of all skills and abilities and challenges them to address a number of problem statements over a weekend utilising the wealth of open data available. GovHack 2022 will be the Victorian Government\u0027s 10th anniversary of participation at the event and will return to a series of in-person events post COVID. This year\u0027s GovHack will be held from 19 to 21 August. So if you want to join thousands of others and apply your creativity, problem solving and critical thinking skills to address real problem statements, or you just wish to volunteer your time to help support the event, go to the GovHack website to register your interest. The Melbourne Connections event will be held on 21 July. Go to the website to secure a ticket ."
+          ],
+          "changed": [
+            "2024-05-30T15:37:27+10:00"
+          ],
+          "created": [
+            "2024-05-30T15:37:27+10:00"
+          ],
+          "field_content_category": [
+            1338
+          ],
+          "field_content_category_name": [
+            "News article"
+          ],
+          "field_event_intro_text": [
+            "GovHack is Australia\u0027s largest open government and open data hackathon attracting over 1,000 participants each year"
+          ],
+          "field_landing_page_summary": [
+            "What is GovHack? GovHack is Australia\u0027s largest open government and open data hackathon attracting over 1,000 participants each year"
+          ],
+          "field_media_image_absolute_path": [
+            "https://develop.content.vic.gov.au/sites/default/files/tide_demo_content/Melbourne-tram.jpg"
+          ],
+          "field_news_date": [
+            "2022-07-13T19:54:00+10:00"
+          ],
+          "field_node_primary_csite": [
+            8896
+          ],
+          "field_node_site": [
+            8896,
+            8897,
+            8898,
+            4,
+            56,
+            57,
+            125,
+            129,
+            157,
+            224,
+            281,
+            283,
+            287,
+            290,
+            408,
+            507,
+            509,
+            515,
+            581,
+            582,
+            622,
+            679,
+            1285,
+            1287,
+            1481,
+            1488,
+            1522,
+            1523,
+            2063,
+            2069,
+            2075,
+            2076,
+            8888,
+            8891
+          ],
+          "field_tags": [
+            2095,
+            2099
+          ],
+          "field_tags_name": [
+            "Boomers tag demo",
+            "Gen Alpha tag demo"
+          ],
+          "field_tags_path": [
+            "/tags/boomers-tag-demo",
+            "/tags/gen-alpha-tag-demo"
+          ],
+          "field_tags_uuid": [
+            "11dede11-10c0-111e1-1101-000000000016",
+            "111dede11-10c0-111e1-1101-000000000020"
+          ],
+          "field_topic": [
+            2109
+          ],
+          "field_topic_name": [
+            "Bourke topic demo"
+          ],
+          "field_topic_path": [
+            "/topic/bourke-topic-demo"
+          ],
+          "field_topic_uuid": [
+            "11dede11-10c0-111e1-1102-000000000028"
+          ],
+          "langcode": [
+            "en"
+          ],
+          "nid": [
+            39680
+          ],
+          "status": [
+            true
+          ],
+          "summary_processed": [
+            ""
+          ],
+          "title": [
+            "GovHack 2022 is coming"
+          ],
+          "type": [
+            "news"
+          ],
+          "uid": [
+            1
+          ],
+          "uuid": [
+            "7ced455a-1e8a-4f3b-857b-336de5307df1"
+          ]
+        },
+        "sort": [
+          "GovHack 2022 is coming soon - Connections Event and Hack weekend - demo"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -110,6 +110,10 @@ Then(
           if (row.content) {
             cy.wrap(item).should('contain', row.content)
           }
+
+          if (row.component) {
+            cy.wrap(item).find('> *').should('have.class', row.component)
+          }
         })
     })
   }

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -115,6 +115,7 @@ const appConfig = useAppConfig()
 
 const searchResultsMappingFn = (item): TideSearchListingResultItem => {
   let transformedItem = item._source
+  let itemComponent = 'TideSearchResult'
 
   const transformResultFnName = props.resultsConfig?.transformResultFn
   const fns: Record<string, (result: any) => Promise<any>> =
@@ -132,33 +133,19 @@ const searchResultsMappingFn = (item): TideSearchListingResultItem => {
     transformedItem = transformResultFn(item)
   }
 
-  if (props.resultsConfig.item) {
-    for (const key in props.resultsConfig.item) {
-      const mapping = props.resultsConfig.item[key]
-      if (!item._source?.type || item._source?.type[0] === key || key === '*') {
-        /* If there is no type, a component will be required */
-        return {
-          id: item._id,
-          component: mapping.component,
-          props: {
-            result: transformedItem
-          }
-        }
-      } else {
-        /* Add default search result mapping if none provided */
-        return {
-          id: item._id,
-          component: 'TideSearchResult',
-          props: {
-            result: transformedItem
-          }
-        }
-      }
+  if (props.resultsConfig?.item) {
+    const mapping =
+      props.resultsConfig.item[item._source?.type] ??
+      props.resultsConfig.item?.['*']
+
+    if (mapping) {
+      itemComponent = mapping.component
     }
   }
 
   return {
     id: item._id,
+    component: itemComponent,
     props: {
       result: transformedItem
     }

--- a/packages/ripple-tide-search/components/global/TideSearchResultCard.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchResultCard.vue
@@ -45,7 +45,7 @@ const meta = computed(() => {
 <template>
   <RplPromoCard
     :key="id"
-    class="rpl-col-12 rpl-col-4-m"
+    class="tide-search-result-card rpl-col-12 rpl-col-4-m"
     :image="image"
     :title="title"
     :url="url"

--- a/packages/ripple-tide-search/components/global/TideTideSearchListing.vue
+++ b/packages/ripple-tide-search/components/global/TideTideSearchListing.vue
@@ -17,33 +17,21 @@ const resultsConfig = computed(() => {
 })
 
 const searchResultsMappingFn = (item: any): TideSearchListingResultItem => {
+  let itemComponent = 'TideSearchResult'
+
   if (resultsConfig.value?.item) {
-    for (const key in resultsConfig.value.item) {
-      const mapping = resultsConfig.value.item[key]
-      if (!item._source?.type || item._source?.type[0] === key || key === '*') {
-        /* If there is no type, a component will be required */
-        return {
-          id: item._id,
-          component: mapping.component,
-          props: {
-            result: item._source
-          }
-        }
-      } else {
-        /* Add default search result mapping if none provided */
-        return {
-          id: item._id,
-          component: 'TideSearchResult',
-          props: {
-            result: item._source
-          }
-        }
-      }
+    const mapping =
+      resultsConfig.value.item[item._source?.type] ??
+      resultsConfig.value.item?.['*']
+
+    if (mapping) {
+      itemComponent = mapping.component
     }
   }
 
   return {
     id: item._id,
+    component: itemComponent,
     props: {
       result: item._source
     }

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -93,11 +93,11 @@ export type TideSearchListingResultItem = {
   /**
    * @description search result key
    */
-  id?: string
+  id: string
   /**
    * @description name of Vue component (globally imported) to render result
    */
-  component?: string
+  component: string
   /**
    * @description optionally pass props to component (useful for configuring an existing component)
    */


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->
### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add support for multiple result item types, the search listing API/JSON looks like this would be supported, plus why not support it.

As an example say you wanted something like a News & Events listing, the example config below is now supported.
```
"resultsConfig": {
    "layout": {
      "component": "TideSearchResultsList"
    },
    "item": {
      "news": {
        "component": "TideNewsSearchResult"
      },
      "event": {
        "component": "TideEventSearchResult"
      }
    }
  }
```

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added cypress tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

