### PR TITLE
[R20-1451] - Set a max length on site search bar to match search ui max length

### DIFF
--- a/packages/ripple-tide-search/components/TideSearchPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchPage.vue
@@ -237,6 +237,7 @@ watch(
             :inputValue="searchState.searchTerm"
             :suggestions="searchTermSuggestions"
             :global-events="false"
+            maxlength="128"
             @submit="handleSubmit"
             @update:input-value="updateSearchTerm"
           />

--- a/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.vue
@@ -34,6 +34,7 @@ interface Props {
   items: IRplPrimaryNavItem[]
   showSearch?: boolean
   searchUrl?: string
+  searchMaxLength?: number
   showQuickExit?: boolean
 }
 
@@ -41,7 +42,8 @@ const props = withDefaults(defineProps<Props>(), {
   secondaryLogo: undefined,
   showSearch: true,
   searchUrl: '/search',
-  showQuickExit: true
+  showQuickExit: true,
+  searchMaxLength: 128
 })
 
 const emit = defineEmits<{
@@ -303,6 +305,7 @@ provide('navFocus', navFocus)
         v-if="isSearchActive"
         :show-quick-exit="showQuickExit"
         :search-url="searchUrl"
+        :max-length="searchMaxLength"
       />
     </div>
     <RplPrimaryNavQuickExit v-if="showQuickExit" variant="fixed" />

--- a/packages/ripple-ui-core/src/components/primary-nav/components/search-form/RplPrimaryNavSearchForm.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/search-form/RplPrimaryNavSearchForm.vue
@@ -6,11 +6,14 @@ import { ref, onMounted } from 'vue'
 interface Props {
   showQuickExit: boolean
   searchUrl: boolean
+  maxLength?: number
 }
 
 const searchBar = ref(null)
 
-const props = withDefaults(defineProps<Props>(), {})
+const props = withDefaults(defineProps<Props>(), {
+  maxLength: 128
+})
 
 const handleSubmit = (event) => {
   window.location.href = `${props.searchUrl}?q=${event.value}`
@@ -38,6 +41,7 @@ onMounted(() => {
         ref="searchBar"
         variant="menu"
         placeholder="Start typing..."
+        :maxlength="maxLength"
         @submit="handleSubmit"
       />
     </div>


### PR DESCRIPTION
…
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-1451

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Search UI errors if the query is longer than 128 characters, so I set a max length on the input so the user won't get this error when copy pasting a lot of text
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

