### PR TITLE
[SD-102] Added additional features needed for KYC map migration

### DIFF
--- a/packages/ripple-tide-search/components/global/TideSearchAddressLookup.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchAddressLookup.vue
@@ -36,6 +36,12 @@
           variant="dark"
           class="rpl-u-margin-l-3"
         />
+        <RplTag
+          v-else-if="option?.tag"
+          :label="option?.tag"
+          variant="dark"
+          class="rpl-u-margin-l-3"
+        />
       </template>
     </RplSearchBar>
   </div>
@@ -114,7 +120,11 @@ async function submitAction(e: any) {
     const arcGISAddress = await getAddressFromArcGISMagicKey(
       item.arcGISMagicKey
     )
-    emit('update', arcGISAddress)
+    emit('update', {
+      ...item,
+      ...(arcGISAddress || {}),
+      arcGISMagicKey: undefined
+    })
   } else {
     emit('update', item || null)
   }
@@ -239,7 +249,17 @@ async function centerMapOnLocation(
         animationDuration: animate ? 800 : 0
       })
     }
-  } else if (!location?.postcode) {
+
+    return
+  }
+
+  if (map && location?.center) {
+    const zoom = location?.zoomLevel || 16
+    centerMap(map, fromLonLat(location?.center), zoom, deadSpace.value, null)
+    return
+  }
+
+  if (!location) {
     // reset back to initial view on empty query
     fitDefaultExtent(map, deadSpace.value, defaultExtent)
   }

--- a/packages/ripple-tide-search/utils/rplAddressSuggestionsFn.ts
+++ b/packages/ripple-tide-search/utils/rplAddressSuggestionsFn.ts
@@ -1,7 +1,70 @@
 import { capitalCase } from 'change-case'
 
+const getLGASuggestions = async (query, args) => {
+  const suggestionsIndex = args.lgaIndex
+
+  const searchUrl = `/api/tide/app-search/${suggestionsIndex}/elasticsearch/_search`
+
+  const queryDSL = {
+    query: {
+      bool: {
+        should: [
+          {
+            match: {
+              name: {
+                query,
+                operator: 'and'
+              }
+            }
+          },
+          {
+            prefix: {
+              name: {
+                value: query,
+                case_insensitive: true
+              }
+            }
+          },
+          {
+            term: {
+              postcode: {
+                value: query
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  const test = await $fetch(searchUrl, {
+    method: 'POST',
+    body: {
+      ...queryDSL,
+      size: args.maxLGASuggestions
+    }
+  })
+
+  return test.hits.hits.map((itm) => {
+    const areaType = getSingleResultValue(itm._source.area_type)
+    const rawName = getSingleResultValue(itm._source['name'])
+    const name = areaType === 'lga' ? `${rawName} Council` : rawName
+    const tag =
+      areaType !== 'lga'
+        ? `${itm._source.lga_official_name} Council`
+        : undefined
+
+    return {
+      id: itm._id,
+      name,
+      bbox: itm._source.lga_bbox,
+      tag
+    }
+  })
+}
+
 const getSuburbSuggestions = async (query, args) => {
-  const suggestionsIndex = 'vicpol-postcode-localities'
+  const suggestionsIndex = args.suburbsIndex
 
   const searchUrl = `/api/tide/app-search/${suggestionsIndex}/elasticsearch/_search`
 
@@ -74,15 +137,20 @@ const getAddressSuggestions = async (query, args) => {
     return {
       id: item.magicKey,
       name: capitalCase(item.text),
-      arcGISMagicKey: item.magicKey
+      arcGISMagicKey: item.magicKey,
+      zoomLevel: args?.addressZoomLevel
     }
   })
 }
 
 export default async (query, args) => {
   const defaultArgs = {
+    maxLGASuggestions: 0,
     maxSuburbSuggestions: 0,
-    maxAddressSuggestions: 10
+    maxAddressSuggestions: 10,
+    suburbsIndex: 'vicpol-postcode-localities',
+    lgaIndex: 'budget-areas-data',
+    addressZoomLevel: 12
   }
 
   const argsWithDefaults = {
@@ -91,9 +159,14 @@ export default async (query, args) => {
   }
 
   return [
+    ...(args.maxLGASuggestions > 0
+      ? await getLGASuggestions(query, argsWithDefaults)
+      : []),
     ...(args.maxSuburbSuggestions > 0
       ? await getSuburbSuggestions(query, argsWithDefaults)
       : []),
-    ...(await getAddressSuggestions(query, argsWithDefaults))
+    ...(args.maxAddressSuggestions > 0
+      ? await getAddressSuggestions(query, argsWithDefaults)
+      : [])
   ]
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-102

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Added support for LGAs to the rplAddressSuggestionsFunction
  - LGA suggestions will appear at the top of the suggestions when the `maxLGASuggestions` is greater than 0.
  - ![Screenshot 2024-08-28 at 8 35 45 AM](https://github.com/user-attachments/assets/1ef1e451-e63d-4d96-a8f9-792922794653)
  - ![Screenshot 2024-08-28 at 8 35 54 AM](https://github.com/user-attachments/assets/fdd7940f-498f-4148-9907-2e9b8a745a00)
- Added OOTB support for adding a 'tag' next to a suggestion, if a suggestion has the `tag` attribute it will display next to the suggestion label:
  - ![Screenshot 2024-08-28 at 8 38 40 AM](https://github.com/user-attachments/assets/42d7e4fa-76c2-4afa-8163-1275a32215f2)
  - ![Screenshot 2024-08-28 at 8 38 56 AM](https://github.com/user-attachments/assets/fb4fb26a-bca8-4c8e-9862-71004b838d11)
- Added OOTB support for zooming to a point on the map:
  - When a suggestion has a `bbox` property, the map will zoom to fit that bounding box
  - Otherwise, if a suggestion has a `center` property, the map will zoom to that coordinate
  - A suggestion can now have a 'zoomLevel` property which controls the desired zoom level when zooming into a center point



### How to test
<!-- Summary of how to test  -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

