### PR TITLE
[R20-2046] hide refine search when filters are already open

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/filters.feature
+++ b/examples/nuxt-app/test/features/search-listing/filters.feature
@@ -14,6 +14,7 @@ Feature: Search listing - Filter
 
     When I visit the page "/filters"
     Then the search listing filters section should be open
+    And the filters toggle should be hidden
 
   @mockserver
   Example: Raw filter - Should reflect the value from the URL
@@ -211,7 +212,8 @@ Feature: Search listing - Filter
     And the search network request should be called with the "/search-listing/dependent-filters/request-mammals-children" fixture
     And the filters toggle should show 2 applied filters
 
-    When I click the search listing dropdown field labelled "Terms dependent example"
+    When I toggle the search listing filters section
+    Then I click the search listing dropdown field labelled "Terms dependent example"
     Then the selected dropdown field should have the items:
       | Mammals |
       | Birds   |
@@ -237,7 +239,9 @@ Feature: Search listing - Filter
     When I visit the page "/filters"
     Then the search listing page should have 2 results
     And the search network request should be called with the "/search-listing/dependent-filters/request-empty" fixture
-    And the search listing dropdown field labelled "Terms dependent child example" should be disabled
+
+    When I toggle the search listing filters section
+    Then the search listing dropdown field labelled "Terms dependent child example" should be disabled
     And the search listing dropdown field labelled "Terms dependent grandchild example" should be disabled
 
     When I click the search listing dropdown field labelled "Terms dependent example"
@@ -286,7 +290,8 @@ Feature: Search listing - Filter
     And the search network request should be called with the "/search-listing/dependent-filters/request-birds-grandchildren-single" fixture
     And the filters toggle should show 3 applied filters
 
-    When I click the search listing dropdown field labelled "Terms dependent example"
+    When I toggle the search listing filters section
+    Then I click the search listing dropdown field labelled "Terms dependent example"
     And I click the option labelled "Mammals" in the selected dropdown
     Then I click the search listing dropdown field labelled "Terms dependent example"
 
@@ -314,7 +319,8 @@ Feature: Search listing - Filter
     And the search network request should be called with the "/search-listing/dependent-filters/request-birds-grandchildren" fixture
     And the filters toggle should show 3 applied filters
 
-    When I click the search listing dropdown field labelled "Terms dependent example"
+    When I toggle the search listing filters section
+    Then I click the search listing dropdown field labelled "Terms dependent example"
     And I click the option labelled "Mammals" in the selected dropdown
     Then I click the search listing dropdown field labelled "Terms dependent example"
 
@@ -344,6 +350,7 @@ Feature: Search listing - Filter
     And the search network request should be called with the "/search-listing/dependent-filters/request-birds-grandchildren" fixture
     And the filters toggle should show 3 applied filters
 
+    When I toggle the search listing filters section
     Then the search listing dropdown field labelled "Terms dependent example" should have the value "Birds"
     And I click the search listing dropdown field labelled "Terms dependent example"
     Then the selected dropdown field should allow "single" selection

--- a/examples/nuxt-app/test/fixtures/search-listing/dependent-filters/page-mix.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/dependent-filters/page-mix.json
@@ -8,8 +8,7 @@
   "summary": "",
   "config": {
     "searchListingConfig": {
-      "resultsPerPage": 10,
-      "showFiltersOnLoad": true
+      "resultsPerPage": 10
     },
     "queryConfig": {
       "multi_match": {

--- a/examples/nuxt-app/test/fixtures/search-listing/dependent-filters/page-single.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/dependent-filters/page-single.json
@@ -8,8 +8,7 @@
   "summary": "",
   "config": {
     "searchListingConfig": {
-      "resultsPerPage": 10,
-      "showFiltersOnLoad": true
+      "resultsPerPage": 10
     },
     "queryConfig": {
       "multi_match": {

--- a/examples/nuxt-app/test/fixtures/search-listing/dependent-filters/page.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/dependent-filters/page.json
@@ -8,8 +8,7 @@
   "summary": "",
   "config": {
     "searchListingConfig": {
-      "resultsPerPage": 10,
-      "showFiltersOnLoad": true
+      "resultsPerPage": 10
     },
     "queryConfig": {
       "multi_match": {

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -333,6 +333,10 @@ Then(
   }
 )
 
+Then('the filters toggle should be hidden', () => {
+  cy.get(`.tide-search-header .rpl-search-bar-refine`).should('not.exist')
+})
+
 Then(
   `I click the option labelled {string} in the selected dropdown`,
   (label: string) => {

--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -410,6 +410,7 @@ watch(
           </template>
           <RplSearchBarRefine
             v-if="
+              !searchListingConfig?.showFiltersOnLoad &&
               !searchListingConfig?.showFiltersOnly &&
               userFilters &&
               userFilters.length > 0

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -586,6 +586,7 @@ const locationOrGeolocation = computed(() => {
         <div class="tide-search-refine-wrapper">
           <RplSearchBarRefine
             v-if="
+              !searchListingConfig?.showFiltersOnLoad &&
               !searchListingConfig?.showFiltersOnly &&
               userFilters &&
               userFilters.length > 0


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

Jira: https://digital-vic.atlassian.net/browse/R20-2046

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Hide refine search when filters are already open

![Screenshot 2024-06-20 at 11 51 49 AM](https://github.com/dpc-sdp/ripple-framework/assets/287178/4bd29a00-6a3b-45ba-8f4e-e980ae37b02f)


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

