### PR TITLE
feat(@dpc-sdp/nuxt-ripple-cli): update action versions, allow layer pre-releases

### DIFF
--- a/packages/nuxt-ripple-cli/src/commands/init/_templates/layer/latest/github/publish.yml.t
+++ b/packages/nuxt-ripple-cli/src/commands/init/_templates/layer/latest/github/publish.yml.t
@@ -14,9 +14,9 @@ jobs:
       packages: write
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           registry-url: 'https://npm.pkg.github.com/'
           node-version: 20
@@ -25,10 +25,10 @@ jobs:
           git config --global user.email "sdp.devs@dpc.vic.gov.au"
           git config --global user.name "SDP Deploy"
       - name: Bump version from release number
-        run: npm version ${{ github.event.release.name }} --allow-same-version
+        run: npm version ${{ github.event.release.name }} --no-git-tag-version
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to GH Package registry
-        run: npm publish
+        run: npm publish --tag ${{ github.event.release.prerelease && 'alpha' || 'latest' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->


### What I did
<!-- Summary of changes made in the Pull Request  -->
- Update action versions
- Allow for publishing layer pre-release versions using GitHubs pre-release checkbox
  <img width="402" alt="Screenshot 2024-07-02 at 4 23 32 PM" src="https://github.com/dpc-sdp/ripple-lib-starter/assets/287178/8533a288-4ab6-4dc3-bb13-5a7f8e339bda">
- Updated `--allow-same-version` to bring it inline with what's actually used in the layers/ripple-lib-starter repo
- Also updated ripple-lib-starter: https://github.com/dpc-sdp/ripple-lib-starter/pull/26

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

