### PR TITLE
[SD-264] add lga data to suggestion mapping

### DIFF
--- a/packages/ripple-tide-search/utils/rplAddressSuggestionsFn.ts
+++ b/packages/ripple-tide-search/utils/rplAddressSuggestionsFn.ts
@@ -57,6 +57,10 @@ const getLGASuggestions = async (query, args) => {
     return {
       id: itm._id,
       name,
+      areaType,
+      lgaName: itm._source?.lga_name,
+      lgaOfficialName: itm._source?.lga_official_name,
+      lgaCode: itm._source?.lga_code,
       bbox: itm._source.lga_bbox,
       tag
     }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-264

### What I did
<!-- Summary of changes made in the Pull Request  -->
- This adds the extra lga data to the suggestion mapping so that data can be used down the line, for instance when adding a `dslTransformFunction` for filtering results

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

