### PR TITLE
[R20-2041] always ensure expanded menu is visible

### DIFF
--- a/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.css
+++ b/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.css
@@ -78,6 +78,7 @@
   }
 
   .rpl-primary-nav--expanded & {
+    display: block;
     transition: height var(--rpl-motion-speed-7) ease-in,
       background-color var(--rpl-motion-speed-4) ease-in;
     background-color: var(--rpl-clr-primary-alt);


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-2041

### What I did
<!-- Summary of changes made in the Pull Request  -->
The latest version of safari on ios was triggering a scroll when the search field was focused, this in turned triggered our menu to be hidden as that's what it does, it hides when the page is scrolled down. 
This issue only effected sites using the quick exit as having the quick exit in the menu pushes down the search input down just enough for safari to decided it needs to move up the page so the user can see/access the input field better.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

