### PR TITLE
[SD-921] support for animating extra table content

### DIFF
--- a/examples/nuxt-app/test/features/search-listing/table.feature
+++ b/examples/nuxt-app/test/features/search-listing/table.feature
@@ -42,8 +42,12 @@ Feature: Table layout
     Given a data table with type "search-listing-layout-table"
     And the table should have the caption "My Table"
     And the table should have the footer "Some notes about the table"
+    Then the tables extra content should be hidden
     When I toggle the tables extra content row
-    Then the tables extra content should contain the text "Details: 1 Implemented"
+    Then the tables extra content should be visible
+    And the tables extra content should contain the text "Details: 1 Implemented"
+    When I toggle the tables extra content row
+    Then the tables extra content should be hidden
 
   @mockserver
   Example: Table shows extra structured content using object keys and components

--- a/packages/ripple-test-utils/step_definitions/components/data-table.ts
+++ b/packages/ripple-test-utils/step_definitions/components/data-table.ts
@@ -79,6 +79,18 @@ Then('the table should not display extra content', () => {
   })
 })
 
+Then('the tables extra content should be visible', () => {
+  cy.get('@component').within(() => {
+    cy.get('.rpl-data-table__details').should('be.visible')
+  })
+})
+
+Then('the tables extra content should be hidden', () => {
+  cy.get('@component').within(() => {
+    cy.get('.rpl-data-table__details').should('not.be.visible')
+  })
+})
+
 Then(
   'the tables extra content should contain the text {string}',
   (text: string) => {

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.css
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.css
@@ -17,6 +17,16 @@
     }
   }
 
+  .rpl-data-table__details-wrap {
+    padding: 0 var(--rpl-sp-4) var(--rpl-sp-4);
+  }
+
+  .rpl-data-table__details-wrap--offset {
+    @media (--rpl-bp-m) {
+      padding-left: var(--rpl-sp-3);
+    }
+  }
+
   table {
     width: 100%;
   }
@@ -177,6 +187,7 @@
 }
 
 .rpl-data-table .rpl-data-table__details > td:nth-child(1n) {
+  padding: 0;
   margin-top: 0;
 }
 

--- a/packages/ripple-ui-core/src/components/expandable/RplExpandable.vue
+++ b/packages/ripple-ui-core/src/components/expandable/RplExpandable.vue
@@ -10,6 +10,11 @@ const props = withDefaults(defineProps<Props>(), {
   expanded: false
 })
 
+const emit = defineEmits<{
+  (e: 'opened'): void
+  (e: 'closed'): void
+}>()
+
 const containerRef = ref(null)
 const startExpanded = ref(false)
 const duration = useComputedSpeed(containerRef, '--rpl-motion-speed-9', 420)
@@ -30,6 +35,8 @@ function onEnter(el: any, done: Function): void {
 function onAfterEnter(el: any) {
   el.style.height = 'auto'
   el.style.overflow = 'initial'
+
+  emit('opened')
 }
 
 function onBeforeLeave(el: any) {
@@ -44,6 +51,10 @@ function onLeave(el: any, done: Function) {
 
   // call the done callback to indicate transition end
   setTimeout(done, duration.value)
+}
+
+function onAfterLeave() {
+  emit('closed')
 }
 
 const classes = computed(() => ({
@@ -66,6 +77,7 @@ onMounted(() => {
     @after-enter="onAfterEnter"
     @before-leave="onBeforeLeave"
     @leave="onLeave"
+    @after-leave="onAfterLeave"
   >
     <div v-show="expanded" ref="containerRef" :class="classes" role="region">
       <slot />


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-921

### What I did
<!-- Summary of changes made in the Pull Request -->
- Animate in the extra content section, had to 'nest' this expandable section within the td for a couple reasons: 
  1. You can't really animate the height of the `tr` itself; because the display is set to `table-row` (needed for the offset column) setting a height of 0 for animating from is ignored, the min-height will always be the min height of it's cells contents.
  2. The only valid child of `tbody` is `tr`, see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tbody#technical_summary so we can't technically wrap the `tr`


https://github.com/user-attachments/assets/2d70caeb-2c49-4c64-9ec5-f917f363c1af


https://github.com/user-attachments/assets/9a0063c5-5953-479d-9303-40ac307a0b30


https://github.com/user-attachments/assets/d9043621-8ef0-4815-9e0f-503b0668df56

### How to test
<!-- Summary of how to test the changes -->
- See storybook

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
