### PR TITLE
[SD-103] Added option to hide results count on custom collections

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/custom-collection.feature
+++ b/examples/nuxt-app/test/features/landingpage/custom-collection.feature
@@ -115,3 +115,13 @@ Feature: Custom Collection
     When I visit the page "/filter-only"
     Then the custom collection component results count should read "Displaying 1-20 of 282 results"
     And only the search filters should be visible
+
+  @mockserver
+  Example: Should hide results count when hideResultsCount is set
+    Given I load the page fixture with "/landingpage/custom-collection/page"
+    And the custom collection results count has been hidden
+    And the search network request is stubbed with fixture "/landingpage/custom-collection/response" and status 200
+    Then the page endpoint for path "/filter-only" returns the loaded fixture
+
+    When I visit the page "/filter-only"
+    Then the custom collection component results count should be hidden

--- a/packages/ripple-test-utils/step_definitions/components/custom-collection.ts
+++ b/packages/ripple-test-utils/step_definitions/components/custom-collection.ts
@@ -15,6 +15,12 @@ Then(
   }
 )
 
+Then(`the custom collection component results count should be hidden`, () => {
+  cy.get(`[data-component-type="search-listing-result-count"]`).should(
+    'not.exist'
+  )
+})
+
 Then(
   `the custom collection component should have the {string} form theme applied`,
   (theme: string) => {
@@ -113,3 +119,13 @@ Then(
     })
   }
 )
+
+When('the custom collection results count has been hidden', () => {
+  cy.get('@pageFixture').then((response) => {
+    set(
+      response,
+      `bodyComponents[0].props.resultsConfig.hideResultsCount`,
+      true
+    )
+  })
+})

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -667,7 +667,7 @@ const locationOrGeolocation = computed(() => {
       >
         <template #left>
           <TideSearchResultsCount
-            v-if="!searchError"
+            v-if="!resultsConfig.hideResultsCount && !searchError"
             :pagingStart="pagingStart + 1"
             :pagingEnd="pagingEnd + 1"
             :totalResults="totalResults"

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -89,6 +89,10 @@ export type TideSearchListingResultsConfig = {
    * by default, with no transformResultFn, the raw result is mapped to item._source
    */
   transformResultFn?: string
+  /**
+   * @description useful for listings that want to completely customise the results area
+   */
+  hideResultsCount?: false
 }
 
 export type TideSearchListingLayoutConfig = {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-103

### What I did
<!-- Summary of changes made in the Pull Request  -->
- to support a new requirement to completely override the custom collection listing view
- option is called hideResultsCount, defaults to false to keep backwards compatibility

### How to test
<!-- Summary of how to test  -->
- Added cypress test
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

