### PR TITLE
[SD-815] Fixed sidebar type popup closing on click

### DIFF
--- a/packages/ripple-ui-maps/src/components/layer-list/RplMapLayerList.vue
+++ b/packages/ripple-ui-maps/src/components/layer-list/RplMapLayerList.vue
@@ -11,7 +11,13 @@
     </RplButton>
   </div>
 
-  <RplMapPopUp :isOpen="isOpen" type="layerlist" @close="handleClose">
+  <RplMapPopUp
+    :isOpen="isOpen"
+    type="layerlist"
+    :closeOnClickOutside="true"
+    :closeOnEscape="true"
+    @close="handleClose"
+  >
     <template #header>{{ title }}</template>
     <ul ref="content" class="rpl-map-layer-list">
       <li v-for="layer in layers" :key="layer.id">

--- a/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.vue
+++ b/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.vue
@@ -73,6 +73,8 @@ interface Props {
   pinColor?: string
   type?: 'standalone' | 'popover' | 'sidebar' | 'layerlist'
   mapHeight?: number
+  closeOnClickOutside?: boolean
+  closeOnEscape?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -80,7 +82,9 @@ const props = withDefaults(defineProps<Props>(), {
   isArea: false,
   pinColor: 'green',
   type: 'sidebar',
-  mapHeight: 600
+  mapHeight: 600,
+  closeOnClickOutside: false,
+  closeOnEscape: false
 })
 
 const emit = defineEmits<{
@@ -94,8 +98,13 @@ function onClose() {
   emitRplEvent('close')
 }
 
-onClickOutside(popupEL, onClose)
-onKeyStroke(['Escape'], onClose)
+if (props.closeOnClickOutside) {
+  onClickOutside(popupEL, onClose)
+}
+
+if (props.closeOnEscape) {
+  onKeyStroke(['Escape'], onClose)
+}
 
 const breakpoints = useBreakpoints(bpMin)
 const isLargePlus = breakpoints.greaterOrEqual('l')


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-815

### What I did
<!-- Summary of changes made in the Pull Request -->
- Adding functionality to the popup for the new RplMapLayerList component caused a regression in the existing sidebar popup behaviour
- To fix this I made the new close on click outside and escape turned off by default and enabled just for the layer list.

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
