### PR TITLE
[SD-527] add page detail to search, sitemap and print all pages

### DIFF
--- a/examples/nuxt-app/test/features/publication/publication.feature
+++ b/examples/nuxt-app/test/features/publication/publication.feature
@@ -57,7 +57,10 @@ Feature: Publication page
   Example: Publication print all
     Given the endpoint "/api/tide/publication-children" with query "?ids=4a6d9877-326a-4090-8f7d-51c79191c63b&ids=7f608818-51e5-4c42-831a-a51d46a41ff6&ids=3479556d-7daa-4bc4-985a-d0ec1d954713&ids=a805aea1-6b50-4327-b176-ff4468775ad6&ids=c17daa15-9ad8-412d-a049-aa1ef6c668c2&ids=f85fab41-8217-44c4-bb0d-29ab5bc2832c&ids=c83e001c-2429-4c87-a53c-62a96ee426c6&ids=d51a4112-fd63-42cb-91a6-c17057c25242&ids=095e703d-e8cc-4153-9cf4-13e8a4f095c9&ids=ad3fd4c8-60dc-4c0d-a55c-5137766a2056&ids=64d7c641-640d-46e9-9967-7ad49104d744&ids=463ebde6-f906-427e-adaa-e2c7dba9f875&ids=3218f7fa-e189-44a2-8fdb-fc750409c421&ids=c0bf3b7f-1819-4cdb-99e8-4fd50071adac&ids=bf8208e7-bbc7-40cf-b3c0-111e6caabd91&ids=e0ce9cb4-df4f-4ae9-84e6-b1589486cdc8&ids=03b2d101-d6d8-4e55-a3e4-cad2d08f625b&ids=181e7b7e-ad44-4451-843a-044d760aa18e&ids=9c4656a6-3294-4515-8a7e-e15cd32841b6&ids=fadb534c-9598-40d0-a211-ca4b8a7c140a&ids=556bcf1a-46d6-4565-87e5-79e1b4b31cc5&ids=133ddcfa-b7f7-431c-bc85-f59ba8f44eac&ids=ff6440cc-7605-4ff1-b8a1-f25a5797549f&ids=f197320e-e9e3-46c8-b402-43ddd409599a&ids=e6cdf8c8-c19a-419b-9bb1-22a0938bba58&ids=cf1bfe5d-929e-44e2-a542-18d8b9fcd234&ids=16ef10ae-d3e4-4217-9508-eb4981336a3e" returns fixture "/publication/sample-print-all" with status 200
     When I visit the print all page "/victorian-skills-plan-2023-implementation-update/print-all"
-    Then the in page navigation should include
+    Then the dataLayer should include the following events
+      | event       | page_title                                          |
+      | routeChange | Print - Victorian Skills Plan Implementation Update |
+    And the in page navigation should include
       | title                                                                     | url                                                                                                            |
       | The Victorian Skills Plan 2022 into 2023 actions and initiatives          | /victorian-skills-plan-2023-implementation-update/2022-victorian-skills-plan-actions-and-initiatives           |
       | Promoting post-secondary education skills and career pathways             | /victorian-skills-plan-2023-implementation-update/promoting-post-secondary-education-skills-and-career         |

--- a/examples/nuxt-app/test/features/site/search.feature
+++ b/examples/nuxt-app/test/features/site/search.feature
@@ -6,6 +6,9 @@ Feature: Site search
     Given the "/api/tide/search/**" network request is delayed by 500 milliseconds and stubbed with fixture "/site/search-response", status 200 and alias "siteSearchReq"
     When I visit the page "/search?q=demo"
     Then the search listing skeleton should display 10 items with the class "tide-search-result-skeleton"
+    And the dataLayer should include the following events
+      | event       | page_title | search_term |
+      | routeChange | Search     | demo        |
 
     When I wait 500 milliseconds
     Then the search listing page should have 5 results

--- a/examples/nuxt-app/test/features/sitemap/sitemap.feature
+++ b/examples/nuxt-app/test/features/sitemap/sitemap.feature
@@ -16,3 +16,6 @@ Feature: Sitemap
       | Level 4 - Item 2 |
       | Level 2 - Item 2 |
       | Level 1 - Item 2 |
+    And the dataLayer should include the following events
+      | event       | page_title |
+      | routeChange | Sitemap    |

--- a/packages/nuxt-ripple/pages/sitemap.vue
+++ b/packages/nuxt-ripple/pages/sitemap.vue
@@ -8,6 +8,7 @@ export default {
 import { useTideSite } from '#imports'
 
 const site = await useTideSite()
+const page = { title: 'Sitemap' }
 
 const toc = computed(() => {
   return site.menus.menuMain.map((item) => {
@@ -22,8 +23,8 @@ const toc = computed(() => {
 <template>
   <TideBaseLayout
     :site="site"
-    :page="{}"
-    :pageTitle="`Sitemap - ${site.name}`"
+    :page="page"
+    :pageTitle="page.title"
     pageLanguage="en-AU"
   >
     <template #aboveBody="{ hasBreadcrumbs }">

--- a/packages/ripple-tide-publication/pages/[slug]/print-all.vue
+++ b/packages/ripple-tide-publication/pages/[slug]/print-all.vue
@@ -33,6 +33,10 @@ const childPages = await useTidePublicationChildren(
   flattenedChildIds
 )
 
+const page = computed(() => {
+  return { title: `Print - ${parentPage.title}` }
+})
+
 onMounted(() => {
   window.print()
 })
@@ -45,8 +49,8 @@ useHead({
 <template>
   <TideBaseLayout
     :site="site"
-    :page="{}"
-    :pageTitle="`Print - ${parentPage.title}`"
+    :page="page"
+    :pageTitle="page.title"
     pageLanguage="en-AU"
   >
     <template #breadcrumbs>

--- a/packages/ripple-tide-search/components/TideSearchPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchPage.vue
@@ -14,11 +14,12 @@ import { FormKit } from '@formkit/vue'
 import { SearchDriverOptions } from '@elastic/search-ui'
 import { useRippleEvent } from '@dpc-sdp/ripple-ui-core'
 import type { rplEventPayload } from '@dpc-sdp/ripple-ui-core'
-import type { TideSiteData } from '@dpc-sdp/ripple-tide-api/types'
+import type { TideSiteData, TidePageBase } from '@dpc-sdp/ripple-tide-api/types'
 
 interface Props {
   id?: string
   site: TideSiteData
+  page: TidePageBase
   pageTitle: string
   filtersConfig: AppSearchFilterConfigItem[]
   searchDriverOptions: Omit<SearchDriverOptions, 'apiConnector'>
@@ -256,7 +257,7 @@ watch(
 </script>
 
 <template>
-  <TideBaseLayout :id="id" :site="site" :pageTitle="pageTitle">
+  <TideBaseLayout :id="id" :site="site" :page="page" :pageTitle="pageTitle">
     <template #aboveBody>
       <RplHeroHeader
         :title="pageTitle"

--- a/packages/ripple-tide-search/pages/search.vue
+++ b/packages/ripple-tide-search/pages/search.vue
@@ -11,6 +11,7 @@ const appConfig = useAppConfig()
 const runtimeConfig = useRuntimeConfig()
 const site = await useTideSite()
 const featureFlags = useFeatureFlags(site?.featureFlags)
+const page = { title: 'Search' }
 
 const getContentTypes = () => {
   let contentTypes = appConfig.ripple?.search?.contentTypes
@@ -126,7 +127,8 @@ const searchResultsMappingFn = (item): MappedSearchResult<any> => {
 
 <template>
   <TideSearchPage
-    pageTitle="Search"
+    :pageTitle="page.title"
+    :page="page"
     :site="site"
     :searchDriverOptions="searchDriverOptions"
     :filtersConfig="filtersConfig"


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-527

### What I did
<!-- Summary of changes made in the Pull Request -->
- Add page detail to search, sitemap and print all pages so they come through in the analytics events
- Also update the sitemap page title to be consistent with the rest and avoid the double site name

<img width="188" alt="Screenshot 2024-12-09 at 10 44 17 am" src="https://github.com/user-attachments/assets/483d641c-f171-4eda-a9ab-8175dfb43ff0">

#### Events
<img width="307" alt="Screenshot 2024-12-09 at 10 26 16 am" src="https://github.com/user-attachments/assets/5eb120e8-4c7f-4665-80a2-4a87d3e4db8c">
<img width="313" alt="Screenshot 2024-12-09 at 10 27 01 am" src="https://github.com/user-attachments/assets/d6595756-ecf5-4d21-afd9-710938646dde">
<img width="444" alt="Screenshot 2024-12-09 at 10 27 49 am" src="https://github.com/user-attachments/assets/a91b28ac-77af-47bf-be96-40693d8e0d0c">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
