### PR TITLE
[SD-851] switch to even/odd row classes on data tables

### DIFF
--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.css
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.css
@@ -22,11 +22,11 @@
   }
 
   tbody {
-    &.rpl-data-table__row:nth-child(even) tr {
+    &.rpl-data-table__row--even tr {
       background-color: transparent;
     }
 
-    &.rpl-data-table__row:nth-child(odd) tr {
+    &.rpl-data-table__row--odd tr {
       background-color: var(--local-table-row-background);
     }
 

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.stories.mdx
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.stories.mdx
@@ -15,7 +15,8 @@ import {
   RplDataTableObjects,
   RplDataTableStructuredColumns,
   RplDataTableStructuredItems,
-  RplDataTableExtraComponents
+  RplDataTableExtraComponents,
+  RplDataTableItemsSimple
 } from './fixtures/sample'
 import { a11yStoryCheck } from './../../../stories/interactions.js'
 
@@ -151,6 +152,19 @@ export const SingleTemplate = (args) => ({
       },
       showExtraContent: true,
       offset: 0
+    }}
+  >
+    {SingleTemplate.bind()}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Simple"
+    play={a11yStoryCheck}
+    args={{
+      columns: RplDataTableColumns,
+      items: RplDataTableItemsSimple
     }}
   >
     {SingleTemplate.bind()}

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTableRow.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTableRow.vue
@@ -72,6 +72,9 @@ const state = reactive({
 const rowClasses = computed(() => [
   'rpl-data-table__row',
   state.enabled ? 'rpl-data-table__row--open' : null,
+  (props.index + 1) % 2 === 0
+    ? 'rpl-data-table__row--even'
+    : 'rpl-data-table__row--odd',
   ...(props.columns[props.index]?.classes || [])
 ])
 

--- a/packages/ripple-ui-core/src/components/data-table/fixtures/sample.ts
+++ b/packages/ripple-ui-core/src/components/data-table/fixtures/sample.ts
@@ -53,6 +53,12 @@ export const RplDataTableItemsSimple = [
     col2: 'R3 - C2',
     col3: 'R3 - C3',
     col4: 'R3 - C4'
+  },
+  {
+    col1: 'R4 - C1',
+    col2: 'R4 - C2',
+    col3: 'R4 - C3',
+    col4: 'R4 - C4'
   }
 ]
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-851 
 
### What I did
<!-- Summary of changes made in the Pull Request -->
- Switch to even/odd row classes on data tables, the nth selector wasn't working for this use case

**Before and after**
<img width="2327" alt="Screenshot 2025-05-02 at 12 02 14 pm" src="https://github.com/user-attachments/assets/fe8391fe-29d3-46cc-b730-a7882fa99850" />


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
