### PR TITLE
[SDPAP-9392] support for inline checkboxes

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/custom-collection.feature
+++ b/examples/nuxt-app/test/features/landingpage/custom-collection.feature
@@ -31,6 +31,7 @@ Feature: Custom Collection
     Then the custom collection dropdown field labelled "Term filter example" should have the "default" variant applied
     Then the custom collection dropdown field labelled "Terms dependent example" should have the "default" variant applied
     Then the custom collection dropdown field labelled "Terms dependent child example" should have the "default" variant applied
+    And the custom collection checkbox group labelled "Checkbox group" should have the "default" variant applied
 
   @mockserver
   Scenario: Default page - reverse form theme
@@ -45,6 +46,7 @@ Feature: Custom Collection
     Then the custom collection dropdown field labelled "Term filter example" should have the "reverse" variant applied
     Then the custom collection dropdown field labelled "Terms dependent example" should have the "reverse" variant applied
     Then the custom collection dropdown field labelled "Terms dependent child example" should have the "reverse" variant applied
+    And the custom collection checkbox group labelled "Checkbox group" should have the "reverse" variant applied
 
   @mockserver
   Scenario: Alt page - default form theme
@@ -59,6 +61,7 @@ Feature: Custom Collection
     Then the custom collection dropdown field labelled "Term filter example" should have the "reverse" variant applied
     Then the custom collection dropdown field labelled "Terms dependent example" should have the "reverse" variant applied
     Then the custom collection dropdown field labelled "Terms dependent child example" should have the "reverse" variant applied
+    And the custom collection checkbox group labelled "Checkbox group" should have the "reverse" variant applied
 
   @mockserver
   Scenario: Alt page - reverse form theme
@@ -73,6 +76,7 @@ Feature: Custom Collection
     Then the custom collection dropdown field labelled "Term filter example" should have the "default" variant applied
     Then the custom collection dropdown field labelled "Terms dependent example" should have the "default" variant applied
     Then the custom collection dropdown field labelled "Terms dependent child example" should have the "default" variant applied
+    And the custom collection checkbox group labelled "Checkbox group" should have the "default" variant applied
 
   @mockserver
   Scenario: Error

--- a/examples/nuxt-app/test/features/search-listing/filters.feature
+++ b/examples/nuxt-app/test/features/search-listing/filters.feature
@@ -38,16 +38,19 @@ Feature: Search listing - Filter
     And the search network request is stubbed with fixture "/search-listing/filters/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
 
-    When I visit the page "/filters?termFilter=Green&singleTermFilter=Aqua&checkboxFilter=Archived"
+    When I visit the page "/filters?termFilter=Green&singleTermFilter=Aqua&checkboxFilter=Archived&checkboxFilterGroup=Weekdays"
     Then the search listing page should have 2 results
     And the search network request should be called with the "/search-listing/filters/request-term-single" fixture
 
-    Then the filters toggle should show 3 applied filters
+    Then the filters toggle should show 4 applied filters
 
     When I toggle the search listing filters section
     Then the search listing dropdown field labelled "Term filter example" should have the value "Green"
     And the search listing dropdown field labelled "Single term filter example" should have the value "Aqua"
     And the search listing checkbox field labelled "Show archived content" should be checked
+    And the search listing checkbox group labelled "Checkbox group" should have the following options checked
+      | label    |
+      | Weekdays |
 
   @mockserver
   Example: Term filter - Should reflect an array from the URL
@@ -55,14 +58,18 @@ Feature: Search listing - Filter
     And the search network request is stubbed with fixture "/search-listing/filters/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
 
-    When I visit the page "/filters?termFilter=Green&termFilter=Red"
+    When I visit the page "/filters?termFilter=Green&termFilter=Red&checkboxFilterGroup=Weekdays&checkboxFilterGroup=Weekends"
     Then the search listing page should have 2 results
     And the search network request should be called with the "/search-listing/filters/request-term-array" fixture
 
-    Then the filters toggle should show 1 applied filters
+    Then the filters toggle should show 2 applied filters
 
     When I toggle the search listing filters section
     Then the search listing dropdown field labelled "Term filter example" should have the value "Red, Green"
+    And the search listing checkbox group labelled "Checkbox group" should have the following options checked
+      | label    |
+      | Weekdays |
+      | Weekends |
 
   @mockserver
   Example: Terms (with an 's') - Should reflect a single value from the URL
@@ -124,23 +131,24 @@ Feature: Search listing - Filter
     And the search network request is stubbed with fixture "/search-listing/filters/response" and status 200
     And the current date is "Fri, 02 Feb 2050 03:04:05 GMT"
 
-    When I visit the page "/filters?q=test123&page=2&functionFilter=open&termsFilter=Purple&termFilter=Green&rawFilter=Birds&checkboxFilter=Archived"
+    When I visit the page "/filters?q=test123&page=2&functionFilter=open&termsFilter=Purple&termFilter=Green&rawFilter=Birds&checkboxFilter=Archived&checkboxFilterGroup=Weekdays"
     Then the search listing page should have 2 results
     And the search network request should be called with the "/search-listing/filters/request-clear-filled" fixture
 
-    Then the filters toggle should show 5 applied filters
+    Then the filters toggle should show 6 applied filters
     Then the URL should reflect that the current page number is 2
     Then the URL should reflect that the current search term is "test123"
 
     When I toggle the search listing filters section
     Then the search input should have the value "test123"
     Then the URL should reflect that the current active filters are as follows:
-      | id             | value    |
-      | rawFilter      | Birds    |
-      | termFilter     | Green    |
-      | termsFilter    | Purple   |
-      | functionFilter | open     |
-      | checkboxFilter | Archived |
+      | id                  | value    |
+      | rawFilter           | Birds    |
+      | termFilter          | Green    |
+      | termsFilter         | Purple   |
+      | functionFilter      | open     |
+      | checkboxFilter      | Archived |
+      | checkboxFilterGroup | Weekdays |
 
     Then the search listing dropdown field labelled "Raw filter example" should have the value "Birds"
     Then the search listing dropdown field labelled "Term filter example" should have the value "Green"
@@ -154,12 +162,13 @@ Feature: Search listing - Filter
     Then the URL should reflect that the current page has been reset
     Then the URL should reflect that the current search term is ""
     Then the URL should reflect that the current active filters are as follows:
-      | id             |
-      | rawFilter      |
-      | termFilter     |
-      | termsFilter    |
-      | functionFilter |
-      | checkboxFilter |
+      | id                  |
+      | rawFilter           |
+      | termFilter          |
+      | termsFilter         |
+      | functionFilter      |
+      | checkboxFilter      |
+      | checkboxFilterGroup |
 
     Then the search input should have the value ""
     Then the search listing dropdown field labelled "Raw filter example" should have the value "Select a pet"
@@ -167,6 +176,7 @@ Feature: Search listing - Filter
     Then the search listing dropdown field labelled "Terms filter example" should have the value "Select a colour"
     Then the search listing dropdown field labelled "Custom function filter example" should have the value "Select a status"
     And the search listing checkbox field labelled "Show archived content" should not be checked
+    And the search listing checkbox group labelled "Checkbox group" should not have any options checked
 
   @mockserver
   Example: Should update the URL when the filters are applied

--- a/examples/nuxt-app/test/fixtures/landingpage/custom-collection/alt-form-theme-default.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/custom-collection/alt-form-theme-default.json
@@ -92,6 +92,32 @@
             }
           },
           {
+            "id": "checkboxFilterGroup",
+            "component": "TideSearchFilterCheckboxGroup",
+            "filter": {
+              "type": "terms",
+              "value": "checkboxFilterGroup.keyword",
+              "multiple": true
+            },
+            "props": {
+              "id": "checkboxFilterGroup",
+              "label": "Checkbox group",
+              "layout": "inline",
+              "options": [
+                {
+                  "id": "Weekdays",
+                  "label": "Weekdays",
+                  "value": "Weekdays"
+                },
+                {
+                  "id": "Weekends",
+                  "label": "Weekends",
+                  "value": "Weekends"
+                }
+              ]
+            }
+          },
+          {
             "id": "dependentFilter",
             "component": "TideSearchFilterDependent",
             "columns": "rpl-grid",

--- a/examples/nuxt-app/test/fixtures/landingpage/custom-collection/alt-form-theme-reverse.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/custom-collection/alt-form-theme-reverse.json
@@ -92,6 +92,32 @@
             }
           },
           {
+            "id": "checkboxFilterGroup",
+            "component": "TideSearchFilterCheckboxGroup",
+            "filter": {
+              "type": "terms",
+              "value": "checkboxFilterGroup.keyword",
+              "multiple": true
+            },
+            "props": {
+              "id": "checkboxFilterGroup",
+              "label": "Checkbox group",
+              "layout": "inline",
+              "options": [
+                {
+                  "id": "Weekdays",
+                  "label": "Weekdays",
+                  "value": "Weekdays"
+                },
+                {
+                  "id": "Weekends",
+                  "label": "Weekends",
+                  "value": "Weekends"
+                }
+              ]
+            }
+          },
+          {
             "id": "dependentFilter",
             "component": "TideSearchFilterDependent",
             "columns": "rpl-grid",

--- a/examples/nuxt-app/test/fixtures/landingpage/custom-collection/form-theme-default.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/custom-collection/form-theme-default.json
@@ -77,6 +77,32 @@
             }
           },
           {
+            "id": "checkboxFilterGroup",
+            "component": "TideSearchFilterCheckboxGroup",
+            "filter": {
+              "type": "terms",
+              "value": "checkboxFilterGroup.keyword",
+              "multiple": true
+            },
+            "props": {
+              "id": "checkboxFilterGroup",
+              "label": "Checkbox group",
+              "layout": "inline",
+              "options": [
+                {
+                  "id": "Weekdays",
+                  "label": "Weekdays",
+                  "value": "Weekdays"
+                },
+                {
+                  "id": "Weekends",
+                  "label": "Weekends",
+                  "value": "Weekends"
+                }
+              ]
+            }
+          },
+          {
             "id": "checkboxFilter",
             "component": "TideSearchFilterCheckbox",
             "filter": {

--- a/examples/nuxt-app/test/fixtures/landingpage/custom-collection/form-theme-reverse.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/custom-collection/form-theme-reverse.json
@@ -92,6 +92,32 @@
             }
           },
           {
+            "id": "checkboxFilterGroup",
+            "component": "TideSearchFilterCheckboxGroup",
+            "filter": {
+              "type": "terms",
+              "value": "checkboxFilterGroup.keyword",
+              "multiple": true
+            },
+            "props": {
+              "id": "checkboxFilterGroup",
+              "label": "Checkbox group",
+              "layout": "inline",
+              "options": [
+                {
+                  "id": "Weekdays",
+                  "label": "Weekdays",
+                  "value": "Weekdays"
+                },
+                {
+                  "id": "Weekends",
+                  "label": "Weekends",
+                  "value": "Weekends"
+                }
+              ]
+            }
+          },
+          {
             "id": "dependentFilter",
             "component": "TideSearchFilterDependent",
             "columns": "rpl-grid",

--- a/examples/nuxt-app/test/fixtures/search-listing/filters/page.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/filters/page.json
@@ -218,6 +218,32 @@
           "checkboxLabel": "Show archived content",
           "onValue": "Archived"
         }
+      },
+      {
+        "id": "checkboxFilterGroup",
+        "component": "TideSearchFilterCheckboxGroup",
+        "filter": {
+          "type": "terms",
+          "value": "checkboxFilterGroup.keyword",
+          "multiple": true
+        },
+        "props": {
+          "id": "checkboxFilterGroup",
+          "label": "Checkbox group",
+          "layout": "inline",
+          "options": [
+            {
+              "id": "Weekdays",
+              "label": "Weekdays",
+              "value": "Weekdays"
+            },
+            {
+              "id": "Weekends",
+              "label": "Weekends",
+              "value": "Weekends"
+            }
+          ]
+        }
       }
     ]
   }

--- a/examples/nuxt-app/test/fixtures/search-listing/filters/request-clear-filled.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/filters/request-clear-filled.json
@@ -72,6 +72,11 @@
           "terms": {
             "checkboxFilter.keyword": ["Archived"]
           }
+        },
+        {
+          "terms": {
+            "checkboxFilterGroup.keyword": ["Weekdays"]
+          }
         }
       ]
     }

--- a/examples/nuxt-app/test/fixtures/search-listing/filters/request-term-array.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/filters/request-term-array.json
@@ -21,6 +21,11 @@
           "terms": {
             "termFilter.keyword": ["Green", "Red"]
           }
+        },
+        {
+          "terms": {
+            "checkboxFilterGroup.keyword": ["Weekdays", "Weekends"]
+          }
         }
       ]
     }

--- a/examples/nuxt-app/test/fixtures/search-listing/filters/request-term-single.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/filters/request-term-single.json
@@ -31,6 +31,11 @@
           "terms": {
             "checkboxFilter.keyword": ["Archived"]
           }
+        },
+        {
+          "terms": {
+            "checkboxFilterGroup.keyword": ["Weekdays"]
+          }
         }
       ]
     }

--- a/packages/ripple-test-utils/step_definitions/components/custom-collection.ts
+++ b/packages/ripple-test-utils/step_definitions/components/custom-collection.ts
@@ -54,6 +54,19 @@ Then(
 )
 
 Then(
+  `the custom collection checkbox group labelled {string} should have the {string} variant applied`,
+  (label: string, theme: string) => {
+    cy.get(`[data-component-type="TideCustomCollection"] .rpl-form-label`)
+      .contains(label)
+      .parents('.rpl-form__fieldset')
+      .find('.rpl-form-option-group .rpl-form-option')
+      .each(($el) => {
+        cy.wrap($el).should('have.class', `rpl-form-option--${theme}`)
+      })
+  }
+)
+
+Then(
   `the custom collection dropdown field labelled {string} should have the {string} variant applied`,
   (label: string, theme: string) => {
     cy.get(`[data-component-type="TideCustomCollection"] label`)

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -251,6 +251,42 @@ Then(
 )
 
 Then(
+  `the search listing checkbox group labelled {string} should have the following options checked`,
+  (label: string, dataTable: DataTable) => {
+    const table = dataTable.hashes()
+
+    cy.get('.rpl-form-label')
+      .contains(label)
+      .parents('.rpl-form__fieldset')
+      .find('.rpl-form-option-group')
+      .as('checkboxGroup')
+
+    table.forEach((row) => {
+      cy.get('@checkboxGroup').within(() => {
+        cy.contains('label', row.label)
+          .invoke('attr', 'for')
+          .then((checkboxId) => {
+            cy.get(`#${checkboxId}`).should('be.checked')
+          })
+      })
+    })
+  }
+)
+
+Then(
+  `the search listing checkbox group labelled {string} should not have any options checked`,
+  (label: string) => {
+    cy.get('.rpl-form-label')
+      .contains(label)
+      .parents('.rpl-form__fieldset')
+      .find('.rpl-form-option-group input')
+      .each(($el) => {
+        cy.wrap($el).should('not.be.checked')
+      })
+  }
+)
+
+Then(
   `the search listing checkbox field labelled {string} should not be checked`,
   (label: string) => {
     cy.get(`label`)

--- a/packages/ripple-tide-search/components/global/TideSearchFilterCheckboxGroup.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchFilterCheckboxGroup.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+interface Props {
+  id: string
+  label: string
+  timestamp?: string | number
+  variant: 'default' | 'reverse'
+  layout?: 'block' | 'inline'
+  options?: any[]
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <FormKit
+    :id="id"
+    :key="`${id}-${timestamp}`"
+    :name="id"
+    type="RplFormCheckboxGroup"
+    :label="label"
+    :variant="variant"
+    :layout="layout"
+    :options="options"
+  />
+</template>

--- a/packages/ripple-tide-search/composables/useTideSearch.ts
+++ b/packages/ripple-tide-search/composables/useTideSearch.ts
@@ -296,8 +296,9 @@ export default ({
         // Need to work out if form has value - will be different for different controls
         const hasValue = (v: unknown) => {
           if (
-            itm.component === 'TideSearchFilterDropdown' &&
-            itm?.props?.multiple
+            (itm.component === 'TideSearchFilterDropdown' &&
+              itm?.props?.multiple) ||
+            itm?.component === 'TideSearchFilterCheckboxGroup'
           ) {
             return Array.isArray(v) && v.length > 0
           }
@@ -750,6 +751,7 @@ export default ({
         if (
           (filterConfig?.component === 'TideSearchFilterDropdown' &&
             filterConfig?.props?.multiple) ||
+          filterConfig?.component === 'TideSearchFilterCheckboxGroup' ||
           filterConfig?.component === 'TideSearchFilterDependent'
         ) {
           parsedValue = Array.isArray(parsedValue) ? parsedValue : [parsedValue]

--- a/packages/ripple-tide-webform/mapping/webforms-mapping.ts
+++ b/packages/ripple-tide-webform/mapping/webforms-mapping.ts
@@ -200,6 +200,8 @@ export const getFormSchemaFromMapping = async (
           disabled: field['#disabled'],
           label: field['#title'],
           help: field['#description'],
+          layout:
+            field['#options_display'] === 'side_by_side' ? 'inline' : 'block',
           options: Object.entries(field['#options'] || {}).map(
             ([value, label]) => {
               return {
@@ -223,6 +225,8 @@ export const getFormSchemaFromMapping = async (
           disabled: field['#disabled'],
           label: field['#title'],
           help: field['#description'],
+          layout:
+            field['#options_display'] === 'side_by_side' ? 'inline' : 'block',
           options: Object.entries(field['#options'] || {}).map(
             ([value, label]) => {
               return {

--- a/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormCheckboxGroup.css
+++ b/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormCheckboxGroup.css
@@ -2,3 +2,9 @@
   display: flex;
   flex-direction: column;
 }
+
+.rpl-form-option-group--inline {
+  flex-wrap: wrap;
+  flex-direction: row;
+  column-gap: var(--rpl-sp-6);
+}

--- a/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormCheckboxGroup.stories.mdx
+++ b/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormCheckboxGroup.stories.mdx
@@ -56,7 +56,6 @@ export const SingleTemplate = (args) => ({
   </Story>
 </Canvas>
 
-
 <Canvas>
   <Story
     name='Reverse variant'
@@ -84,7 +83,6 @@ export const SingleTemplate = (args) => ({
     {SingleTemplate.bind()}
   </Story>
 </Canvas>
-
 
 <Canvas>
   <Story
@@ -122,3 +120,26 @@ export const SingleTemplate = (args) => ({
   </Story>
 </Canvas>
 
+<Canvas>
+  <Story
+    name='Horizontal layout'
+    args={{
+      id: 'checkbox-inline',
+      layout: 'inline',
+      options: [
+        {
+          id: 'checkbox-inline-item-1',
+          value: 'item-1',
+          label: 'An inline checkbox'
+        },
+        {
+          id: 'checkbox-inline-item-2',
+          value: 'item-2',
+          label: 'Another inline checkbox'
+        }
+      ]
+    }}
+  >
+    {SingleTemplate.bind()}
+  </Story>
+</Canvas>

--- a/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormCheckboxGroup.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormCheckboxGroup.vue
@@ -12,6 +12,7 @@ interface Props {
   label?: string
   disabled?: boolean
   variant?: 'default' | 'reverse'
+  layout?: 'block' | 'inline'
   pii?: boolean
   onChange: (value: string[]) => void
   options: {
@@ -26,6 +27,7 @@ const props = withDefaults(defineProps<Props>(), {
   label: undefined,
   disabled: false,
   variant: 'default',
+  layout: 'block',
   pii: true,
   onChange: () => undefined,
   options: () => []
@@ -77,7 +79,7 @@ const isChecked = (optionValue: string): boolean => {
 </script>
 
 <template>
-  <div class="rpl-form-option-group">
+  <div :class="['rpl-form-option-group', `rpl-form-option-group--${layout}`]">
     <RplFormOption
       v-for="(option, i) in options"
       :id="`${id}-${option.id}`"

--- a/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormRadioGroup.css
+++ b/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormRadioGroup.css
@@ -4,6 +4,7 @@
 }
 
 .rpl-form-radio-group--inline {
+  flex-wrap: wrap;
   flex-direction: row;
-  gap: var(--rpl-sp-6);
+  column-gap: var(--rpl-sp-6);
 }

--- a/packages/ripple-ui-forms/src/inputs/checkboxGroup.ts
+++ b/packages/ripple-ui-forms/src/inputs/checkboxGroup.ts
@@ -20,6 +20,8 @@ export const checkboxGroup: FormKitTypeDefinition = {
       onChange: '$node.input',
       options: '$node.props.options',
       validationMeta: '$node.props.validationMeta',
+      variant: '$node.props.variant',
+      layout: '$node.props.layout',
       pii: '$node.props.pii'
     }
   }),
@@ -36,7 +38,7 @@ export const checkboxGroup: FormKitTypeDefinition = {
   /**
    * An array of extra props to accept for this input.
    */
-  props: ['options', 'pii'],
+  props: ['options', 'variant', 'layout', 'pii'],
   /**
    * Additional features that should be added to your input
    */


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SDPAP-9392

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Add support for inline checkboxes (much like our existing inline radios)
- Support 'Side by side' mode i.e. `inline` for radios and checkboxes in webforms
- Add checkbox group support to search listings 

#### Search listing
<img width="1122" alt="search-listing" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/ed69b866-4b6f-4887-a797-ff413d9cf38b">

#### Webforms
<img width="547" alt="webforms" src="https://github.com/dpc-sdp/ripple-framework/assets/287178/bdd167a6-255a-4e08-9a1d-78a92531dd55">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added cypress tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

