### PR TITLE
[SD-863] make sure a11y click only fires once

### DIFF
--- a/packages/ripple-ui-core/src/composables/useAccessibleContainer.ts
+++ b/packages/ripple-ui-core/src/composables/useAccessibleContainer.ts
@@ -35,8 +35,9 @@ export function useAccessibleContainer() {
         const element = container.value?.$el || container.value
         // Only fire a click if the target is not the trigger el
         const clickedElement = element.querySelector('a')
+        const targetElement = (e.target as HTMLElement).closest('a')
 
-        if (clickedElement !== e.target) {
+        if (clickedElement !== targetElement) {
           clickedElement.click()
         }
       }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-863

### What I did
<!-- Summary of changes made in the Pull Request -->
- Make sure a11y click only fires once, it was firing twice if the element the user clicked on was a span within the anchor.

*Before*
![card-click-before](https://github.com/user-attachments/assets/6b9388d5-a20e-41a2-86b6-7cb8b4912d1a)

*After*
![card-click-after](https://github.com/user-attachments/assets/f4c3b6a8-fc00-4560-80b6-ec40beb51727)


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
