### PR TITLE
fix: add example id to search banner story

### DIFF
--- a/packages/ripple-ui-core/src/components/search-banner/RplSearchBanner.stories.mdx
+++ b/packages/ripple-ui-core/src/components/search-banner/RplSearchBanner.stories.mdx
@@ -25,7 +25,10 @@ export const SingleTemplate = (args) => ({
   }}
   args={{
     title: 'Search banner',
-    intro: 'A neat little search banner.'
+    intro: 'A neat little search banner.',
+    searchBar: {
+      id: 'search-banner'
+    }
   }}
 />
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

### What I did
<!-- Summary of changes made in the Pull Request -->
- Add example id to search banner story to fix axe error

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
