### PR TITLE
[SD-481] map markers not using themed colour on sites

### DIFF
--- a/packages/ripple-ui-maps/src/components/map/RplMap.vue
+++ b/packages/ripple-ui-maps/src/components/map/RplMap.vue
@@ -1,7 +1,5 @@
 <script lang="ts">
-const primaryColor = getComputedStyle(
-  document.documentElement
-).getPropertyValue('--rpl-clr-primary')
+let mapAccentColor: string = ''
 </script>
 
 <script setup lang="ts">
@@ -66,7 +64,7 @@ const props = withDefaults(defineProps<Props>(), {
   initialCenter: () => [144.9631, -36.8136], // melbourne CBD
   homeViewExtent: () => [144.9631, -36.8136], // melbourne CBD
   pinStyle: (feature) => {
-    let color = feature.color || primaryColor || 'red'
+    let color = feature.color || mapAccentColor || 'red'
     const ic = new Icon({
       src: markerIconDefaultSrc,
       color,
@@ -94,6 +92,10 @@ const mapRef = ref<{ map: Map } | null>(null)
 
 onMounted(() => {
   setRplMapRef(mapRef.value.map)
+
+  mapAccentColor = getComputedStyle(document.documentElement).getPropertyValue(
+    '--rpl-clr-link'
+  )
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-481

### What I did
<!-- Summary of changes made in the Pull Request -->
- Map markers where not using themed colour on actual sites https://www.earlylearning.vic.gov.au/find-centre
- Also we now use rpl-clr-link as the pin colour instead of rpl-clr-primary 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
