### PR TITLE
[SD-584] breadcrumb language support

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/languages.feature
+++ b/examples/nuxt-app/test/features/landingpage/languages.feature
@@ -23,6 +23,7 @@ Feature: Languages
     When I visit the page "/arabic-page"
     Then the section ".rpl-header" should be display "rtl" in "ar" with the font "Noto Kufi Arabic"
     And the section "#rpl-main" should be display "rtl" in "ar" with the font "Noto Kufi Arabic"
+    And the section ".rpl-breadcrumbs__item:last-child" should be display "rtl" in "ar" with the font "Noto Kufi Arabic"
     And the html language should be "ar"
 
   @mockserver
@@ -31,4 +32,5 @@ Feature: Languages
     When I visit the page "/korean-page"
     Then the section ".rpl-header" should be display "ltr" in "ko" with the font "Noto Sans KR"
     And the section "#rpl-main" should be display "ltr" in "ko" with the font "Noto Sans KR"
+    And the section ".rpl-breadcrumbs__item:last-child" should be display "ltr" in "ko" with the font "Noto Sans KR"
     And the html language should be "ko"

--- a/examples/nuxt-app/test/fixtures/landingpage/languages-ar.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/languages-ar.json
@@ -1,5 +1,5 @@
 {
-  "title": "Demo Landing Page",
+  "title": "مزايا رياض الأطفال",
   "changed": "2022-11-02T12:47:29+11:00",
   "created": "2022-11-02T12:47:29+11:00",
   "type": "landing_page",

--- a/examples/nuxt-app/test/fixtures/landingpage/languages-ko.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/languages-ko.json
@@ -1,5 +1,5 @@
 {
-  "title": "Demo Landing Page",
+  "title": "지역 사회 서비스, 계약업체 청소 및 경비 산업의 빅토리아주",
   "changed": "2022-11-02T12:47:29+11:00",
   "created": "2022-11-02T12:47:29+11:00",
   "type": "landing_page",

--- a/packages/nuxt-ripple/components/TideBreadcrumbs.vue
+++ b/packages/nuxt-ripple/components/TideBreadcrumbs.vue
@@ -4,11 +4,13 @@
     :items="breadcrumbs"
     :besideQuickExit="besideQuickExit"
     data-cy="breadcrumbs"
+    :current-class="language"
+    :current-dir="direction"
   />
 </template>
 
 <script setup lang="ts">
-import { computed, toRaw, unref } from 'vue'
+import { computed, inject, toRaw, unref } from 'vue'
 import { getBreadcrumbs } from '#imports'
 
 interface IRplBreadcrumbsItem {
@@ -31,6 +33,8 @@ const props = withDefaults(defineProps<Props>(), {
   currentPageTitle: undefined,
   besideQuickExit: false
 })
+
+const { direction, language } = inject('language')
 
 const breadcrumbs = computed(() => {
   return props.items.length > 0

--- a/packages/ripple-ui-core/src/components/breadcrumbs/RplBreadcrumbs.vue
+++ b/packages/ripple-ui-core/src/components/breadcrumbs/RplBreadcrumbs.vue
@@ -17,13 +17,17 @@ interface Props {
   besideQuickExit?: boolean
   displayBeforeCollapse?: number
   collapse?: boolean
+  currentClass?: string
+  currentDir?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   items: () => [],
   besideQuickExit: false,
   displayBeforeCollapse: 3,
-  collapse: false
+  collapse: false,
+  currentClass: undefined,
+  currentDir: undefined
 })
 
 const emit = defineEmits<{
@@ -105,8 +109,12 @@ const toggleCollapsed = () => {
                 !firstItem(index) &&
                 !secondLastItem(index) &&
                 collapseInnerLinks
+            },
+            {
+              [currentClass]: lastItem(index) && currentClass
             }
           ]"
+          :dir="lastItem(index) ? currentDir : undefined"
         >
           <RplTextLink
             v-if="!lastItem(index) || collapseInnerLinks"


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-584

### What I did
<!-- Summary of changes made in the Pull Request -->
- Adds breadcrumb language support, we only know the the language of the current page so this just allows for setting the current pages language and direction. We wouldn't want to set direction on the entire breadcrumbs anyway it would break the layout. Also note different fonts can appear slightly differently even with the same font size, line height etc set, this means the alignment of the breadcrumbs text may looks ever so slightly off for certain languages.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
