### PR TITLE
[SD-782] Use site name as secondary logo alt

### DIFF
--- a/packages/nuxt-ripple/mapping/site/index.ts
+++ b/packages/nuxt-ripple/mapping/site/index.ts
@@ -21,15 +21,16 @@ export default {
     _src: (src: any) =>
       process.env.NODE_ENV === 'development' ? src : undefined,
     siteAlerts: siteAlertsMapping,
-    slogan: (src: any) => getBodyFromField(src, 'field_site_slogan'),
-    favicon: (src: any) => getImageFromField(src, 'field_site_favicon'),
-    appIcon: (src: any) => getImageFromField(src, 'field_site_app_icon'),
-    siteLogo: (src: any) => {
+    slogan: (src) => getBodyFromField(src, 'field_site_slogan'),
+    favicon: (src) => getImageFromField(src, 'field_site_favicon'),
+    appIcon: (src) => getImageFromField(src, 'field_site_app_icon'),
+    siteLogo: (src) => {
       if (src.field_site_logo) {
         return {
           href: '/',
           src: getMediaPath(src, 'field_site_logo'),
-          altText: src.field_site_logo.meta?.alt,
+          altText:
+            src.field_site_logo.meta?.alt || src.field_taxonomy_machine_name,
           printSrc: getMediaPath(src, 'field_print_friendly_logo')
         }
       }


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-782

### What I did
<!-- Summary of changes made in the Pull Request -->
- Uses the new `field_taxonomy_machine_name` as an alt for the secondary logo - this works on BEs that do not have the field as well (it just ignores it, same as current behaviour)
- 

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
