### PR TITLE
[SD-883] use runtime site value in page and site endpoints

### DIFF
--- a/examples/nuxt-app/mockserver.js
+++ b/examples/nuxt-app/mockserver.js
@@ -10,22 +10,21 @@ const setupMockServer = async () => {
 
   console.log('starting mock server...', mockServer.url)
 
-  console.log(`Mocking site data: ${mockServer.url}/api/tide/site?id=8888`)
+  console.log(`Mocking site data: ${mockServer.url}/api/tide/site`)
   await mockServer
     .forGet('/api/tide/site')
     .always()
-    .withExactQuery(`?id=8888`)
     .thenJson(200, mockSiteTaxonomy)
 
   for (let index = 0; index < mockedRoutes.length; index++) {
     const route = mockedRoutes[index]
     console.log(
-      `Mocking route : ${mockServer.url}/api/tide/page?path=${route.path}&site=8888`
+      `Mocking route : ${mockServer.url}/api/tide/page?path=${route.path}`
     )
     await mockServer
       .forGet('/api/tide/page')
       .always()
-      .withExactQuery(`?path=${route.path}&site=8888`)
+      .withExactQuery(`?path=${route.path}`)
       .thenJson(200, require(`./test/fixtures/${route.fixture}`))
   }
 

--- a/packages/nuxt-ripple-cli/src/commands/mock/mockserver.ts
+++ b/packages/nuxt-ripple-cli/src/commands/mock/mockserver.ts
@@ -18,11 +18,10 @@ const rippleMockServer = async (
     path.resolve(process.cwd(), `${siteFixturePath}`)
   )
 
-  console.info(`Mocking site data: ${mockServer.url}/api/tide/site?id=8888`)
+  console.info(`Mocking site data: ${mockServer.url}/api/tide/site`)
   await mockServer
     .forGet('/api/tide/site')
     .always()
-    .withExactQuery(`?id=8888`)
     .thenJson(200, mockSiteTaxonomy)
 
   /*
@@ -36,7 +35,7 @@ const rippleMockServer = async (
   for (let index = 0; index < mockedRoutes.length; index++) {
     const route = mockedRoutes[index]
     console.info(
-      `Mocking route : ${mockServer.url}/api/tide/page?path=${route.path}&site=8888`
+      `Mocking route : ${mockServer.url}/api/tide/page?path=${route.path}`
     )
     const fixture = await import(
       path.resolve(process.cwd(), `${fixtureFolder}/${route.fixture}`)
@@ -45,7 +44,7 @@ const rippleMockServer = async (
     await mockServer
       .forGet('/api/tide/page')
       .always()
-      .withExactQuery(`?path=${route.path}&site=8888`)
+      .withExactQuery(`?path=${route.path}`)
       .thenJson(200, fixture)
   }
   /*

--- a/packages/nuxt-ripple/composables/use-tide-page.ts
+++ b/packages/nuxt-ripple/composables/use-tide-page.ts
@@ -131,10 +131,7 @@ export const useTidePage = async (
     const { data, error } = await useFetch('/api/tide/page', {
       key: `page-${path}`,
       baseURL: config.apiUrl || '',
-      params: {
-        path,
-        site: siteId
-      },
+      params: { path },
       headers,
       async onResponse({ response }) {
         sectionCacheTags = response.headers.get('section-cache-tags')

--- a/packages/nuxt-ripple/composables/use-tide-site.ts
+++ b/packages/nuxt-ripple/composables/use-tide-site.ts
@@ -23,9 +23,6 @@ export const useTideSite = async (id?: number): Promise<TideSiteData> => {
     const { data, error } = await useFetch('/api/tide/site', {
       key: `site-${siteId}`,
       baseURL: config.apiUrl || '',
-      params: {
-        id: siteId
-      },
       headers,
       async onResponse({ response }) {
         sectionCacheTags = response.headers.get('section-cache-tags')

--- a/packages/nuxt-ripple/server/api/tide/page.ts
+++ b/packages/nuxt-ripple/server/api/tide/page.ts
@@ -18,13 +18,10 @@ export const createPageHandler = async (
 ) => {
   return createHandler(event, 'TidePageHandler', async () => {
     const query = await getQuery(event)
+    const { site } = useRuntimeConfig().public.tide
 
     if (!query.path || Array.isArray(query.path)) {
       throw new BadRequestError('Path is required')
-    }
-
-    if (Array.isArray(query.site)) {
-      throw new BadRequestError('Duplicate site values')
     }
 
     const tokenCookie = getCookie(event, AuthCookieNames.ACCESS_TOKEN)
@@ -50,7 +47,7 @@ export const createPageHandler = async (
 
     const pageResponse = await tidePageApi.getPageByPath(
       path,
-      query.site,
+      site,
       {},
       headers,
       sectionId

--- a/packages/nuxt-ripple/server/api/tide/site.ts
+++ b/packages/nuxt-ripple/server/api/tide/site.ts
@@ -1,23 +1,18 @@
 //@ts-nocheck runtime imports
-import { defineEventHandler, getQuery, H3Event } from 'h3'
+import { defineEventHandler, H3Event } from 'h3'
 import { createHandler, TideSiteApi } from '@dpc-sdp/ripple-tide-api'
-import { BadRequestError } from '@dpc-sdp/ripple-tide-api/errors'
-import { useNitroApp } from '#imports'
+import { useNitroApp, useRuntimeConfig } from '#imports'
 
 export const createSiteHandler = async (
   event: H3Event,
   tideSiteApi: TideSiteApi
 ) => {
   return createHandler(event, 'TidePageHandler', async () => {
-    const query = await getQuery(event)
-
-    if (!query.id) {
-      throw new BadRequestError('Site id is required')
-    }
+    const { site } = useRuntimeConfig().public.tide
 
     const sectionId = getHeader(event, 'x-section-request-id')
 
-    const siteResponse = await tideSiteApi.getSiteData(query.id, sectionId)
+    const siteResponse = await tideSiteApi.getSiteData(site, sectionId)
 
     // Need to pass on the section cache tags to the nuxt app
     if (siteResponse.headers && siteResponse.headers['section-cache-tags']) {

--- a/packages/ripple-test-utils/step_definitions/common/mocks.ts
+++ b/packages/ripple-test-utils/step_definitions/common/mocks.ts
@@ -44,11 +44,10 @@ Given(
   (fixture: string, status: number) => {
     cy.log(Cypress.env('NUXT_PUBLIC_TIDE_SITE'))
     cy.fixture(fixture).then((response) => {
-      cy.task('setMockRouteWithQuery', {
+      cy.task('setMockRoute', {
         route: '/api/tide/site',
         status,
-        response,
-        query: `?id=${encodeURIComponent(Cypress.env('NUXT_PUBLIC_TIDE_SITE'))}`
+        response
       })
     })
   }
@@ -62,9 +61,7 @@ Given(
         route: '/api/tide/page',
         status,
         response,
-        query: `?path=${encodeURIComponent(path)}&site=${Cypress.env(
-          'NUXT_PUBLIC_TIDE_SITE'
-        )}`
+        query: `?path=${encodeURIComponent(path)}`
       })
     })
   }
@@ -82,9 +79,7 @@ Given(
         route: '/api/tide/page',
         status: 200,
         response,
-        query: `?path=${encodeURIComponent(path)}&site=${Cypress.env(
-          'NUXT_PUBLIC_TIDE_SITE'
-        )}`
+        query: `?path=${encodeURIComponent(path)}`
       })
     })
   }
@@ -96,11 +91,10 @@ Given('I load the site fixture with {string}', (fixture: string) => {
 
 Given(`the site endpoint returns the loaded fixture`, () => {
   cy.get('@siteFixture').then((response) => {
-    cy.task('setMockRouteWithQuery', {
+    cy.task('setMockRoute', {
       route: '/api/tide/site',
       status: 200,
-      response,
-      query: `?id=${Cypress.env('NUXT_PUBLIC_TIDE_SITE')}`
+      response
     })
   })
 })


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-883

### What I did
<!-- Summary of changes made in the Pull Request -->
- Use runtime site value in page and site endpoints instead site being passed to said endpoints as a query param. This is to avoid people being able able to pull data from other sites.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
