### PR TITLE
[R20-2053] Map improvements to support R20-2053

### DIFF
--- a/packages/nuxt-ripple/app.config.ts
+++ b/packages/nuxt-ripple/app.config.ts
@@ -46,7 +46,7 @@ declare module '@nuxt/schema' {
         >
         mapResultHooks?: Record<
           string,
-          (map: any, results: any, location: any) => void
+          (map: any, results: any, location: any, mapDeadSpace: any) => void
         >
       }
     }

--- a/packages/ripple-tide-search/components/TideSearchResultTableCell.vue
+++ b/packages/ripple-tide-search/components/TideSearchResultTableCell.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="tide-search-result-cell"><slot></slot></div>
+</template>
+
+<style>
+.tide-search-result-cell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rpl-sp-3);
+
+  address {
+    font-style: normal;
+  }
+}
+</style>

--- a/packages/ripple-tide-search/components/TideSearchResultTableHeading.vue
+++ b/packages/ripple-tide-search/components/TideSearchResultTableHeading.vue
@@ -1,0 +1,16 @@
+<template>
+  <h4
+    class="tide-search-result-table-heading"
+  >
+    <slot></slot>
+  </h4>
+</template>
+
+
+<style>
+@import '@dpc-sdp/ripple-ui-core/style/breakpoints';
+
+.tide-search-result-table-heading {
+  font-weight: bold;
+}
+</style>

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -286,7 +286,12 @@ onMapResultsHook.value = () => {
   const hookFnName = props.mapConfig?.onResultsHook
   const fns: Record<
     string,
-    (map: any, results: any, locationQuery: any) => Promise<any>
+    (
+      map: any,
+      results: any,
+      locationQuery: any,
+      mapDeadSpace?: any
+    ) => Promise<any>
   > = appConfig?.ripple?.search?.mapResultHooks || {}
 
   if (!hookFnName) {
@@ -301,7 +306,12 @@ onMapResultsHook.value = () => {
     )
   }
 
-  hookFn(rplMapRef.value, mapResults.value, locationOrGeolocation.value)
+  hookFn(
+    rplMapRef.value,
+    mapResults.value,
+    locationOrGeolocation.value,
+    deadSpace.value
+  )
 }
 
 const resultsContainer = computed(

--- a/packages/ripple-ui-core/src/components/description-list/constants.ts
+++ b/packages/ripple-ui-core/src/components/description-list/constants.ts
@@ -9,4 +9,4 @@ export type IRplDescriptionListItem = {
   iconColour?: (typeof RplColorThemes)[number]
 }
 
-export type IRplDescriptionListVariant = 'default' | 'icon'
+export type IRplDescriptionListVariant = 'default' | 'icon' | 'compact'

--- a/packages/ripple-ui-maps/src/components/map/RplMap.vue
+++ b/packages/ripple-ui-maps/src/components/map/RplMap.vue
@@ -1,3 +1,9 @@
+<script lang="ts">
+const primaryColor = getComputedStyle(
+  document.documentElement
+).getPropertyValue('--rpl-clr-primary')
+</script>
+
 <script setup lang="ts">
 import { RplIcon } from '@dpc-sdp/ripple-ui-core/vue'
 import type { IRplMapFeature } from './../../types'
@@ -57,7 +63,7 @@ const props = withDefaults(defineProps<Props>(), {
   initialCenter: () => [144.9631, -36.8136], // melbourne CBD
   homeViewExtent: () => [144.9631, -36.8136], // melbourne CBD
   pinStyle: (feature) => {
-    let color = feature.color || 'red'
+    let color = feature.color || primaryColor || 'red'
     const ic = new Icon({
       src: markerIconDefaultSrc,
       color,

--- a/packages/ripple-ui-maps/src/components/map/utils.ts
+++ b/packages/ripple-ui-maps/src/components/map/utils.ts
@@ -153,7 +153,7 @@ export const centerMap = (
   }
 
   const view = map.getView()
-  const resolution = view.getResolution()
+  const resolution = view.getResolutionForZoom(zoom || view.getZoom())
   const offsetCoord = [
     position[0] + offset.x * resolution,
     position[1] + offset.y * resolution


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/R20-2053

### What I did
<!-- Summary of changes made in the Pull Request  -->
- default map pin color to primary site color instead of red
- fixed description list missing types
- added helper components for laying out result tables
- pass map deadspace to map results hook so that they can zoom correctly
- fixed centreMap util when it's given a custom zoom level

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

