### PR TITLE
[R20-402] add new portrait aspect ratio for media embed

### DIFF
--- a/packages/ripple-ui-core/src/components/media-embed/RplMediaEmbed.vue
+++ b/packages/ripple-ui-core/src/components/media-embed/RplMediaEmbed.vue
@@ -73,7 +73,7 @@ const imageAspect = computed(() => {
     case 'landscape':
       return 'wide'
     case 'portrait':
-      return 'full'
+      return 'portrait'
     case 'square':
       return 'square'
     case 'avatar':

--- a/packages/ripple-ui-core/src/styles/components/_embed.css
+++ b/packages/ripple-ui-core/src/styles/components/_embed.css
@@ -20,7 +20,8 @@
   /* Portrait */
   &.rpl-media-embed__image--portrait {
     &.rpl-media-embed__image--large {
-      max-width: none;
+      width: auto;
+      height: auto;
       max-height: 595px;
     }
   }
@@ -97,6 +98,7 @@
 
 .rpl-media-embed__actions-list {
   margin-top: var(--rpl-sp-3);
+  max-width: var(--rpl-content-max-width);
 
   li {
     margin-bottom: var(--rpl-sp-3);

--- a/packages/ripple-ui-core/src/styles/utilities/_aspect.css
+++ b/packages/ripple-ui-core/src/styles/utilities/_aspect.css
@@ -1,6 +1,6 @@
 .rpl-u-aspect {
-  @each $name, $ratio in (square, full, wide, ultrawide, panorama),
-    (1/1, 4/3, 16/9, 21/9, 3/1)
+  @each $name, $ratio in (square, full, wide, ultrawide, panorama, portrait),
+    (1/1, 4/3, 16/9, 21/9, 3/1, 3/4)
   {
     &-$(name) {
       aspect-ratio: $(ratio);
@@ -8,8 +8,8 @@
   }
 
   @each $size in (s, m, l, xl) {
-    @each $name, $ratio in (square, full, wide, ultrawide, panorama),
-      (1/1, 4/3, 16/9, 21/9, 3/1)
+    @each $name, $ratio in (square, full, wide, ultrawide, panorama, portrait),
+      (1/1, 4/3, 16/9, 21/9, 3/1, 3/4)
     {
       &-$(name)-$(size) {
         /* stylelint-disable-next-line media-query-no-invalid */


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-402

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add new portrait aspect ratio for media embed, the confluence doc had the wrong aspect ratio i.e. 4/3 when it should have been 3/4

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

