### PR TITLE
[SD-695] Use DL in stats grid markup

### DIFF
--- a/packages/ripple-ui-core/src/components/stats-grid/RplStatsGrid.css
+++ b/packages/ripple-ui-core/src/components/stats-grid/RplStatsGrid.css
@@ -61,6 +61,7 @@
 
 .rpl-stats-grid-item__inner {
   background: var(--rpl-clr-neutral-100);
+  margin: 0;
   padding: var(--rpl-sp-9) var(--rpl-sp-4);
   text-align: center;
   word-break: break-word;
@@ -69,4 +70,8 @@
   .rpl-stats-grid--on-dark & {
     background: var(--rpl-clr-light);
   }
+}
+
+.rpl-stats-grid-item__description {
+  margin-left: 0;
 }

--- a/packages/ripple-ui-core/src/components/stats-grid/RplStatsGrid.css
+++ b/packages/ripple-ui-core/src/components/stats-grid/RplStatsGrid.css
@@ -20,7 +20,8 @@
   flex-shrink: 0;
   flex-grow: 1;
   overflow: hidden;
-  padding: calc(var(--rpl-sp-2) * 0.5);
+  text-align: center;
+  word-break: break-word;
 
   /* Small screens always have two columns */
   /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
@@ -57,18 +58,14 @@
       flex-basis: 25%;
     }
   }
-}
 
-.rpl-stats-grid-item__inner {
-  background: var(--rpl-clr-neutral-100);
-  margin: 0;
   padding: var(--rpl-sp-9) var(--rpl-sp-4);
-  text-align: center;
-  word-break: break-word;
-  height: 100%;
+  background: var(--rpl-clr-neutral-100);
+  border: var(--rpl-sp-1) solid var(--rpl-clr-light);
 
   .rpl-stats-grid--on-dark & {
     background: var(--rpl-clr-light);
+    border-color: var(--rpl-clr-neutral-100);
   }
 }
 

--- a/packages/ripple-ui-core/src/components/stats-grid/RplStatsGrid.vue
+++ b/packages/ripple-ui-core/src/components/stats-grid/RplStatsGrid.vue
@@ -12,12 +12,12 @@ withDefaults(defineProps<Props>(), {
 })
 
 const numItems = computed(() => {
-  return useSlots().default()[0].children.length
+  return useSlots().default()[0].children.length as number
 })
 </script>
 
 <template>
-  <ul
+  <div
     :class="{
       'rpl-stats-grid': true,
       'rpl-stats-grid--on-light': variant === 'onLight',
@@ -28,7 +28,7 @@ const numItems = computed(() => {
     }"
   >
     <slot />
-  </ul>
+  </div>
 </template>
 
 <style src="./RplStatsGrid.css" />

--- a/packages/ripple-ui-core/src/components/stats-grid/RplStatsGrid.vue
+++ b/packages/ripple-ui-core/src/components/stats-grid/RplStatsGrid.vue
@@ -17,7 +17,7 @@ const numItems = computed(() => {
 </script>
 
 <template>
-  <div
+  <dl
     :class="{
       'rpl-stats-grid': true,
       'rpl-stats-grid--on-light': variant === 'onLight',
@@ -28,7 +28,7 @@ const numItems = computed(() => {
     }"
   >
     <slot />
-  </div>
+  </dl>
 </template>
 
 <style src="./RplStatsGrid.css" />

--- a/packages/ripple-ui-core/src/components/stats-grid/RplStatsGridItem.vue
+++ b/packages/ripple-ui-core/src/components/stats-grid/RplStatsGridItem.vue
@@ -8,11 +8,9 @@ withDefaults(defineProps<Props>(), {})
 
 <template>
   <div class="rpl-stats-grid-item">
-    <dl class="rpl-stats-grid-item__inner">
-      <dt class="rpl-type-h3">{{ value }}</dt>
-      <dd class="rpl-type-p rpl-stats-grid-item__description">
-        <slot></slot>
-      </dd>
-    </dl>
+    <dt class="rpl-type-h3">{{ value }}</dt>
+    <dd class="rpl-type-p rpl-stats-grid-item__description">
+      <slot></slot>
+    </dd>
   </div>
 </template>

--- a/packages/ripple-ui-core/src/components/stats-grid/RplStatsGridItem.vue
+++ b/packages/ripple-ui-core/src/components/stats-grid/RplStatsGridItem.vue
@@ -7,12 +7,12 @@ withDefaults(defineProps<Props>(), {})
 </script>
 
 <template>
-  <li class="rpl-stats-grid-item">
-    <div class="rpl-stats-grid-item__inner">
-      <span class="rpl-type-h3">{{ value }}</span>
-      <span class="rpl-type-p">
+  <div class="rpl-stats-grid-item">
+    <dl class="rpl-stats-grid-item__inner">
+      <dt class="rpl-type-h3">{{ value }}</dt>
+      <dd class="rpl-type-p rpl-stats-grid-item__description">
         <slot></slot>
-      </span>
-    </div>
-  </li>
+      </dd>
+    </dl>
+  </div>
 </template>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-695

### What I did
<!-- Summary of changes made in the Pull Request -->
- ~Ideally, the stats blocks would all form one `dl` but the rules say that a `dl` can _only_ contain `dt` and `dd` els, so there is no way of wrapping them for alignment in flex. I think this (using a `dl` for each pair) is still correct, but a bit verbose - no difference visually or in size of markup.~
- Refactor markup to `dl` with `dt` and `dd` (wrapped in a single div), use border instead of margin/gap

### How to test
<!-- Summary of how to test the changes -->
- Chromatic
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
