### PR TITLE
[SD-308] fix mobile secondary logo height

### DIFF
--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.css
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.css
@@ -69,7 +69,7 @@
 .rpl-primary-nav__secondary-logo-image {
   display: block;
   max-width: 126px;
-  max-height: 36px;
+  max-height: 32px;
 
   @media (--rpl-bp-m) {
     max-width: 140px;


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-308

### What I did
<!-- Summary of changes made in the Pull Request -->
- Fix max-height for mobile secondary logo, this stops the menu items being pushed down

![secondary-mobile-logo](https://github.com/user-attachments/assets/6a58fec9-dd40-4cb6-9133-873e67999865)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
