### PR TITLE
[SD-788] Fixed double encoding of search terms in the search banner

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/home.feature
+++ b/examples/nuxt-app/test/features/landingpage/home.feature
@@ -66,10 +66,10 @@ Feature: Home page
   Scenario: Header component - Search banner
     Given the page endpoint for path "/search/cats" returns fixture "/landingpage/home" with status 200
     Then a search banner with ID "1911" should exist with the placeholder "Test search placeholder"
-    Then in a search banner with ID "1911", searching for "cats" should take me to "/search?q=cats"
+    Then in a search banner with ID "1911", searching for "cats" should take me to "/search/cats"
 
   @mockserver
   Scenario: Header component - Search banner - url encoding
     Given the page endpoint for path "/search/cats" returns fixture "/landingpage/home" with status 200
     Then a search banner with ID "1911" should exist with the placeholder "Test search placeholder"
-    Then in a search banner with ID "1911", searching for "cats test" should take me to "/search?q=cats%20test"
+    Then in a search banner with ID "1911", searching for "cats test" should take me to "/search/cats%20test"

--- a/examples/nuxt-app/test/features/landingpage/home.feature
+++ b/examples/nuxt-app/test/features/landingpage/home.feature
@@ -66,4 +66,10 @@ Feature: Home page
   Scenario: Header component - Search banner
     Given the page endpoint for path "/search/cats" returns fixture "/landingpage/home" with status 200
     Then a search banner with ID "1911" should exist with the placeholder "Test search placeholder"
-    Then in a search banner with ID "1911", searching for "cats" should take me to "/search/cats"
+    Then in a search banner with ID "1911", searching for "cats" should take me to "/search?q=cats"
+
+  @mockserver
+  Scenario: Header component - Search banner - url encoding
+    Given the page endpoint for path "/search/cats" returns fixture "/landingpage/home" with status 200
+    Then a search banner with ID "1911" should exist with the placeholder "Test search placeholder"
+    Then in a search banner with ID "1911", searching for "cats test" should take me to "/search?q=cats%20test"

--- a/examples/nuxt-app/test/fixtures/landingpage/home.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/home.json
@@ -349,7 +349,7 @@
       "id": "1911",
       "props": {
         "placeholder": "Test search placeholder",
-        "searchUrl": "/search/[SEARCH-KEYWORDS]",
+        "searchUrl": "/search?q=[SEARCH-KEYWORDS]",
         "openInNewWindow": false
       }
     },

--- a/examples/nuxt-app/test/fixtures/landingpage/home.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/home.json
@@ -349,7 +349,7 @@
       "id": "1911",
       "props": {
         "placeholder": "Test search placeholder",
-        "searchUrl": "/search?q=[SEARCH-KEYWORDS]",
+        "searchUrl": "/search/[SEARCH-KEYWORDS]",
         "openInNewWindow": false
       }
     },

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/SearchBanner.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/SearchBanner.vue
@@ -14,10 +14,7 @@ const props = defineProps<{
 
 const handleSubmit = (event) => {
   const searchPath = encodeURI(
-    props.searchUrl.replace(
-      '[SEARCH-KEYWORDS]',
-      encodeURIComponent(event.value)
-    )
+    props.searchUrl.replace('[SEARCH-KEYWORDS]', event.value)
   )
 
   const isInternalUrl = !isExternalUrl(searchPath, $app_hostname)


### PR DESCRIPTION

<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-788

### What I did
<!-- Summary of changes made in the Pull Request -->
- Removed double encoding
- Added a test for search tests with spaces

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
