### PR TITLE
[SD-329] per site section quick exit

### DIFF
--- a/examples/nuxt-app/test/features/site/shared-elements.feature
+++ b/examples/nuxt-app/test/features/site/shared-elements.feature
@@ -26,10 +26,32 @@ Feature: Shared site elements
     Then the quick exit should be displayed
 
   @mockserver
-  Scenario: Quick Exit (enabled in site section)
+  Scenario: Quick Exit (disabled site wide, enabled in site section)
     Given the site endpoint returns fixture "/site/shared-elements" with status 200
     And I load the page fixture with "/landingpage/home"
     And the site section quick exit is enabled
+    And the page endpoint for path "/section-page" returns the loaded fixture
+    Given I visit the page "/section-page"
+    Then the quick exit should be displayed
+
+  @mockserver
+  Scenario: Quick Exit (enabled site wide, disabled in site section)
+    Given I load the site fixture with "/site/shared-elements"
+    And the site wide quick exit is enabled
+    And the site endpoint returns the loaded fixture
+    Given I load the page fixture with "/landingpage/home"
+    And the site section quick exit is disabled
+    And the page endpoint for path "/section-page" returns the loaded fixture
+    Given I visit the page "/section-page"
+    Then the quick exit should not be displayed
+
+  @mockserver
+  Scenario: Quick Exit (enabled site wide, inherited in site section)
+    Given I load the site fixture with "/site/shared-elements"
+    And the site wide quick exit is enabled
+    And the site endpoint returns the loaded fixture
+    Given I load the page fixture with "/landingpage/home"
+    And the site section quick exit is inherited
     And the page endpoint for path "/section-page" returns the loaded fixture
     Given I visit the page "/section-page"
     Then the quick exit should be displayed

--- a/packages/nuxt-ripple/mapping/base/index.ts
+++ b/packages/nuxt-ripple/mapping/base/index.ts
@@ -23,7 +23,11 @@ import {
   includes as sidebarSiteSectionNavIncludes
 } from './sidebar-site-section-nav/sidebar-site-section-nav-mapping.js'
 import TidePageMeta from './page-meta.js'
-import { getSiteKeyValues, getSiteSection } from '@dpc-sdp/ripple-tide-api'
+import {
+  getSiteKeyValues,
+  getSiteSection,
+  getBoolFromString
+} from '@dpc-sdp/ripple-tide-api'
 
 export const tidePageBaseMapping = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -76,7 +80,9 @@ export const tidePageBaseMapping = ({
         id: siteData.drupal_internal__tid,
         name: siteData.name,
         siteOverrides: {
-          showQuickExit: siteData?.field_site_show_exit_site || null,
+          showQuickExit: getBoolFromString(
+            siteData?.field_show_exit_site_specific
+          ),
           theme: getSiteKeyValues('field_site_theme_values', siteData) || {},
           featureFlags:
             getSiteKeyValues('field_site_feature_flags', siteData) || {}

--- a/packages/ripple-test-utils/step_definitions/common/shared-elements.ts
+++ b/packages/ripple-test-utils/step_definitions/common/shared-elements.ts
@@ -252,6 +252,18 @@ Given('the site section quick exit is enabled', () => {
   })
 })
 
+Given('the site section quick exit is disabled', () => {
+  cy.get('@pageFixture').then((response) => {
+    set(response, 'siteSection.siteOverrides.showQuickExit', false)
+  })
+})
+
+Given('the site section quick exit is inherited', () => {
+  cy.get('@pageFixture').then((response) => {
+    set(response, 'siteSection.siteOverrides.showQuickExit', null)
+  })
+})
+
 Then('the quick exit should be displayed', () => {
   cy.get('.rpl-primary-nav__quick-exit').should('be.visible')
 })

--- a/packages/ripple-tide-api/src/utils/mapping-utils.test.ts
+++ b/packages/ripple-tide-api/src/utils/mapping-utils.test.ts
@@ -9,7 +9,8 @@ import {
   getSiteKeyValues,
   getSiteSection,
   humanizeFilesize,
-  getPlainText
+  getPlainText,
+  getBoolFromString
 } from './mapping-utils.js'
 
 const field = {
@@ -228,5 +229,11 @@ describe('ripple-tide-api/mapping utils', () => {
     expect(getPlainText(field.field_acknowledgement_to_country)).toEqual(
       'We acknowledge Aboriginal and Torres Strait Islander people as the First People and traditional owners and custodians of the lands, seas and waters of Australia. We pay our respect to Elders past and present.'
     )
+  })
+
+  it(`returns a boolean value from supplied string`, () => {
+    expect(getBoolFromString('yes')).toEqual(true)
+    expect(getBoolFromString('no')).toEqual(false)
+    expect(getBoolFromString('')).toEqual(null)
   })
 })

--- a/packages/ripple-tide-api/src/utils/mapping-utils.ts
+++ b/packages/ripple-tide-api/src/utils/mapping-utils.ts
@@ -251,6 +251,16 @@ export const getPlainText = (content: string): string => {
   return content?.replace(/(\r\n|\n|\r)/g, '')?.trim()
 }
 
+/**
+ * @description converts supplied string value i.e. 'yes', 'no' into true or false
+ */
+export const getBoolFromString = (text: string): boolean | null => {
+  if (text === 'yes') return true
+  if (text === 'no') return false
+
+  return null
+}
+
 export default {
   getImageFromField,
   getLinkFromField,
@@ -263,5 +273,6 @@ export default {
   getDocumentFromField,
   getSiteKeyValues,
   getSiteSection,
-  getPlainText
+  getPlainText,
+  getBoolFromString
 }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-329

### What I did
<!-- Summary of changes made in the Pull Request -->
- Allow quick exit to be overridden per site section

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
