### PR TITLE
[SD-810] add 'id' to searchResultsMappingFn

### DIFF
--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -154,6 +154,7 @@ const searchResultsMappingFn = (item): TideSearchListingResultItem => {
     component: itemComponent,
     props: {
       result: {
+        // NOTE: id was added to match the mapResultsMappingFn signature; _id remains for backwards compatibility
         id: item._id,
         _id: item._id,
         ...transformedItem

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -154,6 +154,7 @@ const searchResultsMappingFn = (item): TideSearchListingResultItem => {
     component: itemComponent,
     props: {
       result: {
+        id: item._id,
         _id: item._id,
         ...transformedItem
       }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-810

### What I did
<!-- Summary of changes made in the Pull Request -->
- Add `id` to searchResultsMappingFn to match mapResultsMappingFn. i.e. both searchResultsMappingFn and mapResultsMappingFn now have an `id` set by default, previously one was `id` and the other was `_id`; Note `_id` is still set for backwards compatibility.


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
