### PR TITLE
[SRM-1505] add default timeZone for formatDate

### DIFF
--- a/packages/ripple-ui-core/src/lib/helpers.ts
+++ b/packages/ripple-ui-core/src/lib/helpers.ts
@@ -15,7 +15,7 @@ export const formatDate = (
 ): string => {
   const date = new Date(value)
 
-  const defaultOptions: Intl.DateTimeFormatOptions = { dateStyle: 'medium' }
+  const defaultOptions: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeZone: 'Australia/Melbourne' }
 
   options = { ...defaultOptions, ...options }
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SRM-1505

### What I did
<!-- Summary of changes made in the Pull Request  -->
-  Add default timeZone for formatDate so it matches the other date formatter and avoids rare hydration missmatch warnings

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

