### PR TITLE
Feature/reusable paragraphs

### DIFF
--- a/packages/ripple-tide-landing-page/mapping/components.ts
+++ b/packages/ripple-tide-landing-page/mapping/components.ts
@@ -1,4 +1,5 @@
 import basicTextMapping from './components/basic-text/basic-text-mapping'
+import fromLibraryMapping from './components/from-library/from-library-mapping'
 import accordionMapping from './components/accordion/accordion-mapping'
 import promoCardMapping from './components/promo-card/promo-card-mapping'
 import navigationCardMapping from './components/navigation-card/navigation-card-mapping'
@@ -19,6 +20,7 @@ import openFormsMapping from './components/openforms/openforms-mapping'
 
 export default {
   'paragraph--basic_text': basicTextMapping,
+  'paragraph--from_library': fromLibraryMapping,
   'paragraph--accordion': accordionMapping,
   'paragraph--promotion_card': promoCardMapping,
   'paragraph--navigation_card': navigationCardMapping,

--- a/packages/ripple-tide-landing-page/mapping/components.ts
+++ b/packages/ripple-tide-landing-page/mapping/components.ts
@@ -18,7 +18,7 @@ import dataTableMapping from './components/data-table/data-table-mapping'
 import compactCardsMapping from './components/compact-cards/compact-cards-mapping'
 import openFormsMapping from './components/openforms/openforms-mapping'
 
-export default {
+const mappings = {
   'paragraph--basic_text': basicTextMapping,
   'paragraph--from_library': fromLibraryMapping,
   'paragraph--accordion': accordionMapping,
@@ -39,3 +39,12 @@ export default {
   'paragraph--compact_card_collection': compactCardsMapping,
   'paragraph--form_embed_openforms': openFormsMapping
 }
+
+// Handle reusable paragraphs in any includes so they load the referenced items.
+Object.keys(mappings).forEach(k => {
+  if (k !== 'paragraph--from_library' && mappings[k].includes.length > 0) {
+    mappings[k].includes = mappings[k].includes.concat(mappings[k].includes.map(k => k.replace('field_landing_page_component.','field_landing_page_component.field_reusable_paragraph.paragraphs.')))
+  }
+})
+
+export default mappings

--- a/packages/ripple-tide-landing-page/mapping/components/from-library/from-library-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/from-library/from-library-mapping.ts
@@ -1,0 +1,29 @@
+import { TideDynamicPageComponent } from '@dpc-sdp/ripple-tide-api/types'
+import componentMappings from '../../components'
+
+export interface ITideFromLibrary {
+  id: string | null
+}
+
+export const fromLibraryMapping = async (
+  field,
+  page,
+  tidePageApi
+): TideDynamicPageComponent<ITideFromLibrary> => {
+  const paragraph = field?.field_reusable_paragraph?.paragraphs;
+  if (paragraph) {
+    return componentMappings[paragraph.type].mapping(paragraph, page, tidePageApi)
+  }
+
+  console.error(`No mapping found for paragraphs library item ${id}`)
+}
+
+export const fromLibraryIncludes = [
+  'field_landing_page_component.field_reusable_paragraph.paragraphs'
+]
+
+export default {
+  includes: fromLibraryIncludes,
+  mapping: fromLibraryMapping,
+  contentTypes: ['landing_page']
+}


### PR DESCRIPTION
**Issue**: PR for [Reusable Content feature request](https://github.com/dpc-sdp/ripple-framework/issues/1264)

### What I did
- Added a `from-library` component mapping to `ripple-tide-landing-page` (to handle the `from_library` paragraph type from the backend, see 'How to test')
- Modified component mapping's `includes` properties to include a `from_library` instance's referenced paragraph so it can be passed on to the appropriate existing component mapping

### How to test
#### Backend steps
-  In the Tide installation the local Ripple installation fetches from, enable the Paragraphs Library module, and edit a paragraph type to check the "Can be promoted to library" checkbox
- Create or edit a Landing page, and add a paragraph of the type configured to be reusable. In the action dots menu for the paragraph, click "Promote to library"
- Save & publish the landing page

#### Frontend steps
- Load the frontend URL for the landing page that was created or edited
- Confirm the reusable paragraph is rendered, the same as if it was a regular instance of the same type

### Checklist

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

