### PR TITLE
[SD-921] remove double heading

### DIFF
--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.vue
@@ -107,6 +107,7 @@ const displayMobileView: ComputedRef<boolean> = computed(() => {
           :extraContent="(row.__extraContent as extraRowContent) || null"
           :showExtraContent="showExtraContent"
           :vertical-header="headingType.vertical"
+          :horizontal-header="headingType.horizontal"
           :offset="offset"
           :caption="caption"
           :index="index"

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTableRow.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTableRow.vue
@@ -44,6 +44,7 @@ interface Props {
   row: tableRow
   extraContent?: extraRowContent | null
   verticalHeader?: boolean
+  horizontalHeader?: boolean
   offset: number
   caption?: string
   index: number
@@ -53,6 +54,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   items: () => [],
   verticalHeader: true,
+  horizontalHeader: true,
   caption: undefined,
   extraContent: null
 })
@@ -126,7 +128,11 @@ const handleClosed = () => (state.opened = false)
         :data-label="column.label"
         :scope="i === 0 && verticalHeader ? 'row' : null"
       >
-        <div class="rpl-data-table__mobile-label" v-html="column.label" />
+        <div
+          v-if="!(i === 0 && verticalHeader) && horizontalHeader"
+          class="rpl-data-table__mobile-label"
+          v-html="column.label"
+        />
         <template v-if="hasComponent(column)">
           <component
             :is="(column as tableColumnConfig).component"


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-921

### What I did
<!-- Summary of changes made in the Pull Request -->
- When both vertical and horizontal headings are used the first horizontal heading should be omitted in the mobile view.

_(Left = updated, Right = previous)_
<img width="1216" alt="Screenshot 2025-05-29 at 10 45 36 am" src="https://github.com/user-attachments/assets/446aee44-35b2-4041-aa6a-937ad33bfbf7" />

### How to test
<!-- Summary of how to test the changes -->
- See storybook

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
