### PR TITLE
[SD-456] re-add elastic aliases

### DIFF
--- a/packages/ripple-tide-search/nuxt.config.ts
+++ b/packages/ripple-tide-search/nuxt.config.ts
@@ -26,6 +26,14 @@ export default defineNuxtConfig({
     }
   },
   modules: ['@dpc-sdp/ripple-ui-maps/nuxt'],
+  alias: {
+    '@elastic/search-ui': '@elastic/search-ui/lib/esm/index.js',
+    '@elastic/search-ui-app-search-connector':
+      '@elastic/search-ui-app-search-connector/lib/esm/index.js',
+    '@elastic/search-ui-elasticsearch-connector':
+      '@elastic/search-ui-elasticsearch-connector/lib/esm/index.js',
+    '@searchkit/sdk': '@searchkit/sdk/lib/esm/index.js'
+  },
   build: {
     transpile: [
       ({ isDev }) => !isDev && '@elastic/search-ui',


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-456

### What I did
<!-- Summary of changes made in the Pull Request -->
We updated `@elastic/search-ui` a while back (https://github.com/dpc-sdp/ripple-framework/pull/1207) which removed the need for these aliases, but we've since reverted back to the previous versions (https://github.com/dpc-sdp/ripple-framework/pull/1300), this just re-adds the aliases so site search works in layers and sites in dev mode once again.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
