### PR TITLE
[SD-466] - Made logic for centering map on load more reliable

### DIFF
--- a/examples/nuxt-app/test/features/maps/maps.feature
+++ b/examples/nuxt-app/test/features/maps/maps.feature
@@ -21,7 +21,7 @@ Feature: Custom collection map component
     And the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is delayed by 1000 milliseconds and stubbed with fixture "/site/search-response", status 200 and alias "searchReq"
     Given I visit the page "/map"
     Then the map loading screen should be displayed
-    When I wait 2 seconds
+    And the map is loaded
     Then the map should be displayed
 
   @mockserver
@@ -31,7 +31,7 @@ Feature: Custom collection map component
     Given the page endpoint for path "/map" returns the loaded fixture
     Given the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map"
-    When I wait 2 seconds
+    And the map is loaded
     When I click the map component at coordinates 517 242
     When I wait 2 seconds
     Then the map matches the image snapshot "map-popup-type-popover"
@@ -43,7 +43,7 @@ Feature: Custom collection map component
     Given the page endpoint for path "/map" returns the loaded fixture
     Given the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map"
-    When I wait 2 seconds
+    And the map is loaded
     When I click the map component at coordinates 517 242
     When I wait 2 seconds
     Then the map matches the image snapshot "map-popup-type-sidebar"
@@ -56,7 +56,7 @@ Feature: Custom collection map component
     Given the page endpoint for path "/map" returns the loaded fixture
     Given the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map"
-    When I wait 2 seconds
+    And the map is loaded
     When I click the map component at coordinates 663 242
     When I wait 2 seconds
     Then the map matches the image snapshot "map-popup-type-popover-with-sidepanel"
@@ -69,7 +69,7 @@ Feature: Custom collection map component
     Given the page endpoint for path "/map" returns the loaded fixture
     Given the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map"
-    When I wait 2 seconds
+    And the map is loaded
     When I click the map component at coordinates 663 242
     When I wait 2 seconds
     Then the map matches the image snapshot "map-popup-type-sidebar-with-sidepanel"
@@ -81,7 +81,7 @@ Feature: Custom collection map component
     Given the page endpoint for path "/map" returns the loaded fixture
     Given the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map"
-    When I wait 2 seconds
+    And the map is loaded
     When I click the map component at coordinates 606 424
     When I wait 2 seconds
     Then the map matches the image snapshot "map-popup-type-sidebar-with-sidepanel-double-pin"
@@ -94,6 +94,7 @@ Feature: Custom collection map component
     Given the page endpoint for path "/map" returns the loaded fixture
     Given the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map"
+    And the map is loaded
     Given I click the side panel item with text "Single Pin Test"
     When I wait 2 seconds
     Then the map matches the image snapshot "map-sidepanel-item-click"
@@ -107,7 +108,7 @@ Feature: Custom collection map component
     Then the page endpoint for path "/map" returns the loaded fixture
     And the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map"
-    When I wait 2 seconds
+    And the map is loaded
     Then I click the map component at coordinates 545 385
     And I wait 1 seconds
     Then I click the map component at coordinates 660 320
@@ -121,7 +122,7 @@ Feature: Custom collection map component
     Then the page endpoint for path "/map" returns the loaded fixture
     And the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map?location[center]=15809362.126037747&location[center]=-4543542.166789566"
-    When I wait 2 seconds
+    And the map is loaded
     Then the map matches the image snapshot "map-initial-location-results-hook"
 
   @mockserver
@@ -133,7 +134,7 @@ Feature: Custom collection map component
     Then the page endpoint for path "/map" returns the loaded fixture
     And the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
     Given I visit the page "/map"
-    And I wait 2 seconds
+    And the map is loaded
     Then the map matches the image snapshot "map-custom-default-extent"
 
   @mockserver

--- a/examples/nuxt-app/test/features/maps/vsba.feature
+++ b/examples/nuxt-app/test/features/maps/vsba.feature
@@ -87,9 +87,9 @@ Feature: School buildings map
   Scenario: Click on cluster should zoom in
     Given the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/map-table/vsba/response-all" and status 200 as alias "searchReq"
     And I visit the page "/map"
-    When I wait 4 seconds
+    When the map is loaded
     When I click the map component at coordinates 650 429
-    When I wait 8 seconds
+    When I wait 4 seconds
     Then the map matches the image snapshot "map-cluster-zoom"
 
   @mockserver

--- a/packages/ripple-test-utils/step_definitions/components/maps.ts
+++ b/packages/ripple-test-utils/step_definitions/components/maps.ts
@@ -287,3 +287,7 @@ Given('the map height is set to {int}', (height: number) => {
 Then('the map height is {int}', (height: number) => {
   cy.get('.rpl-map__map').should('have.css', 'height', `${height}px`)
 })
+
+Then('the map is loaded', () => {
+  cy.get('.ol-map-fully-loaded', { timeout: 12000 }).should('be.visible')
+})

--- a/packages/ripple-tide-search/components/global/TideSearchAddressLookup.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchAddressLookup.vue
@@ -179,24 +179,25 @@ const onUpdate = useDebounceFn(async (q: string): Promise<void> => {
   }
 }, 300)
 
-// Center the map on the location when the map instance is ready
-// this is for tab switching only
+// Center the map on the correct location on first load or when switching back to the map tab
+//
+// Wait until both:
+// - the openlayers map instance has been created
+// - the map results have loaded
+// Then listen for the 'rendercomplete' event is fired by openlayers before centering
 watch(
-  () => rplMapRef.value,
-  (newVal, oldVal) => {
-    if (!oldVal && newVal && props.resultsloaded) {
-      // We don't animate the zoom here, because it's the initial load or a tab change
-      centerMapOnLocation(newVal, props.inputValue, false)
+  [() => rplMapRef.value, () => props.resultsloaded],
+  ([newMapRef, newLoaded], [oldMapRef, oldLoaded]) => {
+    const stateHasChanged = newMapRef !== oldMapRef || newLoaded !== oldLoaded
+
+    if (!stateHasChanged) {
+      return
     }
-  }
-)
-// we also watch for the map search results to be loaded before centering
-// this is for first load
-watch(
-  () => props.resultsloaded,
-  (newVal, oldVal) => {
-    if (!oldVal && newVal && rplMapRef.value) {
-      centerMapOnLocation(rplMapRef.value, props.inputValue, false)
+
+    if (newMapRef && newLoaded) {
+      rplMapRef.value.once('rendercomplete', function () {
+        centerMapOnLocation(newMapRef, props.inputValue, false)
+      })
     }
   }
 )


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-466

### What I did
<!-- Summary of changes made in the Pull Request -->
- Consolidated the two watchers that were handling first load
- Listen for 'rendercomplete' event on map to ensure map is rendered before zooming

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
