### PR TITLE
[R20-2027] set default layout background colour

### DIFF
--- a/packages/ripple-ui-core/src/components/layout/RplLayout.css
+++ b/packages/ripple-ui-core/src/components/layout/RplLayout.css
@@ -1,5 +1,9 @@
 @import '@dpc-sdp/ripple-ui-core/style/breakpoints';
 
+.rpl-layout {
+  background-color: var(--rpl-clr-neutral-0);
+}
+
 .rpl-layout__body-wrap {
   padding-top: var(--rpl-sp-8);
   padding-bottom: var(--rpl-sp-8);


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-2027

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Some accessibility tools allow inverting a page, however without the bg being explicitly set this doesn't work well.

#### Before
<img width="1073" alt="Screenshot 2024-06-26 at 2 51 55 PM" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/8e817453-f396-472e-ad35-9b9e692d699a">


#### After
<img width="1115" alt="Screenshot 2024-06-26 at 2 53 36 PM" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/e3b7110e-fef4-4846-a325-a1ed016af6e2">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

