### PR TITLE
[SD-508] ensure popup area doesn't extend beyond visible popup

### DIFF
--- a/packages/ripple-ui-maps/src/components/map/RplMap.vue
+++ b/packages/ripple-ui-maps/src/components/map/RplMap.vue
@@ -396,6 +396,7 @@ const fullScreenLabel = computed(() =>
           :position="popup.position"
           positioning="top-center"
           :stopEvent="true"
+          :offset="[0, popup.isArea ? 6 : 8]"
         >
           <RplMapPopUp
             :is-open="popup.isOpen"

--- a/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.css
+++ b/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.css
@@ -10,14 +10,9 @@
   border-radius: var(--rpl-border-radius-2);
   border: var(--rpl-border-1) solid var(--rpl-clr-neutral-300);
   margin: 0 auto;
-  margin-top: var(--rpl-sp-1);
 
   @media (--rpl-bp-s) {
     width: 300px;
-  }
-
-  @media (--rpl-bp-m) {
-    margin-top: var(--rpl-sp-2);
   }
 }
 
@@ -108,11 +103,14 @@
   height: auto;
   display: block;
   width: 300px;
+  margin-top: -2px;
+
+  @media (--rpl-bp-m) {
+    margin-top: 0;
+  }
 }
 
 .rpl-map-popup--popover.rpl-map-popup--area {
-  margin-top: var(--rpl-sp-3);
-
   &::before {
     position: absolute;
     content: '';


### PR DESCRIPTION

<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-508

### What I did
<!-- Summary of changes made in the Pull Request -->
- Ensure popup area doesn't extend beyond popup, i.e. the margin at the top of the popup was blocking interactions
- Adjust active pin (was a pixel off)

#### Click above (Current)
![click-above-current](https://github.com/user-attachments/assets/d45abdaf-0332-486a-af50-79e658fa7f4c)

#### Click above (Updated)
![click-above-updated](https://github.com/user-attachments/assets/85fc2019-2054-4596-96a5-c31e449bc185)


#### Hover above (Current)
![hover-above-current](https://github.com/user-attachments/assets/a7c4e86c-42d9-4826-ae03-593801972348)

#### Hover above (Updated)
![hover-above-updated](https://github.com/user-attachments/assets/274af9e5-3872-41be-bd0f-fdf393130545)

#### Move active pin 1px
![marker-1px-off](https://github.com/user-attachments/assets/71ef4ebb-5859-48f4-8015-2efcac3a3c68)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
