### PR TITLE
[SD-127] fixed getTaxonomy only getting first 50 pages

### DIFF
--- a/packages/ripple-tide-api/src/services/tide-page.ts
+++ b/packages/ripple-tide-api/src/services/tide-page.ts
@@ -327,10 +327,10 @@ export default class TidePageApi extends TideApiBase {
   async getEntityList(
     entityType,
     bundle,
-    filtering,
-    includes,
-    pagination,
-    sorting,
+    filtering?,
+    includes?,
+    pagination?,
+    sorting?,
     { allPages = true } = {}
   ) {
     const params: Record<string, any> = {
@@ -442,20 +442,8 @@ export default class TidePageApi extends TideApiBase {
   }
 
   async getTaxonomy(taxonomyName: string) {
-    const params = {
-      site: this.site
-    }
     try {
-      const { data: response } = await this.get(
-        `/taxonomy_term/${taxonomyName}`,
-        {
-          params
-        }
-      )
-      if (response) {
-        const resource = jsonapiParse.parse(response).data
-        return resource
-      }
+      return await this.getEntityList('taxonomy_term', taxonomyName)
     } catch (error: any) {
       throw new ApplicationError('Error fetching taxonomy', { cause: error })
     }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-127

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Changed getTaxonomy to utilise the existing 'getEntityList' function, which already handles pagination of the drupal API
- 

### How to test
<!-- Summary of how to test  -->
- See ticket
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

