### PR TITLE
[SD-676] allow elastic response source to be customised

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/result-items.feature
+++ b/examples/nuxt-app/test/features/search-listing/result-items.feature
@@ -17,3 +17,31 @@ Feature: Result items
       | Accessibility guidelines | tide-search-result-card  |
       | Small business grant     | tide-grant-search-result |
       | GovHack 2022 is coming   | tide-search-result       |
+
+  @mockserver
+  Example: Result contents from elasticsearch can be customised to exclude fields
+    Given I load the page fixture with "/search-listing/result-items/page"
+    And the search listing config has the following excludes added to source
+      | key             |
+      | nid             |
+      | field_node_site |
+    Then the page endpoint for path "/search-results" returns the loaded fixture
+    And the search network request is stubbed with fixture "/search-listing/result-items/response" and status 200
+
+    When I visit the page "/search-results"
+    Then the search listing page should have 4 results
+    And the search network request should be called with the "/search-listing/result-items/request-source-exclude" fixture
+
+  @mockserver
+  Example: Result contents from elasticsearch can be customised to include fields
+    Given I load the page fixture with "/search-listing/result-items/page"
+    And the search listing config has the following includes added to source
+      | key           |
+      | title         |
+      | field_summary |
+    Then the page endpoint for path "/search-results" returns the loaded fixture
+    And the search network request is stubbed with fixture "/search-listing/result-items/response" and status 200
+
+    When I visit the page "/search-results"
+    Then the search listing page should have 4 results
+    And the search network request should be called with the "/search-listing/result-items/request-source-include" fixture

--- a/examples/nuxt-app/test/fixtures/search-listing/result-items/request-source-exclude.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/result-items/request-source-exclude.json
@@ -1,0 +1,40 @@
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match_all": {}
+        }
+      ],
+      "filter": [
+        {
+          "terms": {
+            "type": [
+              "news",
+              "grant",
+              "event",
+              "landing_page"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [
+              8888
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "size": 20,
+  "from": 0,
+  "sort": [
+    {
+      "title.keyword": "asc"
+    }
+  ],
+  "_source": {
+    "exclude": ["nid", "field_node_site"]
+  }
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/result-items/request-source-include.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/result-items/request-source-include.json
@@ -1,0 +1,43 @@
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match_all": {}
+        }
+      ],
+      "filter": [
+        {
+          "terms": {
+            "type": [
+              "news",
+              "grant",
+              "event",
+              "landing_page"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [
+              8888
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "size": 20,
+  "from": 0,
+  "sort": [
+    {
+      "title.keyword": "asc"
+    }
+  ],
+  "_source": {
+    "include": [
+      "title",
+      "field_summary"
+    ]
+  }
+}

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -592,3 +592,35 @@ Then(
     })
   }
 )
+
+Then(
+  'the search listing config has the following excludes added to source',
+  (dataTable: DataTable) => {
+    const table = dataTable.hashes()
+    const excludes = table.map((row) => row.key)
+
+    cy.get('@pageFixture').then((response) => {
+      set(
+        response,
+        `config.searchListingConfig.responseSource.exclude`,
+        excludes
+      )
+    })
+  }
+)
+
+Then(
+  'the search listing config has the following includes added to source',
+  (dataTable: DataTable) => {
+    const table = dataTable.hashes()
+    const includes = table.map((row) => row.key)
+
+    cy.get('@pageFixture').then((response) => {
+      set(
+        response,
+        `config.searchListingConfig.responseSource.include`,
+        includes
+      )
+    })
+  }
+)

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -296,6 +296,13 @@ export type TideSearchListingConfig = {
      * @description show filters in the sidebar?
      */
     filtersInSidebar?: boolean
+    /**
+     * @description modify the elasticsearch response source
+     */
+    responseSource?: {
+      include?: string[]
+      exclude?: string[]
+    }
   }
   /**
    * @description Tabs to display, key needs to be one of TideSearchListingTabKey


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-676

### What I did
<!-- Summary of changes made in the Pull Request -->
- Allow elastic response source to be customised, this means you can set and array of includes or excludes to streamline the response data


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
