### PR TITLE
feat: use prop value for map height

### DIFF
--- a/examples/nuxt-app/test/features/maps/maps.feature
+++ b/examples/nuxt-app/test/features/maps/maps.feature
@@ -147,3 +147,11 @@ Feature: Custom collection map component
     When I click the exit fullscreen button
     And I wait 100 milliseconds
     Then the map should not be fullscreen
+
+  @mockserver
+  Scenario: Map height can be customised
+    Given I load the page fixture with "/maps/basic-page"
+    And the map height is set to 606
+    Then the page endpoint for path "/map" returns the loaded fixture
+    When I visit the page "/map"
+    Then the map height is 606

--- a/packages/ripple-test-utils/step_definitions/components/maps.ts
+++ b/packages/ripple-test-utils/step_definitions/components/maps.ts
@@ -277,3 +277,13 @@ Then('the map should not be fullscreen', () => {
     expect(doc.fullscreenElement).to.be.null
   })
 })
+
+Given('the map height is set to {int}', (height: number) => {
+  cy.get('@pageFixture').then((response) => {
+    set(response, 'bodyComponents[0].props.mapConfig.props.height', height)
+  })
+})
+
+Then('the map height is {int}', (height: number) => {
+  cy.get('.rpl-map__map').should('have.css', 'height', `${height}px`)
+})

--- a/packages/ripple-tide-search/components/global/TideSearchListingResultsMap.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchListingResultsMap.vue
@@ -8,7 +8,7 @@
       :features="features"
       projection="EPSG:3857"
       :popupType="popupType"
-      :map-height="550"
+      :map-height="height"
       :pinStyle="pinStyle"
       :noresults="noresults"
       :hasSidePanel="hasSidePanel"
@@ -103,6 +103,7 @@ interface Props {
   initialising?: boolean
   clusteringDistance?: number
   maxZoom?: number
+  height?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -117,7 +118,8 @@ const props = withDefaults(defineProps<Props>(), {
   hasSidePanel: false,
   initialising: false,
   clusteringDistance: undefined,
-  maxZoom: undefined
+  maxZoom: undefined,
+  height: 550
 })
 
 const appConfig = useAppConfig()


### PR DESCRIPTION
### What I did
<!-- Summary of changes made in the Pull Request  -->
- Use prop value for map height

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed.
- [ ] I've updated the documentation site as needed.
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new components only

- [ ] I have added a story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] Any events are emitted on the event bus

