### PR TITLE
fix: update tabs story so tabs can be clicked

### DIFF
--- a/packages/ripple-ui-core/src/components/tabs/RplTabs.stories.mdx
+++ b/packages/ripple-ui-core/src/components/tabs/RplTabs.stories.mdx
@@ -4,15 +4,20 @@ import {
   Story,
   ArgsTable
 } from '@storybook/addon-docs'
+import { ref } from 'vue'
 import RplTabs from './RplTabs.vue'
 import { a11yStoryCheck } from './../../../stories/interactions.js'
 
 export const SingleTemplate = (args) => ({
   components: { RplTabs },
   setup() {
-    return { args }
+    const activeTab = ref('default')
+
+    const handleTabChange = ({ key }) => activeTab.value = key
+
+    return { args, activeTab, handleTabChange }
   },
-  template: '<RplTabs v-bind="args" /><div id="panel-default"></div><div id="panel-extra"></div><div id="panel-more"></div>'
+  template: '<RplTabs v-bind="args" :activeTab="args?.activeTab || activeTab" @toggleTab="handleTabChange" /><div id="panel-default"></div><div id="panel-extra"></div><div id="panel-more"></div>'
 })
 
 <Meta
@@ -53,7 +58,6 @@ export const SingleTemplate = (args) => ({
           icon: 'pin'
         }
       ],
-      activeTab: 'default',
       mode: 'horizontal'
     }}
   >
@@ -78,7 +82,6 @@ export const SingleTemplate = (args) => ({
           icon: 'pin'
         }
       ],
-      activeTab: 'default',
       mode: 'vertical'
     }}
   >


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Just updates the tabs story so tabs can be clicked/interacted with in the story, like the olden days https://www.ripple.sdp.vic.gov.au/storybook/?path=/story/core-navigation-tabs--default-story
 
### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [ ] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

