### PR TITLE
[SD-943] Standardised og:image attribute to be always be absolute URL

### DIFF
--- a/packages/nuxt-ripple/composables/use-tide-site-meta.ts
+++ b/packages/nuxt-ripple/composables/use-tide-site-meta.ts
@@ -29,6 +29,19 @@ const metaProperty = (str: string) => {
   return p[0] + p[1].charAt(0).toUpperCase() + p[1].slice(1)
 }
 
+/**
+ * The og:image attribute should be an absolute URL, but the share image can come to us in many formats.
+ * Here we standardize all of them to absolute URLs.
+ */
+const getAbsoluteImageUrl = (siteURL: string, imgUrl: string): string => {
+  if (siteURL && imgURL) {
+    const url = new URL(imgUrl, siteURL)
+    return `${siteURL}${url?.pathname}`
+  }
+
+  return imgUrl
+}
+
 export default (props: {
   page: PageProps
   site: TideSiteData
@@ -145,13 +158,13 @@ export default (props: {
       ogDescription: description,
       ogType: 'website',
       ogUrl: $app_origin + page.meta?.url,
-      ogImage: featuredImage,
+      ogImage: getAbsoluteImageUrl($app_origin, featuredImage),
       ogImageAlt: featuredImageAlt,
       twitterCard: 'summary',
       twitterSite: $app_origin,
       twitterTitle: props.pageTitle,
       twitterDescription: description,
-      twitterImage: twitterImage,
+      twitterImage: getAbsoluteImageUrl($app_origin, twitterImage),
       twitterImageAlt: twitterImageAlt,
       keywords: page.meta?.keywords,
 


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-943

### What I did
<!-- Summary of changes made in the Pull Request -->
- Sometimes the og:image meta tag is a relative URL, there are a few sources that say that og:image can't be relative so this may be what's causing the issue


### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
