### PR TITLE
[SD-707] Maps keyboard nav improvements

### DIFF
--- a/packages/ripple-test-utils/step_definitions/components/maps.ts
+++ b/packages/ripple-test-utils/step_definitions/components/maps.ts
@@ -145,10 +145,8 @@ Given('the side panel is enabled', () => {
   })
 })
 
-Given('I click the side panel item with text {string}', (title) => {
-  cy.get('.rpl-map-side-panel [role="button"]')
-    .contains(title)
-    .click({ force: true })
+Given('I click the side panel item with text {string}', (title: string) => {
+  cy.get('.rpl-map-side-panel button').contains(title).click({ force: true })
 })
 
 Given('a custom suggestions function called {string} is used', (fnName) => {

--- a/packages/ripple-tide-search/components/TideSearchPagination.vue
+++ b/packages/ripple-tide-search/components/TideSearchPagination.vue
@@ -29,10 +29,13 @@ const props = withDefaults(defineProps<Props>(), {
 
 const handlePageChange = (event) => {
   const navHeight = 92
-  const scrollToElement = document.querySelector(props.scrollToSelector)
+  const scrollToElement = document.querySelector(
+    props.scrollToSelector
+  ) as HTMLElement
 
   if (scrollToElement) {
     scrollToElementTopWithOffset(scrollToElement, navHeight)
+    scrollToElement.focus?.({ preventScroll: true })
   }
   emit('paginate', event)
 }

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -724,7 +724,7 @@ watch(baseEvent, (newBaseEvent) => {
       </RplExpandable>
     </div>
 
-    <div class="tide-search-results-wrapper">
+    <div tabIndex="-1" class="tide-search-results-wrapper">
       <RplTabs
         v-if="searchListingConfig?.displayMapTab"
         :tabs="tabs"
@@ -954,5 +954,9 @@ watch(baseEvent, (newBaseEvent) => {
   @media (--rpl-bp-m) {
     order: -1;
   }
+}
+
+.tide-search-results-wrapper {
+  outline: none;
 }
 </style>

--- a/packages/ripple-tide-search/composables/useTideSearch.ts
+++ b/packages/ripple-tide-search/composables/useTideSearch.ts
@@ -967,7 +967,7 @@ export default ({
    */
   const scrollToResults = (selector: string, offset = 0) => {
     if (searchListingConfig?.scrollToResultsOnSubmit !== false) {
-      const scrollToElement = document.querySelector(selector)
+      const scrollToElement = document.querySelector(selector) as HTMLElement
 
       if (scrollToElement) {
         const scrollElementTop = scrollToElement.getBoundingClientRect()?.top
@@ -977,6 +977,7 @@ export default ({
         }
 
         scrollToElementTopWithOffset(scrollToElement, offset)
+        scrollToElement.focus({ preventScroll: true })
       }
     }
   }

--- a/packages/ripple-ui-maps/src/components/map/RplMap.vue
+++ b/packages/ripple-ui-maps/src/components/map/RplMap.vue
@@ -349,6 +349,16 @@ const fullScreenLabel = computed(() =>
 const handleUpdateSelectedLayers = (newSelectedLayers: string[]) => {
   emit('updateSelectedLayers', newSelectedLayers)
 }
+
+const popupId = computed(() => {
+  const features = Array.isArray(popup.value?.feature)
+    ? popup.value.feature
+    : [popup.value.feature]
+  return (
+    popup.value.position.join(',') ||
+    features.map((feature) => feature?.id).join('-')
+  )
+})
 </script>
 
 <template>
@@ -449,11 +459,13 @@ const handleUpdateSelectedLayers = (newSelectedLayers: string[]) => {
           :offset="[0, popup.isArea ? 6 : 8]"
         >
           <RplMapPopUp
+            :featureId="popupId"
             :is-open="popup.isOpen"
             :is-area="popup.isArea"
             :type="popupType"
             :pinColor="popup.color"
             :mapHeight="mapHeight"
+            :closeOnEscape="true"
             @close="onPopUpClose"
           >
             <template #header>
@@ -477,6 +489,41 @@ const handleUpdateSelectedLayers = (newSelectedLayers: string[]) => {
         :selectedLayers="selectedLayers"
         @update="handleUpdateSelectedLayers"
       />
+
+      <slot
+        v-if="hasSidePanel && $slots.sidepanel"
+        name="sidepanel"
+        :mapHeight="mapHeight"
+      />
+
+      <slot
+        v-if="popupType === 'sidebar'"
+        name="sidebar"
+        :popupIsOpen="popup.isOpen"
+        :mapHeight="mapHeight"
+      >
+        <RplMapPopUp
+          :featureId="popupId"
+          :is-open="popup.isOpen"
+          :is-area="popup.isArea"
+          :type="popupType"
+          :pinColor="popup.color"
+          :mapHeight="mapHeight"
+          :closeOnEscape="true"
+          @close="onPopUpClose"
+        >
+          <template #header>
+            <slot name="popupTitle" :selectedFeatures="popup.feature">
+              {{ popup.feature[0].title }}
+            </slot>
+          </template>
+          <slot name="popupContent" :selectedFeatures="popup.feature">
+            <p class="rpl-type-p-small">
+              {{ popup.feature[0].description }}
+            </p>
+          </slot>
+        </RplMapPopUp>
+      </slot>
 
       <div
         v-if="supportsFullScreen"
@@ -509,39 +556,6 @@ const handleUpdateSelectedLayers = (newSelectedLayers: string[]) => {
           <RplIcon name="icon-map-zoom-out" size="s"></RplIcon>
         </button>
       </div>
-
-      <slot
-        v-if="hasSidePanel && $slots.sidepanel"
-        name="sidepanel"
-        :mapHeight="mapHeight"
-      />
-
-      <slot
-        v-if="popupType === 'sidebar'"
-        name="sidebar"
-        :popupIsOpen="popup.isOpen"
-        :mapHeight="mapHeight"
-      >
-        <RplMapPopUp
-          :is-open="popup.isOpen"
-          :is-area="popup.isArea"
-          :type="popupType"
-          :pinColor="popup.color"
-          :mapHeight="mapHeight"
-          @close="onPopUpClose"
-        >
-          <template #header>
-            <slot name="popupTitle" :selectedFeatures="popup.feature">
-              {{ popup.feature[0].title }}
-            </slot>
-          </template>
-          <slot name="popupContent" :selectedFeatures="popup.feature">
-            <p class="rpl-type-p-small">
-              {{ popup.feature[0].description }}
-            </p>
-          </slot>
-        </RplMapPopUp>
-      </slot>
     </ol-map>
   </div>
 </template>

--- a/packages/ripple-ui-maps/src/components/map/RplMap.vue
+++ b/packages/ripple-ui-maps/src/components/map/RplMap.vue
@@ -350,14 +350,22 @@ const handleUpdateSelectedLayers = (newSelectedLayers: string[]) => {
   emit('updateSelectedLayers', newSelectedLayers)
 }
 
-const popupId = computed(() => {
+// Try to construct a unique id for the currently active popup, this is needed for focus management
+// Not all features have an id, and not all features have a set of coordinates
+// A popup can also contain multiple features, so we join them together
+const activePopupId = computed(() => {
+  if (!popup.value?.feature || !popup.value?.feature?.length) {
+    return null
+  }
+
   const features = Array.isArray(popup.value?.feature)
     ? popup.value.feature
     : [popup.value.feature]
-  return (
-    popup.value.position.join(',') ||
-    features.map((feature) => feature?.id).join('-')
-  )
+
+  const jointId = features.map((feature) => feature?.id).join('-')
+  const fallbackPositionId = popup.value.position.join(',')
+
+  return jointId ? jointId : fallbackPositionId
 })
 </script>
 
@@ -459,7 +467,7 @@ const popupId = computed(() => {
           :offset="[0, popup.isArea ? 6 : 8]"
         >
           <RplMapPopUp
-            :featureId="popupId"
+            :featureId="activePopupId"
             :is-open="popup.isOpen"
             :is-area="popup.isArea"
             :type="popupType"
@@ -503,7 +511,7 @@ const popupId = computed(() => {
         :mapHeight="mapHeight"
       >
         <RplMapPopUp
-          :featureId="popupId"
+          :featureId="activePopupId"
           :is-open="popup.isOpen"
           :is-area="popup.isArea"
           :type="popupType"

--- a/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.css
+++ b/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.css
@@ -1,5 +1,9 @@
 @import '@dpc-sdp/ripple-ui-core/style/breakpoints';
 
+.rpl-map-popup {
+  outline: none;
+}
+
 .rpl-map-popup--popover,
 .rpl-map-popup--sidebar,
 .rpl-map-popup--layerlist {
@@ -180,7 +184,8 @@
   .rpl-map-pop-up-scroll-container {
     max-height: var(--local-popup-body-height);
     overflow-y: auto;
-    background: linear-gradient(white 33%, rgb(255 255 255 / 0%)),
+    background:
+      linear-gradient(white 33%, rgb(255 255 255 / 0%)),
       linear-gradient(to bottom, rgb(26 26 26 / 16%), transparent);
     background-color: white;
     background-repeat: no-repeat;

--- a/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.vue
+++ b/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.vue
@@ -95,10 +95,14 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-map-popup', emit)
 const popupEL = ref()
-const previouslyFocused = ref(null)
+const previouslyFocused = ref<Element>(null)
 
 function onClose() {
-  if (previouslyFocused.value) {
+  // Return focus to where the popup was originally opened from, if the element is still in the dom
+  if (
+    previouslyFocused.value &&
+    previouslyFocused.value instanceof HTMLElement
+  ) {
     previouslyFocused.value.focus({ preventScroll: true })
   }
 
@@ -140,16 +144,16 @@ const bodyHeight = computed(() => {
   return Math.min(maxPopupHeight, availablePopupHeight) - headerHeight.value
 })
 
-watch(
-  [() => props.isOpen, () => props.featureId],
-  async (newIsOpen, newFeatureId) => {
-    if (newIsOpen) {
-      previouslyFocused.value = document.activeElement
+// Watch the featureId and isOpen to know when the popup is opened or has updated with new data.
+// Anytime this happens we want to bring focus to the popup and remember the previously focused element
+// so that we can return there when the popup is closed.
+watch([() => props.isOpen, () => props.featureId], async (newIsOpen) => {
+  if (newIsOpen) {
+    previouslyFocused.value = document.activeElement
 
-      await nextTick()
-      popupEL.value?.focus({ preventScroll: true })
-    }
+    await nextTick()
+    popupEL.value?.focus({ preventScroll: true })
   }
-)
+})
 </script>
 <style src="./RplMapPopUp.css" />

--- a/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.vue
+++ b/packages/ripple-ui-maps/src/components/popup/RplMapPopUp.vue
@@ -3,6 +3,7 @@
     <div
       v-if="isOpen"
       ref="popupEL"
+      tabIndex="-1"
       class="rpl-map-popup"
       :class="{
         [`rpl-map-popup--${type}`]: type,
@@ -55,7 +56,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch, nextTick } from 'vue'
 import {
   useResizeObserver,
   useBreakpoints,
@@ -68,6 +69,7 @@ import type { rplEventPayload } from '@dpc-sdp/ripple-ui-core'
 import LargePinIcon from './../../assets/icons/icon-pin-large.svg?component'
 
 interface Props {
+  featureId: string
   isOpen: boolean
   isArea: boolean
   pinColor?: string
@@ -93,8 +95,13 @@ const emit = defineEmits<{
 
 const { emitRplEvent } = useRippleEvent('rpl-map-popup', emit)
 const popupEL = ref()
+const previouslyFocused = ref(null)
 
 function onClose() {
+  if (previouslyFocused.value) {
+    previouslyFocused.value.focus({ preventScroll: true })
+  }
+
   emitRplEvent('close')
 }
 
@@ -132,5 +139,17 @@ const bodyHeight = computed(() => {
   // Choose the smaller of the max height and available space to get the body height
   return Math.min(maxPopupHeight, availablePopupHeight) - headerHeight.value
 })
+
+watch(
+  [() => props.isOpen, () => props.featureId],
+  async (newIsOpen, newFeatureId) => {
+    if (newIsOpen) {
+      previouslyFocused.value = document.activeElement
+
+      await nextTick()
+      popupEL.value?.focus({ preventScroll: true })
+    }
+  }
+)
 </script>
 <style src="./RplMapPopUp.css" />

--- a/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.css
+++ b/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.css
@@ -112,7 +112,7 @@
   }
 }
 
-.rpl-map-side-panel__item,
+.rpl-map-side-panel__item-inner,
 .rpl-map-side-panel__above-items,
 .rpl-map-side-panel__below-items {
   padding-block: var(--rpl-sp-4);
@@ -134,11 +134,15 @@
 
 .rpl-map-side-panel__item {
   border-top: var(--rpl-border-1) solid var(--rpl-clr-neutral-300);
-  cursor: pointer;
 
   &:last-child {
     border-bottom: var(--rpl-border-1) solid var(--rpl-clr-neutral-300);
   }
+}
+
+.rpl-map-side-panel__item-inner {
+  cursor: pointer;
+  text-align: start;
 
   &:hover,
   &:focus {
@@ -157,7 +161,9 @@
 }
 
 .rpl-map-side-panel__item--active {
-  background-color: var(--rpl-clr-neutral-100);
+  .rpl-map-side-panel__item-inner {
+    background-color: var(--rpl-clr-neutral-100);
+  }
 }
 
 .rpl-map-side-panel__item-meta {

--- a/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.css
+++ b/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.css
@@ -27,6 +27,7 @@
   overflow-y: auto;
   scrollbar-color: var(--rpl-clr-neutral-300) var(--rpl-clr-neutral-100);
   scrollbar-width: thin;
+  outline: none;
 }
 
 .rpl-map-side-panel--open {
@@ -143,6 +144,7 @@
 .rpl-map-side-panel__item-inner {
   cursor: pointer;
   text-align: start;
+  width: 100%;
 
   &:hover,
   &:focus {

--- a/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.vue
+++ b/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.vue
@@ -19,7 +19,11 @@
         </slot>
       </div>
 
-      <component :is="el" class="rpl-map-side-panel__items">
+      <component
+        :is="el"
+        :aria-label="listLabel"
+        class="rpl-map-side-panel__items"
+      >
         <slot></slot>
       </component>
 
@@ -66,13 +70,15 @@ interface Props {
   totalResults: number
   totalPages: number
   currentPage: number
+  listLabel?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   el: 'ul',
   panelLocation: 'left',
   isStandalone: false,
-  showToggle: false
+  showToggle: false,
+  listLabel: 'Map search results'
 })
 
 const isOpen = ref(true)

--- a/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.vue
+++ b/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanel.vue
@@ -120,6 +120,8 @@ const handlePageChange = async (event) => {
       })
     }
   }
+
+  scrollParentRef?.value?.focus({ preventScroll: true })
 }
 </script>
 

--- a/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanelItem.vue
+++ b/packages/ripple-ui-maps/src/components/sidepanel/RplMapSidePanelItem.vue
@@ -1,36 +1,42 @@
 <template>
   <component
     :is="el"
-    role="button"
-    tabIndex="0"
     :class="{
       'rpl-map-side-panel__item': true,
-      'rpl-map-side-panel__item--active': isActive,
-      'rpl-u-focusable-within': true
+      'rpl-map-side-panel__item--active': isActive
     }"
-    @click="handleClick"
   >
-    <div
-      v-if="$slots.meta"
-      class="rpl-map-side-panel__item-meta rpl-type-p-small"
+    <button
+      :aria-label="buttonLabel"
+      :class="{
+        'rpl-map-side-panel__item-inner': true,
+        'rpl-u-focusable-within': true
+      }"
+      @click="handleClick"
     >
-      <slot name="meta"></slot>
-    </div>
-    <div
-      class="rpl-map-side-panel__item-title rpl-type-p rpl-u-focusable-inline"
-    >
-      {{ title }}
-    </div>
-    <slot></slot>
-    <div
-      v-if="$slots.footer"
-      class="rpl-map-side-panel__item-footer rpl-type-p-small"
-    >
-      <slot name="footer"></slot>
-    </div>
+      <div
+        v-if="$slots.meta"
+        class="rpl-map-side-panel__item-meta rpl-type-p-small"
+      >
+        <slot name="meta"></slot>
+      </div>
+      <div
+        class="rpl-map-side-panel__item-title rpl-type-p rpl-u-focusable-inline"
+      >
+        {{ title }}
+      </div>
+      <slot></slot>
+      <div
+        v-if="$slots.footer"
+        class="rpl-map-side-panel__item-footer rpl-type-p-small"
+      >
+        <slot name="footer"></slot>
+      </div>
+    </button>
   </component>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue'
 import { rplEventPayload, useRippleEvent } from '@dpc-sdp/ripple-ui-core'
 
 interface Props {
@@ -55,6 +61,10 @@ const { emitRplEvent } = useRippleEvent('rpl-map-side-panel', emit)
 const handleClick = () => {
   emitRplEvent('click', { action: 'click', value: props.data })
 }
+
+const buttonLabel = computed(() => {
+  return `View ${props.title} on map`
+})
 </script>
 
 <style src="./RplMapSidePanel.css"></style>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-707

### What I did
<!-- Summary of changes made in the Pull Request -->
- Changed the markup of the map sidepanel items to be `ul > li > button` so that we can take advantage of native keyboard navigation (previously a div with `role=button')
- Updated all search components with pagination (search listings, site search, custom collections, map sidepanel) to put focus back at the top of the list when paginating.
- Popups will now close on escape key press
- When a popup is opened, focus will jump to the popup
- When a popup is closed, focus will return to the element that triggered the popup (if still in the DOM)
- Improved the tab order of the map home/zoom/fullscreen controls in relation to the map sidepanel and popups

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
