### PR TITLE
[SD-75] Clear geolocation button errors on search or reset

### DIFF
--- a/examples/nuxt-app/test/features/maps/geolocate.feature
+++ b/examples/nuxt-app/test/features/maps/geolocate.feature
@@ -1,0 +1,34 @@
+Feature: Custom collection map component
+
+  I want to display a map of features from an indexed data pipeline
+
+  Background:
+    Given the site endpoint returns fixture "/site/vic" with status 200
+    And the search autocomplete request is stubbed with "/search-listing/suggestions/none" fixture
+    Given I am using a "macbook-16" device
+    Given the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" aggregation request is stubbed with fixture "/map-table/vsba/aggregations" and status 200 as alias "aggReq"
+    Given the "/test-map-shape-layer" network request is stubbed with fixture "/maps/sample-shapes"
+      | method | status |
+      | GET    | 200    |
+    Given the "https://base.maps.vic.gov.au/service*" network request is stubbed with fixture "/maps/service.png"
+      | method | status |
+      | GET    | 200    |
+
+  @mockserver
+  Scenario: The geolocate button is hidden when not enabled
+    Given I load the page fixture with "/maps/basic-page"
+    Given the geolocation button is not enabled
+    And the page endpoint for path "/map" returns the loaded fixture
+    And the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is delayed by 1000 milliseconds and stubbed with fixture "/site/search-response", status 200 and alias "searchReq"
+    Given I visit the page "/map"
+
+    Then the geolocate button is hidden
+
+  @mockserver
+  Scenario: The geolocate button is shown when enabled
+    Given I load the page fixture with "/maps/basic-page"
+    Given the geolocation button is enabled
+    And the page endpoint for path "/map" returns the loaded fixture
+    And the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is delayed by 1000 milliseconds and stubbed with fixture "/site/search-response", status 200 and alias "searchReq"
+    Given I visit the page "/map"
+    Then the geolocate button is displayed

--- a/packages/ripple-test-utils/step_definitions/components/maps.ts
+++ b/packages/ripple-test-utils/step_definitions/components/maps.ts
@@ -190,3 +190,31 @@ Given(
     )
   }
 )
+
+Given(`the geolocation button is not enabled`, () => {
+  cy.get('@pageFixture').then((response) => {
+    set(
+      response,
+      'bodyComponents[0].props.locationQueryConfig.showGeolocationButton',
+      false
+    )
+  })
+})
+
+Given(`the geolocation button is enabled`, () => {
+  cy.get('@pageFixture').then((response) => {
+    set(
+      response,
+      'bodyComponents[0].props.locationQueryConfig.showGeolocationButton',
+      true
+    )
+  })
+})
+
+Given(`the geolocate button is hidden`, () => {
+  cy.get('.rpl-map-geolocate__btn').should('not.exist')
+})
+
+Given(`the geolocate button is displayed`, () => {
+  cy.get('.rpl-map-geolocate__btn').should('exist')
+})

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -331,6 +331,8 @@ const emitSearchEvent = (event) => {
 }
 
 const handleSearchSubmit = (event) => {
+  geolocationError.value = null
+
   if (props.userFilters && props.userFilters.length) {
     cachedSubmitEvent.value = event
     // Submitting the search term should also 'apply' the filters, but the filters live in a seperate form.
@@ -378,6 +380,7 @@ const handleFilterReset = (event: rplEventPayload) => {
   )
 
   locationQuery.value = null
+  geolocationError.value = null
   resetSearch()
   resetFilters()
   submitSearch()


### PR DESCRIPTION

<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: Raised from testing https://digital-vic.atlassian.net/browse/SD-75

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Made sure the error message displayed when a user denies location permissions don't stick around after searching or clearing the search.
- 

### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

