### PR TITLE
[R20-2035] add basic keyboard/search support to dropdowns

### DIFF
--- a/packages/ripple-ui-forms/src/components/RplFormDropdown/RplFormDropdown.cy.ts
+++ b/packages/ripple-ui-forms/src/components/RplFormDropdown/RplFormDropdown.cy.ts
@@ -1,0 +1,63 @@
+import RplFormDropDown from './RplFormDropdown.vue'
+import { RplFormDropdownOptions } from './fixtures/sample'
+
+const props = {
+  id: 'dropdown',
+  labelId: 'dropdown',
+  placeholder: 'Select',
+  options: RplFormDropdownOptions
+}
+
+describe('RplFormDropDown', () => {
+  it('mounts', () => {
+    cy.mount(RplFormDropDown, { props })
+
+    cy.get('.rpl-form-dropdown').should('be.visible')
+  })
+
+  it('can be toggled open and closed', () => {
+    cy.mount(RplFormDropDown, { props })
+
+    cy.get('.rpl-form-dropdown-input').click()
+    cy.get('.rpl-form-dropdown-menu').should('be.visible')
+    cy.get('.rpl-form-dropdown-input').click()
+    cy.get('.rpl-form-dropdown-menu').should('not.exist')
+  })
+
+  it('can be "searched" by typing from the input', () => {
+    cy.mount(RplFormDropDown, { props })
+
+    cy.get('.rpl-form-dropdown-input').type('b')
+    cy.focused().contains('Banana')
+
+    cy.get('.rpl-form-dropdown-input').type('bl')
+    cy.focused().contains('Blueberries')
+  })
+
+  it('can be "searched" by typing from an option', () => {
+    cy.mount(RplFormDropDown, { props })
+
+    cy.get('.rpl-form-dropdown-input').click()
+    cy.get('.rpl-form-dropdown-option').first().type('apr')
+    cy.focused().contains('Apricots')
+
+    cy.get('.rpl-form-dropdown-option').first().type('l')
+    cy.focused().contains('Lemon')
+  })
+
+  it('can be "traversed" by cycling through a single key stroke', () => {
+    cy.mount(RplFormDropDown, { props })
+
+    cy.get('.rpl-form-dropdown-input').type('a')
+    cy.focused().contains('Apple')
+
+    cy.focused().type('a')
+    cy.focused().contains('Apricots')
+
+    cy.focused().type('a')
+    cy.focused().contains('Avocado')
+
+    cy.focused().type('a')
+    cy.focused().contains('Apple')
+  })
+})

--- a/packages/ripple-ui-forms/src/components/RplFormDropdown/RplFormDropdown.stories.mdx
+++ b/packages/ripple-ui-forms/src/components/RplFormDropdown/RplFormDropdown.stories.mdx
@@ -7,6 +7,7 @@ import {
 import RplFormDropdown from './RplFormDropdown.vue'
 import { RplButton } from '@dpc-sdp/ripple-ui-core/vue'
 import StorybookInputFixture from './../StorybookInputFixture/StorybookInputFixture.vue'
+import { RplFormDropdownOptions } from './fixtures/sample'
 import '@dpc-sdp/ripple-ui-core/style/components'
 import '../RplForm/RplForm.css'
 
@@ -74,11 +75,7 @@ export const SingleTemplate = (args) => ({
     args={{
       id: 'dropdown-single',
       multiple: false,
-      options: [...Array(10).keys()].map((i) => ({
-        id: `item-${i + 1}`,
-        value: `item-${i + 1}`,
-        label: `Value ${i + 1}`
-      }))
+      options: RplFormDropdownOptions
     }}
   >
     {SingleTemplate.bind()}
@@ -116,11 +113,7 @@ export const SingleTemplate = (args) => ({
     args={{
       id: 'dropdown-multi',
       multiple: true,
-      options: [...Array(10).keys()].map((i) => ({
-        id: `item-${i + 1}`,
-        value: `item-${i + 1}`,
-        label: `Value ${i + 1}`
-      }))
+      options: RplFormDropdownOptions
     }}
   >
     {SingleTemplate.bind()}

--- a/packages/ripple-ui-forms/src/components/RplFormDropdown/RplFormDropdown.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormDropdown/RplFormDropdown.vue
@@ -6,7 +6,7 @@ export default {
 
 <script setup lang="ts">
 import { computed, ref, watch, nextTick, inject } from 'vue'
-import { onClickOutside } from '@vueuse/core'
+import { onClickOutside, useDebounceFn } from '@vueuse/core'
 import useFormkitFriendlyEventEmitter from '../../composables/useFormkitFriendlyEventEmitter'
 import MultiValueLabel from './MultiValueLabel.vue'
 import { useRippleEvent } from '@dpc-sdp/ripple-ui-core'
@@ -32,7 +32,7 @@ export interface RplFormDropdownProps {
   }[]
   maxItemsDisplayed?: number
   pii?: boolean
-  unselectedValue: any
+  unselectedValue?: any
   /**
    * Only applicable when for single selects. If true, no 'placeholder' option
    * is added and the user can't deselect a value, only choose a different value.
@@ -77,6 +77,7 @@ const containerRef = ref(null)
 const inputRef = ref(null)
 const menuRef = ref(null)
 const optionRefs = ref([])
+const searchCache = ref('')
 
 const menuId = computed(() => `${props.id}__menu`)
 
@@ -125,6 +126,29 @@ const getDefaultActiveId = (): string => {
 
 const getUniqueOptionId = (optionId: string): string => {
   return optionId ? `${props.id}-${optionId}` : ''
+}
+
+const processSearch = useDebounceFn(() => {
+  let options = [...(props.options || [])]
+  if (activeOptionId.value) {
+    const index = options.map((o) => o.id).indexOf(activeOptionId.value)
+    options = options.slice(index + 1).concat(options.slice(0, index + 1))
+  }
+  let found = options.find((o) =>
+    o.label.toLowerCase().startsWith(searchCache.value)
+  )
+  if (found) {
+    handleOpen()
+    activeOptionId.value = found.id
+  }
+  searchCache.value = ''
+})
+
+const handleSearch = (event: KeyboardEvent): void => {
+  if (event.key?.length === 1) {
+    searchCache.value = searchCache.value + event.key.toLowerCase()
+    processSearch()
+  }
 }
 
 const handleToggle = (fromKeyboard = false): void => {
@@ -322,6 +346,7 @@ const hasValue = computed((): boolean => {
     @keydown.esc.prevent="handleClose(true)"
     @keydown.exact.tab="handleClose(false)"
     @keydown.shift.tab="handleClose(false)"
+    @keydown.exact="handleSearch"
   >
     <div
       v-bind="$attrs"

--- a/packages/ripple-ui-forms/src/components/RplFormDropdown/fixtures/sample.ts
+++ b/packages/ripple-ui-forms/src/components/RplFormDropdown/fixtures/sample.ts
@@ -1,0 +1,15 @@
+export const RplFormDropdownOptions = [
+  { id: 'apple', value: 'apple', label: 'Apple' },
+  { id: 'banana', value: 'banana', label: 'Banana' },
+  { id: 'orange', value: 'orange', label: 'Orange' },
+  { id: 'strawberry', value: 'strawberry', label: 'Strawberry' },
+  { id: 'apricots', value: 'apricots', label: 'Apricots' },
+  { id: 'grapes', value: 'grapes', label: 'Grapes' },
+  { id: 'pineapple', value: 'pineapple', label: 'Pineapple' },
+  { id: 'sultana', value: 'sultana', label: 'Sultana' },
+  { id: 'blueberries', value: 'blueberries', label: 'Blueberries' },
+  { id: 'avocado', value: 'avocado', label: 'Avocado' },
+  { id: 'peach', value: 'peach', label: 'Peach' },
+  { id: 'lemon', value: 'lemon', label: 'Lemon' },
+  { id: 'watermelon', value: 'watermelon', label: 'Watermelon' }
+]


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-2035

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add basic keyboard/search support to dropdowns, this mimics native behavior. i.e.
  - Using a single key cycles through options, so hitting "a" multiple times (with delay) will cycle through all options starting with "A"
  - Quickly typing multiple characters will jump to any matching options, for example typing "avo" will jump to "Avocado"

![keyboard-nav](https://github.com/dpc-sdp/ripple-framework/assets/287178/5399117f-94f3-4208-abeb-420ff9f133ee)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added cypress tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

