### PR TITLE
[SD-604] - Changed the 'unsupported input message' in webforms to only show up in draft mode

### DIFF
--- a/examples/nuxt-app/layers/ripple-ui-forms-ext/__test__/forms-ext.feature
+++ b/examples/nuxt-app/layers/ripple-ui-forms-ext/__test__/forms-ext.feature
@@ -14,7 +14,7 @@ Feature: Forms, extended
     And a field labelled "Extended" should exist with the CSS class ".rpl-form__input--type-item"
 
   @mockserver
-  Scenario: Unsupported input
+  Scenario: Unsupported input (draft page)
     Given I visit the page "/webform"
     Then the landing page component "TideLandingPageWebForm" should exist
     And an input of type "signature" is not yet supported

--- a/packages/ripple-tide-landing-page/mapping/components/webforms/webforms-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/webforms/webforms-mapping.ts
@@ -1,12 +1,20 @@
 import type { TideDynamicPageComponent } from '@dpc-sdp/ripple-tide-api/types'
 import { TidePageApi } from '@dpc-sdp/ripple-tide-api'
-import type { TideWebform, ApiField } from '@dpc-sdp/ripple-tide-webform/types'
+import type {
+  TideWebform,
+  ApiField,
+  ApiPage
+} from '@dpc-sdp/ripple-tide-webform/types'
 import {
   getFormSchemaFromMapping,
   getCaptchaSettings
 } from '@dpc-sdp/ripple-tide-webform/mapping'
 
-const componentMapping = async (field: ApiField, tidePageApi: TidePageApi) => {
+const componentMapping = async (
+  field: ApiField,
+  page: ApiPage,
+  tidePageApi: TidePageApi
+) => {
   return {
     title: field.field_paragraph_title,
     formId: field.field_paragraph_webform.meta.drupal_internal__target_id,
@@ -24,6 +32,7 @@ const componentMapping = async (field: ApiField, tidePageApi: TidePageApi) => {
       'We are experiencing a server error. Please try again, otherwise contact us.',
     schema: await getFormSchemaFromMapping(
       field.field_paragraph_webform,
+      page,
       tidePageApi
     ),
     captchaConfig: getCaptchaSettings(field.field_paragraph_webform)
@@ -31,15 +40,14 @@ const componentMapping = async (field: ApiField, tidePageApi: TidePageApi) => {
 }
 export const webformMapping = async (
   field: ApiField,
-  // @ts-expect-error unused
-  page,
+  page: ApiPage,
   tidePageApi: TidePageApi
 ): Promise<TideDynamicPageComponent<TideWebform>> => {
   return {
     component: 'TideLandingPageWebForm',
     id: field.drupal_internal__id,
     title: field.field_paragraph_title,
-    props: await componentMapping(field, tidePageApi)
+    props: await componentMapping(field, page, tidePageApi)
   }
 }
 

--- a/packages/ripple-tide-webform/server/api/tide/webform.ts
+++ b/packages/ripple-tide-webform/server/api/tide/webform.ts
@@ -29,8 +29,8 @@ export class TideWebformApi extends TideApiBase {
       mapping: {
         _src: (field: any) =>
           process.env.NODE_ENV === 'development' ? field : undefined,
-        schema: async (field: any, page, tidePageApi: TidePageApi) =>
-          await getFormSchemaFromMapping(field, tidePageApi),
+        schema: async (field: any, page: any, tidePageApi: TidePageApi) =>
+          await getFormSchemaFromMapping(field, page, tidePageApi),
         captchaConfig: (field: any) => getCaptchaSettings(field)
       },
       includes: []

--- a/packages/ripple-tide-webform/types.ts
+++ b/packages/ripple-tide-webform/types.ts
@@ -52,6 +52,10 @@ export interface ApiField {
   field_paragraph_webform: ApiWebForm
 }
 
+export interface ApiPage {
+  moderation_state?: string
+}
+
 export enum CaptchaType {
   RECAPTCHA_V2 = 'google_recaptcha_v2',
   RECAPTCHA_V3 = 'google_recaptcha_v3',


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-604

### What I did
<!-- Summary of changes made in the Pull Request -->
- Changed the 'unsupported input message' to only show up when moderation_state = 'draft' 
- Improved the wording of the message to inform the user that it will only show in draft mode

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
