### PR TITLE
[SD-951] don't use srcset for nav logos

### DIFF
--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
@@ -107,12 +107,14 @@ const showMobileToggle = computed(() => {
           class="rpl-primary-nav__primary-logo-image rpl-u-screen-only"
           :src="primaryLogo.src"
           :alt="primaryLogo.altText"
+          :srcset="null"
         />
         <RplImg
           v-if="primaryLogo?.src"
           class="rpl-primary-nav__primary-logo-image rpl-primary-nav__logo-alt rpl-u-print-only"
           :src="primaryLogo?.printSrc ? primaryLogo?.printSrc : primaryLogo.src"
           :alt="primaryLogo.altText"
+          :srcset="null"
         />
       </RplLink>
 
@@ -132,12 +134,14 @@ const showMobileToggle = computed(() => {
           class="rpl-primary-nav__secondary-logo-image rpl-u-screen-only"
           :src="secondaryLogo.src"
           :alt="secondaryLogo.altText"
+          :srcset="null"
         />
         <RplImg
           v-if="secondaryLogo.printSrc"
           class="rpl-primary-nav__secondary-logo-image rpl-primary-nav__logo-alt rpl-u-print-only"
           :src="secondaryLogo.printSrc"
           :alt="secondaryLogo.altText"
+          :srcset="null"
         />
       </RplLink>
     </div>
@@ -149,7 +153,10 @@ const showMobileToggle = computed(() => {
       ]"
     >
       <!-- Mobile menu toggle -->
-      <li v-if="showMobileToggle" class="rpl-primary-nav__nav-bar-mobile-menu-toggle-container">
+      <li
+        v-if="showMobileToggle"
+        class="rpl-primary-nav__nav-bar-mobile-menu-toggle-container"
+      >
         <RplPrimaryNavBarAction
           type="toggle"
           href="/"


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-951

### What I did
<!-- Summary of changes made in the Pull Request -->
- The legislation logo is too small, this means the srcset value used is incorrect and causes the logo to display incorrectly, this update to remove srcset effectively resets the behavior to how it was previously when it was an <img> tag.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
