### PR TITLE
[SD-198] Reusable paragraphs

### DIFF
--- a/packages/ripple-tide-landing-page/mapping/components.ts
+++ b/packages/ripple-tide-landing-page/mapping/components.ts
@@ -1,4 +1,5 @@
 import basicTextMapping from './components/basic-text/basic-text-mapping'
+import fromLibraryMapping from './components/from-library/from-library-mapping'
 import accordionMapping from './components/accordion/accordion-mapping'
 import promoCardMapping from './components/promo-card/promo-card-mapping'
 import navigationCardMapping from './components/navigation-card/navigation-card-mapping'
@@ -19,6 +20,7 @@ import openFormsMapping from './components/openforms/openforms-mapping'
 
 export default {
   'paragraph--basic_text': basicTextMapping,
+  'paragraph--from_library': fromLibraryMapping,
   'paragraph--accordion': accordionMapping,
   'paragraph--promotion_card': promoCardMapping,
   'paragraph--navigation_card': navigationCardMapping,

--- a/packages/ripple-tide-landing-page/mapping/components.ts
+++ b/packages/ripple-tide-landing-page/mapping/components.ts
@@ -1,3 +1,5 @@
+import { reusableParagraphTypes } from '../types'
+
 import basicTextMapping from './components/basic-text/basic-text-mapping'
 import fromLibraryMapping from './components/from-library/from-library-mapping'
 import accordionMapping from './components/accordion/accordion-mapping'
@@ -18,7 +20,13 @@ import dataTableMapping from './components/data-table/data-table-mapping'
 import compactCardsMapping from './components/compact-cards/compact-cards-mapping'
 import openFormsMapping from './components/openforms/openforms-mapping'
 
-const mappings = {
+const mappings: {
+  [key: string]: {
+    includes: string[]
+    mapping: Function
+    contentTypes: string[]
+  }
+} = {
   'paragraph--basic_text': basicTextMapping,
   'paragraph--from_library': fromLibraryMapping,
   'paragraph--accordion': accordionMapping,
@@ -40,10 +48,18 @@ const mappings = {
   'paragraph--form_embed_openforms': openFormsMapping
 }
 
-// Handle reusable paragraphs in any includes so they load the referenced items.
-Object.keys(mappings).forEach(k => {
-  if (k !== 'paragraph--from_library' && mappings[k].includes.length > 0) {
-    mappings[k].includes = mappings[k].includes.concat(mappings[k].includes.map(k => k.replace('field_landing_page_component.','field_landing_page_component.field_reusable_paragraph.paragraphs.')))
+// Add reusable include on whitelisted paragraph types
+reusableParagraphTypes.forEach((k) => {
+  if (mappings[k].includes.length > 0) {
+    mappings[k].includes = [
+      ...mappings[k].includes,
+      ...mappings[k].includes.map((j) =>
+        j.replace(
+          'field_landing_page_component.',
+          'field_landing_page_component.field_reusable_paragraph.paragraphs.'
+        )
+      )
+    ]
   }
 })
 

--- a/packages/ripple-tide-landing-page/mapping/components.ts
+++ b/packages/ripple-tide-landing-page/mapping/components.ts
@@ -18,7 +18,7 @@ import dataTableMapping from './components/data-table/data-table-mapping'
 import compactCardsMapping from './components/compact-cards/compact-cards-mapping'
 import openFormsMapping from './components/openforms/openforms-mapping'
 
-export default {
+const mappings = {
   'paragraph--basic_text': basicTextMapping,
   'paragraph--from_library': fromLibraryMapping,
   'paragraph--accordion': accordionMapping,
@@ -39,3 +39,12 @@ export default {
   'paragraph--compact_card_collection': compactCardsMapping,
   'paragraph--form_embed_openforms': openFormsMapping
 }
+
+// Handle reusable paragraphs in any includes so they load the referenced items.
+Object.keys(mappings).forEach(k => {
+  if (k !== 'paragraph--from_library' && mappings[k].includes.length > 0) {
+    mappings[k].includes = mappings[k].includes.concat(mappings[k].includes.map(k => k.replace('field_landing_page_component.','field_landing_page_component.field_reusable_paragraph.paragraphs.')))
+  }
+})
+
+export default mappings

--- a/packages/ripple-tide-landing-page/mapping/components/from-library/from-library-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/from-library/from-library-mapping.ts
@@ -1,26 +1,30 @@
 import { TideDynamicPageComponent } from '@dpc-sdp/ripple-tide-api/types'
 import componentMappings from '../../components'
+import { reusableParagraphTypes } from '../../../types'
 
-export interface ITideFromLibrary {
+interface TideFromLibrary {
   id: string | null
+  type: string
 }
 
-export const fromLibraryMapping = async (
-  field,
-  page,
-  tidePageApi
-): TideDynamicPageComponent<ITideFromLibrary> => {
-  const paragraph = field?.field_reusable_paragraph?.paragraphs;
-  if (paragraph) {
-    return componentMappings[paragraph.type].mapping(paragraph, page, tidePageApi)
+export const fromLibraryMapping = (
+  field: { field_reusable_paragraph: { paragraphs: TideFromLibrary } },
+  page: any,
+  tidePageApi: any
+): TideDynamicPageComponent<TideFromLibrary> => {
+  const paragraph = field?.field_reusable_paragraph?.paragraphs
+  if (paragraph && reusableParagraphTypes.includes(paragraph.type)) {
+    return componentMappings[paragraph.type].mapping(
+      paragraph,
+      page,
+      tidePageApi
+    )
   }
 
-  console.error(`No mapping found for paragraphs library item ${id}`)
+  console.error(`No mapping found for paragraphs library item ${field?.id}`)
 }
 
-export const fromLibraryIncludes = [
-  'field_landing_page_component.field_reusable_paragraph.paragraphs'
-]
+export const fromLibraryIncludes = []
 
 export default {
   includes: fromLibraryIncludes,

--- a/packages/ripple-tide-landing-page/mapping/components/from-library/from-library-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/from-library/from-library-mapping.ts
@@ -1,0 +1,29 @@
+import { TideDynamicPageComponent } from '@dpc-sdp/ripple-tide-api/types'
+import componentMappings from '../../components'
+
+export interface ITideFromLibrary {
+  id: string | null
+}
+
+export const fromLibraryMapping = async (
+  field,
+  page,
+  tidePageApi
+): TideDynamicPageComponent<ITideFromLibrary> => {
+  const paragraph = field?.field_reusable_paragraph?.paragraphs;
+  if (paragraph) {
+    return componentMappings[paragraph.type].mapping(paragraph, page, tidePageApi)
+  }
+
+  console.error(`No mapping found for paragraphs library item ${id}`)
+}
+
+export const fromLibraryIncludes = [
+  'field_landing_page_component.field_reusable_paragraph.paragraphs'
+]
+
+export default {
+  includes: fromLibraryIncludes,
+  mapping: fromLibraryMapping,
+  contentTypes: ['landing_page']
+}

--- a/packages/ripple-tide-landing-page/types.ts
+++ b/packages/ripple-tide-landing-page/types.ts
@@ -28,3 +28,18 @@ export interface TideLandingPagePage extends TidePageBase {
    * @description Background body colour
    */
 }
+
+// Whitelist reusable paragraph types
+export const reusableParagraphTypes = [
+  'paragraph--basic_text',
+  'paragraph--from_library',
+  'paragraph--accordion',
+  'paragraph--promotion_card',
+  'paragraph--navigation_card',
+  'paragraph--statistics_grid',
+  'paragraph--timelines',
+  'paragraph--call_to_action',
+  'paragraph--card_carousel',
+  'paragraph--complex_image',
+  'paragraph--data_table'
+]


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-198

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Cherry picked Bryce's POC over from his fork to publish an alpha for integration testing 
- Added a whitelist in types to give some control over which paragraphs have the reusable include added (the API response is fairly resilient, but just wanted to avoid running up too many includes in cases where it clearly isn't needed/used)

### How to test
<!-- Summary of how to test  -->
- Need to run against a BE with reusable paragraphs enabled, e.g. https://nginx-php.pr-1691.content-vic.sdp4.sdp.vic.gov.au/
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

