### PR TITLE
chore: pin es dependency versions

### DIFF
--- a/packages/nuxt-ripple-cli/src/commands/init/_templates/site/latest/package.json.t
+++ b/packages/nuxt-ripple-cli/src/commands/init/_templates/site/latest/package.json.t
@@ -30,8 +30,6 @@ to: package.json
   },
   "devDependencies": {
     "@dpc-sdp/eslint-config-ripple": "<%= rplVersion %>",
-    "@elastic/search-ui-app-search-connector": "1.19.1",
-    "@elastic/search-ui-elasticsearch-connector": "1.19.1",
     "nuxt": "3.11.2",
     "eslint": "^8.28.0"
   },

--- a/packages/ripple-tide-search/package.json
+++ b/packages/ripple-tide-search/package.json
@@ -14,8 +14,8 @@
     "@dpc-sdp/ripple-ui-core": "workspace:*",
     "@dpc-sdp/ripple-ui-forms": "workspace:*",
     "@dpc-sdp/ripple-ui-maps": "workspace:*",
-    "@elastic/search-ui": "^1.21.4",
-    "@elastic/search-ui-app-search-connector": "^1.21.4",
-    "@elastic/search-ui-elasticsearch-connector": "^1.21.4"
+    "@elastic/search-ui": "1.19.1",
+    "@elastic/search-ui-app-search-connector": "1.19.1",
+    "@elastic/search-ui-elasticsearch-connector": "1.19.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -744,14 +744,14 @@ importers:
         specifier: workspace:*
         version: link:../ripple-ui-maps
       '@elastic/search-ui':
-        specifier: ^1.21.4
-        version: 1.21.4
+        specifier: 1.19.1
+        version: 1.19.1
       '@elastic/search-ui-app-search-connector':
-        specifier: ^1.21.4
-        version: 1.21.4
+        specifier: 1.19.1
+        version: 1.19.1
       '@elastic/search-ui-elasticsearch-connector':
-        specifier: ^1.21.4
-        version: 1.21.4
+        specifier: 1.19.1
+        version: 1.19.1
 
   packages/ripple-tide-topic:
     dependencies:
@@ -2314,14 +2314,14 @@ packages:
     resolution: {integrity: sha512-mN5EbbgSp1rfRmQ/5Hv7jqAK8xhGJxCg7G84xje8hSefE59P+HPPCv/+DgesCUSJdZpwXIo0DwOWHfHvktxxLw==}
     engines: {node: '>=14'}
 
-  '@elastic/search-ui-app-search-connector@1.21.4':
-    resolution: {integrity: sha512-HKhmvh9LqfHWTWbqdT57ZrLy7CwBgVgEFJL4ZOZi7bbLWwVaS2r7gt4s7s4HJLep61ZVnefm2lj7i2qqr8qYaQ==}
+  '@elastic/search-ui-app-search-connector@1.19.1':
+    resolution: {integrity: sha512-cHYtk2M6F1OdkJSXdb6EMvn6p4oE2duNZ/Il+W++6l5NXzyqPrVnh+6uGEPN64j+CxvTwxAEdV2uQbUpEKBrtw==}
 
-  '@elastic/search-ui-elasticsearch-connector@1.21.4':
-    resolution: {integrity: sha512-sZcrUA6Zehnn84oyoAE3HnDehH1OWtXBXSvSXUTPMmsNIQkAKLqCQphHBPkDoYe1kUJQMb4lllsXIc6Zk9KQYg==}
+  '@elastic/search-ui-elasticsearch-connector@1.19.1':
+    resolution: {integrity: sha512-cYR1vXN7HLREHsGZridqXtgrqLHH81E2leV/ZkvBlFDIszOUQCBlGnWBi4g/tt6fcfKSb3fGM1GMIRQhMaNSMA==}
 
-  '@elastic/search-ui@1.21.4':
-    resolution: {integrity: sha512-3Uep2aaFVzEn3hYWogd54zd5hbIrtEwEmI3P88o17JOEt296kwcoc6hsXJQLtMiXBIG4Wk3K28dJI+0KKBO9fQ==}
+  '@elastic/search-ui@1.19.1':
+    resolution: {integrity: sha512-2DcZ1b4fiL0vjRhVFU1OnqGKOy7aVJr563VO9FDpUUFCXlMySKWnuwh0kcUatqeNO4Sxw9GyJZbtzOgnTyQaag==}
 
   '@elastic/transport@8.3.1':
     resolution: {integrity: sha512-jv/Yp2VLvv5tSMEOF8iGrtL2YsYHbpf4s+nDsItxUTLFTzuJGpnsB/xBlfsoT2kAYEnWHiSJuqrbRcpXEI/SEQ==}
@@ -7989,9 +7989,6 @@ packages:
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
-
-  domutils@3.0.1:
-    resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
@@ -18121,24 +18118,24 @@ snapshots:
   '@elastic/elasticsearch@8.6.0':
     dependencies:
       '@elastic/transport': 8.3.1
-      tslib: 2.5.0
+      tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@elastic/search-ui-app-search-connector@1.21.4':
+  '@elastic/search-ui-app-search-connector@1.19.1':
     dependencies:
       '@elastic/app-search-javascript': 8.5.1
-      '@elastic/search-ui': 1.21.4
+      '@elastic/search-ui': 1.19.1
 
-  '@elastic/search-ui-elasticsearch-connector@1.21.4':
+  '@elastic/search-ui-elasticsearch-connector@1.19.1':
     dependencies:
       '@elastic/elasticsearch': 8.6.0
-      '@elastic/search-ui': 1.21.4
+      '@elastic/search-ui': 1.19.1
       '@searchkit/sdk': 3.0.0(@elastic/elasticsearch@8.6.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@elastic/search-ui@1.21.4':
+  '@elastic/search-ui@1.19.1':
     dependencies:
       date-fns: 1.30.1
       deep-equal: 1.1.1
@@ -18151,7 +18148,7 @@ snapshots:
       hpagent: 1.2.0
       ms: 2.1.3
       secure-json-parse: 2.7.0
-      tslib: 2.5.0
+      tslib: 2.6.2
       undici: 5.28.2
     transitivePeerDependencies:
       - supports-color
@@ -26065,12 +26062,6 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 4.3.1
 
-  domutils@3.0.1:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-
   domutils@3.1.0:
     dependencies:
       dom-serializer: 2.0.0
@@ -27906,10 +27897,10 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.6
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
-      tiny-invariant: 1.3.1
+      tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
       value-equal: 1.0.1
 
@@ -27968,7 +27959,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      domutils: 3.0.1
+      domutils: 3.1.0
       entities: 4.5.0
 
   htmlparser2@9.1.0:
@@ -34940,7 +34931,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 16.18.12
-      acorn: 8.11.3
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -34960,7 +34951,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.15.10
-      acorn: 8.11.3
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request  -->
- ES dependencies are being pinned in all projects due to change in export upstream. I'd like to be able to remove this at the project level


### How to test
<!-- Summary of how to test  -->
- build project without pinned es version, needs to be installed into other project as workspace imports dont have the same issue
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

