### PR TITLE
[R20-2065][R20-2066] aligned table content

### DIFF
--- a/packages/ripple-tide-api/src/utils/markup-transpiler/cheerio.test.ts
+++ b/packages/ripple-tide-api/src/utils/markup-transpiler/cheerio.test.ts
@@ -17,7 +17,8 @@ const markup = {
   button: `<a class="button" href="https://example.com">Button</a>`,
   link: `<a href="https://example.com" target="_blank">Link</a>`,
   list: `<ul type="disc"><li>List item</li></ul><ul type="circle"><li>List item</li></ul><ul type="square"><li>List item</li></ul><ol type="i"><li>List item</li></ol><ol type="I"><li>List item</li></ol><ol type="a"><li>List item</li></ol><ol type="A"><li>List item</li></ol>`,
-  iframe: `<iframe src="https://powerbi.com" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>`
+  iframe: `<iframe src="https://powerbi.com" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>`,
+  alignment: `<p class="text-align-left">Left</p><p class="text-align-center">Center</p><p class="text-align-right">Right</p>`
 }
 
 const fixed = {
@@ -70,7 +71,8 @@ const fixed = {
   button: `<a class="rpl-button rpl-button--default rpl-u-focusable-block rpl-button--filled" href="https://example.com"><span class="rpl-button__label rpl-type-label rpl-type-weight-bold">Button</span></a>`,
   link: `<a href="https://example.com" target="_blank" class="rpl-text-link rpl-u-focusable-inline">Link<span class="rpl-u-visually-hidden">(opens in a new window)</span></a>`,
   list: `<ul class="rpl-type-list-ul--disc"><li>List item</li></ul><ul class="rpl-type-list-ul--disc"><li>List item</li></ul><ul class="rpl-type-list-ul--square"><li>List item</li></ul><ol class="rpl-type-list-ol--lower-roman"><li>List item</li></ol><ol class="rpl-type-list-ol--upper-roman"><li>List item</li></ol><ol class="rpl-type-list-ol--lower-latin"><li>List item</li></ol><ol class="rpl-type-list-ol--upper-latin"><li>List item</li></ol>`,
-  iframe: `<div class="rpl-iframe rpl-iframe--default rpl-iframe--auto"><iframe src="https://powerbi.com" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div>`
+  iframe: `<div class="rpl-iframe rpl-iframe--default rpl-iframe--auto"><iframe src="https://powerbi.com" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div>`,
+  alignment: `<p class="rpl-u-text-left">Left</p><p class="rpl-u-text-center">Center</p><p class="rpl-u-text-right">Right</p>`
 }
 
 describe('ripple-tide-api/utils/markup-transpiler/cheerio', () => {

--- a/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
+++ b/packages/ripple-tide-api/src/utils/markup-transpiler/default-plugins.ts
@@ -294,6 +294,25 @@ const pluginIFrames = function (this: any) {
   })
 }
 
+const pluginTextAlign = function (this: any) {
+  this.find('.text-align-left, .text-align-center, .text-align-right').map(
+    (i: any, el: any) => {
+      const $el = this.find(el)
+      const alignments = ['left', 'center', 'right']
+
+      alignments.forEach((alignment) => {
+        if ($el.hasClass(`text-align-${alignment}`)) {
+          $el
+            .removeClass(`text-align-${alignment}`)
+            .addClass(`rpl-u-text-${alignment}`)
+        }
+      })
+
+      return $el
+    }
+  )
+}
+
 export default [
   pluginTables,
   pluginCallout,
@@ -304,5 +323,6 @@ export default [
   pluginButtons,
   pluginLinks,
   pluginLists,
-  pluginIFrames
+  pluginIFrames,
+  pluginTextAlign
 ]

--- a/packages/ripple-ui-core/src/styles/components/_table.css
+++ b/packages/ripple-ui-core/src/styles/components/_table.css
@@ -57,6 +57,10 @@
   th,
   td {
     vertical-align: top;
+
+    > *:first-child {
+      margin-top: 0;
+    }
   }
 
   caption {
@@ -76,7 +80,6 @@
   caption,
   th,
   td {
-    text-align: left;
     padding: var(--rpl-sp-4) var(--rpl-sp-3);
 
     &:first-child {
@@ -86,6 +89,11 @@
     &:last-child {
       padding-right: var(--rpl-sp-4);
     }
+  }
+
+  caption:not([align]),
+  th:not([align]) {
+    text-align: left;
   }
 
   tbody {
@@ -142,9 +150,8 @@
 }
 
 [dir='rtl'] .rpl-table {
-  caption,
-  th,
-  td {
+  caption:not([align]),
+  th:not([align]) {
     text-align: right;
   }
 }

--- a/packages/ripple-ui-core/src/styles/components/_table.css
+++ b/packages/ripple-ui-core/src/styles/components/_table.css
@@ -140,3 +140,11 @@
     }
   }
 }
+
+[dir='rtl'] .rpl-table {
+  caption,
+  th,
+  td {
+    text-align: right;
+  }
+}

--- a/packages/ripple-ui-core/src/styles/utilities/_typography.css
+++ b/packages/ripple-ui-core/src/styles/utilities/_typography.css
@@ -305,3 +305,15 @@ html {
 .rpl-u-hyphenate {
   hyphens: auto;
 }
+
+.rpl-u-text-left {
+  text-align: left;
+}
+
+.rpl-u-text-center {
+  text-align: center;
+}
+
+.rpl-u-text-right {
+  text-align: right;
+}


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issues**: 
https://digital-vic.atlassian.net/browse/R20-2065
https://digital-vic.atlassian.net/browse/R20-2066

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Align RTL page tables to the right by default
- Allow for setting alignment of tables via CMS tools

<img width="634" alt="Screenshot 2024-07-12 at 2 31 42 PM" src="https://github.com/user-attachments/assets/50ae8577-e135-4baa-8f1d-e77b92d68f56">

<img width="615" alt="tables-ltr" src="https://github.com/user-attachments/assets/302dae8f-c829-4646-b2bd-fcb6f99a405f">
<img width="623" alt="tables-rtl" src="https://github.com/user-attachments/assets/515a0ca3-d89d-46f6-b279-f2956a179a76">

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

