### PR TITLE
[R20-1977] - Patch vite-plugin-vue to fix CSS files not triggering HMR

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
       "vite@>=5.1.0 <=5.1.6": ">=5.1.7"
     },
     "patchedDependencies": {
-      "vite-svg-loader@4.0.0": "patches/vite-svg-loader@4.0.0.patch"
+      "vite-svg-loader@4.0.0": "patches/vite-svg-loader@4.0.0.patch",
+      "@vitejs/plugin-vue@5.0.4": "patches/@vitejs__plugin-vue@5.0.4.patch"
     }
   }
 }

--- a/patches/@vitejs__plugin-vue@5.0.4.patch
+++ b/patches/@vitejs__plugin-vue@5.0.4.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 651cce2951161bfd811ef55f4ed5c4ed6a676dde..fa381af3d9cc6eab21bd13a41768f8df4940936c 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -2917,6 +2917,13 @@ function vuePlugin(rawOptions = {}) {
+         );
+       } else {
+         const descriptor = query.src ? getSrcDescriptor(filename, query) || getTempSrcDescriptor(filename, query) : getDescriptor(filename, options.value);
++        
++    	// TEMPORARY PATCH: https://github.com/vitejs/vite-plugin-vue/issues/397
++        // Fixes CSS files imported into .vue files not being watched
++        if (query.src) {
++          this.addWatchFile(filename);
++        }
++        
+         if (query.type === "template") {
+           return transformTemplateAsModule(
+             code,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ overrides:
   vite@>=5.1.0 <=5.1.6: '>=5.1.7'
 
 patchedDependencies:
+  '@vitejs/plugin-vue@5.0.4':
+    hash: isqbuc2kkxkzmwgmxoscqh5w4q
+    path: patches/@vitejs__plugin-vue@5.0.4.patch
   vite-svg-loader@4.0.0:
     hash: b7iv6uosp7uohhdjf52hsfxagy
     path: patches/vite-svg-loader@4.0.0.patch
@@ -279,7 +282,7 @@ importers:
         version: 18.15.10
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.0.4(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.0.2))
+        version: 5.0.4(patch_hash=isqbuc2kkxkzmwgmxoscqh5w4q)(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.0.2))
       '@vue/eslint-config-prettier':
         specifier: ^7.1.0
         version: 7.1.0(eslint@8.36.0)(prettier@2.8.7)
@@ -809,7 +812,7 @@ importers:
         version: link:../ripple-tide-api
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.0.4(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
+        version: 5.0.4(patch_hash=isqbuc2kkxkzmwgmxoscqh5w4q)(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
       '@vue/compiler-sfc':
         specifier: ^3.2.47
         version: 3.2.47
@@ -888,7 +891,7 @@ importers:
         version: 18.15.10
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.0.4(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
+        version: 5.0.4(patch_hash=isqbuc2kkxkzmwgmxoscqh5w4q)(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
       babel-loader:
         specifier: ^9.1.2
         version: 9.1.2(@babel/core@7.23.2)(webpack@5.86.0(@swc/core@1.3.70)(esbuild@0.20.2))
@@ -967,7 +970,7 @@ importers:
         version: link:../ripple-ui-core
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.0.4(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
+        version: 5.0.4(patch_hash=isqbuc2kkxkzmwgmxoscqh5w4q)(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
       '@vue/compiler-sfc':
         specifier: ^3.2.47
         version: 3.2.47
@@ -4857,6 +4860,7 @@ packages:
 
   '@storybook/expect@28.1.3-5':
     resolution: {integrity: sha512-lS1oJnY1qTAxnH87C765NdfvGhksA6hBcbUVI5CHiSbNsEtr456wtg/z+dT9XlPriq1D5t2SgfNL9dBAoIGyIA==}
+    deprecated: In Storybook 8, this package functionality has been integrated to a new package called @storybook/test, which uses Vitest APIs for an improved experience. When upgrading to Storybook 8 with 'npx storybook@latest upgrade', you will get prompted and will get an automigration for the new package. Please migrate when you can.
 
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
@@ -15293,8 +15297,8 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  vue-component-type-helpers@2.0.16:
-    resolution: {integrity: sha512-qisL/iAfdO++7w+SsfYQJVPj6QKvxp4i1MMxvsNO41z/8zu3KuAw9LkhKUfP/kcOWGDxESp+pQObWppXusejCA==}
+  vue-component-type-helpers@2.0.19:
+    resolution: {integrity: sha512-cN3f1aTxxKo4lzNeQAkVopswuImUrb5Iurll9Gaw5cqpnbTAxtEMM1mgi6ou4X79OCyqYv1U1mzBHJkzmiK82w==}
 
   vue-demi@0.14.6:
     resolution: {integrity: sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==}
@@ -20165,7 +20169,7 @@ snapshots:
     dependencies:
       '@nuxt/kit': 3.10.2(rollup@4.9.1)
       '@rollup/plugin-replace': 5.0.5(rollup@4.9.1)
-      '@vitejs/plugin-vue': 5.0.4(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
+      '@vitejs/plugin-vue': 5.0.4(patch_hash=isqbuc2kkxkzmwgmxoscqh5w4q)(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
       '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
       autoprefixer: 10.4.17(postcss@8.4.38)
       clear: 0.1.0
@@ -20222,7 +20226,7 @@ snapshots:
     dependencies:
       '@nuxt/kit': 3.11.2(rollup@4.14.3)
       '@rollup/plugin-replace': 5.0.5(rollup@4.14.3)
-      '@vitejs/plugin-vue': 5.0.4(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
+      '@vitejs/plugin-vue': 5.0.4(patch_hash=isqbuc2kkxkzmwgmxoscqh5w4q)(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
       '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))
       autoprefixer: 10.4.19(postcss@8.4.38)
       clear: 0.1.0
@@ -21982,7 +21986,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.23(typescript@5.1.3)
-      vue-component-type-helpers: 2.0.16
+      vue-component-type-helpers: 2.0.19
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -22966,12 +22970,12 @@ snapshots:
     dependencies:
       vue: 3.4.23(typescript@5.1.3)
 
-  '@vitejs/plugin-vue@5.0.4(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.0.2))':
+  '@vitejs/plugin-vue@5.0.4(patch_hash=isqbuc2kkxkzmwgmxoscqh5w4q)(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.0.2))':
     dependencies:
       vite: 5.2.11(@types/node@18.15.10)(terser@5.18.0)
       vue: 3.4.23(typescript@5.0.2)
 
-  '@vitejs/plugin-vue@5.0.4(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))':
+  '@vitejs/plugin-vue@5.0.4(patch_hash=isqbuc2kkxkzmwgmxoscqh5w4q)(vite@5.2.11(@types/node@18.15.10)(terser@5.18.0))(vue@3.4.23(typescript@5.1.3))':
     dependencies:
       vite: 5.2.11(@types/node@18.15.10)(terser@5.18.0)
       vue: 3.4.23(typescript@5.1.3)
@@ -35788,7 +35792,7 @@ snapshots:
       typesafe-path: 0.2.2
       typescript: 5.1.3
 
-  vue-component-type-helpers@2.0.16: {}
+  vue-component-type-helpers@2.0.19: {}
 
   vue-demi@0.14.6(vue@3.4.23(typescript@5.1.3)):
     dependencies:


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1977

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Used the suggested solution here to patch the Vue Vite plugin https://github.com/vitejs/vite-plugin-vue/issues/397
- I tested locally and CSS now updates on save without a restart, and the rest of the project seems to work as before.

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

