### PR TITLE
[SD-788] update search encoding

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/home.feature
+++ b/examples/nuxt-app/test/features/landingpage/home.feature
@@ -73,4 +73,4 @@ Feature: Home page
   Scenario: Header component - Search banner - url encoding
     Given the page endpoint for path "/search/cats" returns fixture "/landingpage/home" with status 200
     Then a search banner with ID "1911" should exist with the placeholder "Test search placeholder"
-    Then in a search banner with ID "1911", searching for "cats test" should take me to "/search/cats%20test"
+    Then in a search banner with ID "1911", searching for "cats test & dogs rest" should take me to "/search/cats%20test%20%26%20dogs%20rest"

--- a/examples/nuxt-app/test/features/site/feature-flags.feature
+++ b/examples/nuxt-app/test/features/site/feature-flags.feature
@@ -54,8 +54,10 @@ Feature: Site feature flags
     And the page endpoint for path "/" returns fixture "/landingpage/image-banner" with status 200
     Given I visit the page "/"
     When I click the primary nav button labelled "Search"
+    And I type "news & events #latest" into the primary nav search box
     And I submit the primary nav search form
     Then the current path should be "/search"
+    And the current query string should include "?q=news%20%26%20events%20%23latest"
 
   @mockserver
   Scenario: Feature flags can set the primary nav search URL

--- a/packages/ripple-test-utils/step_definitions/common/navigation.ts
+++ b/packages/ripple-test-utils/step_definitions/common/navigation.ts
@@ -37,6 +37,10 @@ When('I click the primary nav button labelled {string}', (label: string) => {
     .click({ force: true })
 })
 
+Then('I type {string} into the primary nav search box', (text: string) => {
+  cy.get('#primary-nav-search').type(text)
+})
+
 Then('I submit the primary nav search form', () => {
   cy.get('.rpl-primary-nav .rpl-search-bar').submit()
 })
@@ -44,6 +48,12 @@ Then('I submit the primary nav search form', () => {
 Then('the current path should be {string}', (path: string) => {
   cy.location().should((loc) => {
     expect(path).to.eq(loc.pathname)
+  })
+})
+
+Then('the current query string should include {string}', (path: string) => {
+  cy.location().should((loc) => {
+    expect(path).to.contain(loc.search)
   })
 })
 

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/SearchBanner.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/SearchBanner.vue
@@ -13,8 +13,9 @@ const props = defineProps<{
 }>()
 
 const handleSubmit = (event) => {
-  const searchPath = encodeURI(
-    props.searchUrl.replace('[SEARCH-KEYWORDS]', event.value)
+  const searchPath = props.searchUrl.replace(
+    '[SEARCH-KEYWORDS]',
+    encodeURIComponent(event.value)
   )
 
   const isInternalUrl = !isExternalUrl(searchPath, $app_hostname)

--- a/packages/ripple-ui-core/src/components/primary-nav/components/search-form/RplPrimaryNavSearchForm.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/search-form/RplPrimaryNavSearchForm.vue
@@ -16,7 +16,7 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const handleSubmit = (event) => {
-  window.location.href = `${props.searchUrl}?q=${event.value}`
+  window.location.href = `${props.searchUrl}?q=${encodeURIComponent(event.value)}`
 }
 
 onMounted(() => {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-788

### What I did
<!-- Summary of changes made in the Pull Request -->
- Update search encoding, this is for the primary nav search bar and the search banner component. The main driver for this is; if you search for example "local & community" currently it will only search for "local ".

<img width="1649" alt="Screenshot 2025-05-12 at 1 46 23 pm" src="https://github.com/user-attachments/assets/8fcdbe37-2ad2-4051-adea-c3bd29c8fe3a" />


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
