### PR TITLE
Fixes issue 1495 - form options on mobile, setting option input size to 0x0

### DIFF
--- a/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormOption.css
+++ b/packages/ripple-ui-forms/src/components/RplFormOptions/RplFormOption.css
@@ -11,6 +11,8 @@
 .rpl-form-option__input {
   appearance: none;
   outline: 0;
+  width: 0;
+  height: 0;
 }
 
 .rpl-form-option__label {
@@ -60,19 +62,19 @@
   opacity: 0;
 }
 
-.rpl-form-option__input:is(:hover, :focus, :active) + .rpl-form-option__label {
+.rpl-form-option__input:is(:hover, :focus, :active)+.rpl-form-option__label {
   .rpl-form-option__mark {
     border-color: var(--rpl-clr-dark);
   }
 }
 
-.rpl-form-option__input:checked + .rpl-form-option__label {
+.rpl-form-option__input:checked+.rpl-form-option__label {
   .rpl-form-option__mark-tick {
     opacity: 1;
   }
 }
 
-.rpl-form-option__input:focus + .rpl-form-option__label {
+.rpl-form-option__input:focus+.rpl-form-option__label {
   .rpl-form-option__check {
     border-radius: 0;
   }
@@ -83,7 +85,7 @@
   }
 }
 
-.rpl-form-option__input:disabled + .rpl-form-option__label {
+.rpl-form-option__input:disabled+.rpl-form-option__label {
   color: var(--rpl-clr-neutral-300);
   cursor: not-allowed;
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: #1495 

### What I did
<!-- Summary of changes made in the Pull Request -->
- Set the width and height of the original input with `apparence: none` to 0x0


### How to test
<!-- Summary of how to test the changes -->
- perform a visual test using content similar to https://www.ripple.sdp.vic.gov.au/storybook/iframe?id=forms-checkbox-group--default-variant&args=&viewMode=story&globals=theme:undefined;buttonTheme:default
- make sure that on iOS, the faux checkbox is aligned with the group label (vs. the original input being non-apparent but taking screen space on the left hand side)

### Checklist

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)
