### PR TITLE
[SD-895] Removed app search and useSearchUI from content collection component

### DIFF
--- a/examples/nuxt-app/layers/example-data-driven-component/app.config.ts
+++ b/examples/nuxt-app/layers/example-data-driven-component/app.config.ts
@@ -1,8 +1,5 @@
 export default defineAppConfig({
   ripple: {
-    featureFlags: {
-      contentCollectionSearchConnector: 'elasticsearch'
-    },
     dataDrivenComponents: {
       // add key of field_data_driven_component and value of component name to render
       // eg: find_a_council_map: 'VicCouncilLookup'

--- a/examples/nuxt-app/test/features/landingpage/content-collection.feature
+++ b/examples/nuxt-app/test/features/landingpage/content-collection.feature
@@ -5,23 +5,11 @@ Feature: Content collection
     And the page endpoint for path "/" returns fixture "/landingpage/content-collection" with status 200
 
   @mockserver
-  Scenario: Page component - Content collection (elasticsearch)
+  Scenario: Page component - Content collection
     Given the "/**/_search" network request is stubbed with fixture "/landingpage/content-collection-response-elasticsearch" and status 200 as alias "ccReq"
-    And the feature flag "contentCollectionSearchConnector" is set to "elasticsearch"
     And the site endpoint returns the loaded fixture
     When I visit the page "/"
     Then the content collection with ID "2192" exist with the following cards
       | title          | content                              | image                    | url        |
       | News for CC 01 | NP1 Etiam scelerisque lorem sit amet | /placeholders/medium.png | /news-cc-1 |
       | News for CC 02 | NP2 Pellentesque a pharetra magna    |                          | /news-cc-2 |
-
-  @mockserver
-  Scenario: Page component - Content collection (appSearch)
-    Given the "/api/as/v1/engines/**/search.json" network request is stubbed with fixture "/landingpage/content-collection-response-appsearch" and status 200 as alias "ccReq"
-    And the feature flag "contentCollectionSearchConnector" is set to "appSearch"
-    And the site endpoint returns the loaded fixture
-    When I visit the page "/"
-    Then the content collection with ID "2192" exist with the following cards
-      | title            | content                              | image                    | url        |
-      | News for CC 1 AS | NP1 Etiam scelerisque lorem sit amet | /placeholders/medium.png | /news-cc-1 |
-      | News for CC 2 AS | NP2 Pellentesque a pharetra magna    |                          | /news-cc-2 |

--- a/packages/ripple-tide-api/types.d.ts
+++ b/packages/ripple-tide-api/types.d.ts
@@ -247,6 +247,7 @@ export interface IRplFeatureFlags {
    */
   disableFooterLogo?: boolean
   /**
+   * @deprecated content collections will no longer use app search, this feature flag will have no effect
    * @description Sets which search connector to use for content collection queries
    */
   contentCollectionSearchConnector?: 'appSearch' | 'elasticsearch'

--- a/packages/ripple-tide-landing-page/app.config.ts
+++ b/packages/ripple-tide-landing-page/app.config.ts
@@ -1,8 +1,5 @@
 export default defineAppConfig({
   ripple: {
-    featureFlags: {
-      contentCollectionSearchConnector: 'elasticsearch'
-    },
     dataDrivenComponents: {
       // add key of field_data_driven_component and value of component name to render
       // eg: find_a_council_map: 'VicCouncilLookup'

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -37,7 +37,7 @@
         </ul>
       </template>
       <div
-        v-if="link.url"
+        v-if="link?.url"
         class="rpl-type-label rpl-type-weight-bold rpl-u-margin-t-6"
       >
         <RplTextLink v-bind="link" />
@@ -55,15 +55,14 @@ import { stripMediaBaseUrl } from '@dpc-sdp/ripple-tide-api/utils'
 const { public: config } = useRuntimeConfig()
 
 const props = defineProps<{
-  title: string
   description?: string
-  link: {
+  link?: {
     text: string
     url: string
-  }
+  } | null
   searchQuery: Record<string, any>
   display: IContentCollectionDisplay
-  hasSidebar: boolean
+  hasSidebar?: boolean
 }>()
 
 const cardClasses = computed(() =>

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <RplContent class="rpl-type-p rpl-u-margin-b-4" :html="description" />
-    <RplContent v-if="searchState.error">
+    <RplContent v-if="error">
       <p>Sorry! Something went wrong. Please try again later.</p>
     </RplContent>
-    <RplContent v-else-if="searchComplete && !searchState.totalResults">
+    <RplContent v-else-if="searchComplete && !results.length">
       <p>Sorry! We couldn't find any matches.</p>
     </RplContent>
     <div v-else>
@@ -47,27 +47,12 @@
 </template>
 
 <script setup lang="ts">
-import { formatDate, useSearchUI, useRuntimeConfig } from '#imports'
-import { computed, inject } from 'vue'
-import {
-  IContentCollectionDisplay,
-  IContentCollectionFilter,
-  IContentCollectionSort
-} from '../../../mapping/components/content-collection/content-collection-mapping'
-import type { IRplFeatureFlags } from '@dpc-sdp/ripple-tide-api/types'
+import { formatDate, useRuntimeConfig } from '#imports'
+import { computed } from 'vue'
+import { IContentCollectionDisplay } from '../../../mapping/components/content-collection/content-collection-mapping'
 import { stripMediaBaseUrl } from '@dpc-sdp/ripple-tide-api/utils'
 
 const { public: config } = useRuntimeConfig()
-
-const featureFlags: IRplFeatureFlags = inject('featureFlags', {})
-
-const connectorType =
-  featureFlags.contentCollectionSearchConnector || 'appSearch'
-
-const apiConnectorOptions = {
-  type: connectorType,
-  ...(config.tide?.[connectorType] || {})
-}
 
 const props = defineProps<{
   title: string
@@ -76,10 +61,8 @@ const props = defineProps<{
     text: string
     url: string
   }
+  searchQuery: Record<string, any>
   display: IContentCollectionDisplay
-  perPage: number
-  filters: IContentCollectionFilter[]
-  sortBy: IContentCollectionSort[]
   hasSidebar: boolean
 }>()
 
@@ -91,71 +74,51 @@ const cardClasses = computed(() =>
 
 const searchResultsMappingFn = (item): any => {
   const { $app_origin, $config } = useNuxtApp()
-  const rawUpdated = item.changed?.raw?.[0]
-  const rawImage = item.field_media_image_absolute_path?.raw?.[0]
+  const rawUpdated = getSingleResultValue(item._source?.changed)
+  const rawImage = getSingleResultValue(
+    item._source?.field_media_image_absolute_path
+  )
 
   return {
-    id: item._meta.id,
+    id: item._id,
     props: {
       el: 'li',
-      title: item.title?.raw?.[0],
-      url: stripSiteId(item.url?.raw?.[0], $app_origin || ''),
+      title: getSingleResultValue(item._source?.title),
+      url: stripSiteId(
+        getSingleResultValue(item._source?.url),
+        $app_origin || ''
+      ),
       image:
         props.display.style === 'thumbnail' && rawImage
           ? { src: stripMediaBaseUrl(rawImage, $config.public?.tide?.baseUrl) }
           : null,
       updated: rawUpdated ? formatDate(rawUpdated) : '',
-      type: item.type?.raw?.[0]
+      type: getSingleResultValue(item._source?.type)
     },
     slots: {
-      default:
-        item.field_landing_page_summary?.snippet ||
-        item.field_landing_page_summary?.raw?.[0]
+      default: getSingleResultValue(item._source?.field_landing_page_summary)
     }
   }
 }
 
-const searchDriverOptions = {
-  trackUrlState: false,
-  alwaysSearchOnInitialLoad: true,
-  initialState: {
-    resultsPerPage: props.perPage,
-    sortList: props.sortBy
-  },
-  searchQuery: {
-    filters: props.filters,
-    result_fields: {
-      title: {
-        raw: {
-          size: 150
-        }
-      },
-      field_landing_page_summary: {
-        snippet: {
-          size: 150,
-          fallback: true
-        }
-      },
-      field_media_image_absolute_path: {
-        raw: {}
-      },
-      changed: {
-        raw: {}
-      },
-      url: {
-        raw: {}
-      },
-      type: {
-        raw: {}
-      }
-    }
-  }
-}
+const error = ref(null)
+const searchComplete = ref(false)
+const results = ref(null)
 
-const { results, searchState, searchComplete } = await useSearchUI(
-  apiConnectorOptions,
-  searchDriverOptions,
-  [],
-  searchResultsMappingFn
-)
+const index = config.tide.elasticsearch.index
+const searchUrl = `${config.apiUrl}/api/tide/elasticsearch/${index}/_search`
+
+try {
+  const searchResponse = await $fetch(searchUrl, {
+    method: 'POST',
+    body: props.searchQuery
+  })
+
+  results.value = searchResponse?.hits?.hits?.map(searchResultsMappingFn)
+} catch (e) {
+  trackError(e)
+  error.value = e
+} finally {
+  searchComplete.value = true
+}
 </script>

--- a/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.test.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/content-collection/content-collection-mapping.test.ts
@@ -8,7 +8,7 @@ import { rawData } from './test-data'
 
 describe('contentCollectionMapping', () => {
   it('maps a raw json api response to the correct structure for content collections', () => {
-    const result: TideDynamicPageComponent<IContentCollection> = {
+    const expectedResult: TideDynamicPageComponent<IContentCollection> = {
       component: 'TideLandingPageContentCollection',
       id: '1437',
       title: 'News & Landing Pages',
@@ -18,34 +18,57 @@ describe('contentCollectionMapping', () => {
           text: 'View all',
           url: '#'
         },
-        filters: [
-          {
-            type: 'any',
-            field: 'type',
-            values: ['landing_page', 'news']
+        searchQuery: {
+          query: {
+            bool: {
+              filter: [
+                {
+                  bool: {
+                    should: [
+                      {
+                        terms: {
+                          type: ['landing_page', 'news']
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  bool: {
+                    should: [
+                      {
+                        terms: {
+                          field_topic: [8941, 8940]
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  bool: {
+                    should: [
+                      {
+                        term: {
+                          field_node_site: '8888'
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
           },
-          {
-            type: 'any',
-            field: 'field_topic',
-            values: [8941, 8940]
-          },
-          {
-            type: 'any',
-            field: 'field_node_site',
-            values: ['8888']
-          }
-        ],
-        sortBy: [
-          {
-            field: 'field_news_date',
-            direction: 'desc'
-          },
-          {
-            field: 'created',
-            direction: 'desc'
-          }
-        ],
-        perPage: 6,
+          size: 6,
+          from: 0,
+          sort: [
+            {
+              field_news_date: 'desc'
+            },
+            {
+              created: 'desc'
+            }
+          ]
+        },
         display: {
           type: 'card',
           style: 'thumbnail'
@@ -54,7 +77,7 @@ describe('contentCollectionMapping', () => {
     }
 
     expect(contentCollectionMapping(rawData, {}, { site: '8888' })).toEqual(
-      result
+      expectedResult
     )
   })
 })

--- a/packages/ripple-tide-search/README.md
+++ b/packages/ripple-tide-search/README.md
@@ -61,15 +61,3 @@ NUXT_PUBLIC_TIDE_ELASTICSEARCH_HOST=
 # Elasticsearch index
 NUXT_PUBLIC_TIDE_ELASTICSEARCH_INDEX=
 ```
-
-There's also a feature flag for setting the content collection search engine to either `appSearch` or `elasticsearch`. This can be set in your sites `app.config.js` file under the `ripple` property.
-
-```js
-export default defineAppConfig({
-  ripple: {
-    featureFlags: {
-      contentCollectionSearchConnector: 'elasticsearch'
-    }
-  }
-})
-```


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-895

### What I did
<!-- Summary of changes made in the Pull Request -->
- Removed use of the useSearchUI composable in content collection, in support of removing usage app search.
- Simplified the content collection mapping. A new prop called 'searchQuery' is the body/queryDSL of the call to elasticsearch. There is no longer an intermediate format, this component is simple enough not to need it. All the complexity has been moved to the mapping function.
- Deprecated the `contentCollectionSearchConnector` feature flag as it's no longer relevant.
- Updated tests

### How to test
<!-- Summary of how to test the changes -->
- 
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
