### PR TITLE
fix: removes unwanted internal: from URLs

### DIFF
--- a/packages/ripple-tide-api/src/utils/mapping-utils.test.ts
+++ b/packages/ripple-tide-api/src/utils/mapping-utils.test.ts
@@ -79,6 +79,11 @@ const field = {
       url: '/landing-page-cc-2',
       origin_url: '/landing-page-cc-2'
     },
+    field_related_link: {
+      uri: 'internal:/contact-us',
+      title: 'Get in touch',
+      options: []
+    },
     field_paragraph_location: {
       langcode: null,
       country_code: 'AU',
@@ -159,6 +164,11 @@ describe('ripple-tide-api/mapping utils', () => {
     expect(getLinkFromField(field, 'field_paragraph_link')).toEqual({
       text: '',
       url: '/landing-page-cc-2'
+    })
+
+    expect(getLinkFromField(field, 'field_related_link')).toEqual({
+      text: 'Get in touch',
+      url: '/contact-us'
     })
   })
 

--- a/packages/ripple-tide-api/src/utils/mapping-utils.ts
+++ b/packages/ripple-tide-api/src/utils/mapping-utils.ts
@@ -145,10 +145,14 @@ export const getLinkFromField = (
     return null
   }
 
-  return {
-    text: linkField.title || linkField.text || '',
-    url: linkField.url || linkField.origin_url || linkField.uri || ''
+  let text = linkField.title || linkField.text || ''
+  let url = linkField.url || linkField.origin_url || linkField.uri || ''
+
+  if (url.startsWith('internal:')) {
+    url = url.replace(/^internal:/, '')
   }
+
+  return { text, url }
 }
 
 export const getAddress = (field: drupalField) => {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SDPA-1234 or GitHub Issue Number eg: #123  -->

**Issue**: https://github.com/dpc-sdp/ripple-framework/issues/1321

### What I did
<!-- Summary of changes made in the Pull Request  -->
- Removes  unwanted `internal:` from URLs

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added unit tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

