### PR TITLE
fix(@dpc-sdp/nuxt-ripple): removes trailing slash on api request

### DIFF
--- a/packages/nuxt-ripple/server/api/tide/page.ts
+++ b/packages/nuxt-ripple/server/api/tide/page.ts
@@ -43,9 +43,10 @@ export const createPageHandler = async (
     }
 
     const sectionId = getHeader(event, 'x-section-request-id')
+    const path = query.path.length > 1 && query.path.charAt(query.path.length - 1) === '/' ? query.path.substring(0, query.path.length - 1) : query.path
 
     const pageResponse = await tidePageApi.getPageByPath(
-      query.path,
+      path,
       query.site,
       {},
       headers,


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:
https://github.com/dpc-sdp/ripple-framework/issues/1178

### What I did
<!-- Summary of changes made in the Pull Request  -->
- remove trailing slash before requesting to page API
- 

### How to test
<!-- Summary of how to test  -->
- create a redirect in BE
- access it on FE with trailing slash and without it.
- both should be working.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

