### PR TITLE
[SD-835] Fix incorrect url sent to logger

### DIFF
--- a/packages/ripple-tide-api/src/services/http-client.ts
+++ b/packages/ripple-tide-api/src/services/http-client.ts
@@ -62,9 +62,7 @@ export default class HttpClient {
           this.logger.error(
             `${error.request.method?.toUpperCase()} request failed with status ${
               error.response?.status
-            } - ${error.response?.statusText}: ${error.config?.baseURL}${
-              error.request.path
-            }`,
+            } - ${error.response?.statusText}: ${error.request.protocol}://${error.request.host}${error.request.path}`,
             {
               label: this.logLabel,
               // _logId is a custom property added by us https://github.com/axios/axios/issues/2203

--- a/packages/ripple-tide-api/src/services/http-client.ts
+++ b/packages/ripple-tide-api/src/services/http-client.ts
@@ -35,9 +35,7 @@ export default class HttpClient {
     this.client.interceptors.request.use(
       (request) => {
         this.logger.debug(
-          `${request.method?.toUpperCase()} request to ${this.client.getUri(
-            request
-          )}`,
+          `${request.method!.toUpperCase()} request to ${this.client.getUri(request)}`,
           {
             label: this.logLabel,
             // _logId is a custom property added by us https://github.com/axios/axios/issues/2203
@@ -60,9 +58,9 @@ export default class HttpClient {
       (error) => {
         if (axios.isAxiosError(error)) {
           this.logger.error(
-            `${error.request.method?.toUpperCase()} request failed with status ${
-              error.response?.status
-            } - ${error.response?.statusText}: ${error.request.protocol}://${error.request.host}${error.request.path}`,
+            `${error.request.method!.toUpperCase()} request failed with status ${
+              error.response!.status
+            } - ${error.response!.statusText}: ${this.client.getUri(error.response!.config)}`,
             {
               label: this.logLabel,
               // _logId is a custom property added by us https://github.com/axios/axios/issues/2203


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-835

### What I did
<!-- Summary of changes made in the Pull Request -->
- Use request host instead of config (has api prefix baked in, resulting in double `/api/v1`
- 

### How to test
<!-- Summary of how to test the changes -->
- Put a BE in maintenance mode, check DEBUG log
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
