### PR TITLE
[SD-409] - Made padding for zooming into bbox configurable per map

### DIFF
--- a/packages/ripple-tide-search/components/global/TideSearchAddressLookup.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchAddressLookup.vue
@@ -83,6 +83,7 @@ interface Props {
     args: Record<string, any>
   }
   onLocationSelectOverrideFn?: string | null
+  bboxZoomPadding?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -97,7 +98,8 @@ const props = withDefaults(defineProps<Props>(), {
   mapResultsFnName: '',
   isGettingLocation: false,
   userGeolocation: null,
-  onLocationSelectOverrideFn: null
+  onLocationSelectOverrideFn: null,
+  bboxZoomPadding: 100
 })
 
 const results = ref([])
@@ -283,7 +285,7 @@ async function centerMapOnLocation(
       )
 
       fitExtent(map, bbox, deadSpace.value, {
-        padding: 100,
+        padding: props.bboxZoomPadding,
         animationDuration: animate ? 800 : 0
       })
     }


### PR DESCRIPTION

<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-409

### What I did
<!-- Summary of changes made in the Pull Request -->
- Added `bboxZoomPadding` to address lookup component so that it can be customised per map
- Kept the default value as is to keep backwards compat 

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
