### PR TITLE
Support 'name' attribute (if set) in webform mapping

### DIFF
--- a/packages/ripple-tide-webform/mapping/webforms-mapping.ts
+++ b/packages/ripple-tide-webform/mapping/webforms-mapping.ts
@@ -25,10 +25,11 @@ export const getFormSchemaFromMapping = async (
   const fields = []
   const formId = webform.drupal_internal__id
 
-  for (const [fieldKey, fieldData] of Object.entries(elements)) {
+  for (const [fieldMachineName, fieldData] of Object.entries(elements)) {
     let mappedField
     const field: TideWebformElement = { ...fieldData, formId }
-    const fieldID = `${formId}_${fieldKey}`
+    const fieldID = `${formId}_${fieldMachineName}`
+    const fieldKey = field['#attributes']?.name || fieldMachineName
 
     switch (field['#type']) {
       case 'hidden':


### PR DESCRIPTION
PR for feature request #1410 

<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**:

### What I did
<!-- Summary of changes made in the Pull Request -->
- Use 'name' attribute if set in webform element config as the field key/name, else use machine_name as usual.

### How to test
<!-- Summary of how to test the changes -->
- Build a webform, and for an element, add a custom 'name' attribute in the element's config
- View the form in the frontend and confirm the HTML 'name' attribute uses the custom value

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
