### PR TITLE
[SD-959] issue re-applying filters and switching tabs the first time

### DIFF
--- a/examples/nuxt-app/test/features/maps/maps.feature
+++ b/examples/nuxt-app/test/features/maps/maps.feature
@@ -262,6 +262,90 @@ Feature: Custom collection map component
     Then the map is in the default position
 
   @mockserver
+  Scenario: Navigating off the map tab and back after re-applying search works as expected
+    Given I load the page fixture with "/maps/basic-page"
+    And the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
+    Then the page endpoint for path "/map" returns the loaded fixture
+    Then I visit the page "/map"
+    And the map is loaded
+
+    When I toggle the search listing filters section
+    Then I submit the search filters
+    And I click the tab labelled "List"
+    Then the URL should reflect that the current active filters are as follows:
+      | id        | value   |
+      | activeTab | listing |
+    And the list view should be displayed
+    And the search network request should be called with the "/maps/request-empty" fixture
+
+    When I submit the search filters
+    Then I click the tab labelled "Map"
+    And the map view should be displayed
+    And the URL should reflect that the current active filters are as follows:
+      | id        |
+      | activeTab |
+
+    When I click the search listing dropdown field labelled "Project Type"
+    And I click the option labelled "Planning" in the selected dropdown
+    And I click the search listing dropdown field labelled "Project Type"
+    And I submit the search filters
+    Then I click the tab labelled "List"
+    Then the list view should be displayed
+    And the search network request should be called with the "/maps/request-with-filter" fixture
+
+  @mockserver
+  Scenario: Browser navigation is respected when using the map, search and tabs
+    Given I load the page fixture with "/maps/basic-page"
+    And the "/api/tide/elasticsearch/elasticsearch_index_develop_node/_search" network request is stubbed with fixture "/maps/simple-map-results" and status 200 as alias "searchReq"
+    Then the page endpoint for path "/map" returns the loaded fixture
+    Then I visit the page "/map"
+    And the map is loaded
+
+    When I click the tab labelled "List"
+    Then the list view should be displayed
+    When I toggle the search listing filters section
+    Then I click the search listing dropdown field labelled "Project Type"
+    And I click the option labelled "Planning" in the selected dropdown
+    And I click the search listing dropdown field labelled "Project Type"
+    And I submit the search filters
+    Then the URL should reflect that the current active filters are as follows:
+      | id        | value    |
+      | category  | Planning |
+      | activeTab | listing  |
+    And the search network request should be called with the "/maps/request-with-filter" fixture
+
+    When I navigate back
+    Then the list view should be displayed
+    Then the URL should reflect that the current active filters are as follows:
+      | id        | value   |
+      | category  |         |
+      | activeTab | listing |
+    And the search listing dropdown field labelled "Project Type" should have the value "Select"
+    And the search network request should be called with the "/maps/request-empty" fixture
+
+    When I navigate back
+    Then the URL should reflect that the current active filters are as follows:
+      | id        | value |
+      | category  |       |
+      | activeTab |       |
+    And the map view should be displayed
+
+    When I navigate forward
+    Then the list view should be displayed
+    And the URL should reflect that the current active filters are as follows:
+      | id        | value   |
+      | category  |         |
+      | activeTab | listing |
+    And the search network request should be called with the "/maps/request-empty" fixture
+
+    When I navigate forward
+    And the URL should reflect that the current active filters are as follows:
+      | id        | value    |
+      | category  | Planning |
+      | activeTab | listing  |
+    And the search network request should be called with the "/maps/request-with-filter" fixture
+
+  @mockserver
   Scenario: Clicking a result link fires the click_search_result event
     Given I load the page fixture with "/maps/basic-page"
     Given the popup type is "popover"

--- a/examples/nuxt-app/test/fixtures/maps/request-empty.json
+++ b/examples/nuxt-app/test/fixtures/maps/request-empty.json
@@ -1,0 +1,38 @@
+
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match_all": {}
+        }
+      ],
+      "filter": [
+        {
+          "terms": {
+            "type": [
+              "project_infrastructure"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [
+              622
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "size": 5,
+  "from": 0,
+  "sort": [
+    {
+      "_score": "desc"
+    },
+    {
+      "_doc": "desc"
+    }
+  ]
+}

--- a/examples/nuxt-app/test/fixtures/maps/request-with-filter.json
+++ b/examples/nuxt-app/test/fixtures/maps/request-with-filter.json
@@ -1,0 +1,45 @@
+
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match_all": {}
+        }
+      ],
+      "filter": [
+        {
+          "terms": {
+            "type": [
+              "project_infrastructure"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [
+              622
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_mappintype_value": [
+              "Planning"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "size": 5,
+  "from": 0,
+  "sort": [
+    {
+      "_score": "desc"
+    },
+    {
+      "_doc": "desc"
+    }
+  ]
+}

--- a/packages/ripple-test-utils/step_definitions/common/navigation.ts
+++ b/packages/ripple-test-utils/step_definitions/common/navigation.ts
@@ -134,3 +134,11 @@ Then('I scroll {int} pixels', (pixels: number) => {
 Then('I click the back to top button', () => {
   cy.get('.rpl-back-to-top__button').click()
 })
+
+Then('I navigate back', () => {
+  cy.go('back')
+})
+
+Then('I navigate forward', () => {
+  cy.go('forward')
+})

--- a/packages/ripple-test-utils/step_definitions/components/maps.ts
+++ b/packages/ripple-test-utils/step_definitions/components/maps.ts
@@ -340,6 +340,12 @@ Then(`the list view should be displayed`, () => {
   }).should('be.visible')
 })
 
+Then(`the map view should be displayed`, () => {
+  cy.get('.rpl-map', {
+    timeout: 12000
+  }).should('be.visible')
+})
+
 When(
   `I click the link in the list view with label {string}`,
   (label: string) => {

--- a/packages/ripple-tide-search/composables/useTideSearch.ts
+++ b/packages/ripple-tide-search/composables/useTideSearch.ts
@@ -826,7 +826,9 @@ export default ({
       }
     })
 
+    await nextTick()
     searchFromRoute(route, false)
+    manualSearch.value = false
   }
 
   /**
@@ -1039,7 +1041,6 @@ export default ({
     }
 
     if (manualSearch.value) {
-      manualSearch.value = false
       return
     }
     searchFromRoute(newRoute, false)


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-959

### What I did
<!-- Summary of changes made in the Pull Request -->
- Fixes issue when user re-applies unchanged filters again, then tries to switch tabs the first time

_Note: This will probably need a patch release if `2.34.0` is going out, so can I get a bit of a critical eye 👀 on this, maybe a test too, cheers._ 

### How to test
<!-- Summary of how to test the changes -->
- There's 3 PR envirionments to test this to get good maps coverage
- Early learning 
  - https://app.pr-20.earlylearning-vic-gov-au.sdp4.sdp.vic.gov.au/find-centre
- Police 
  - https://app.pr-500.vicpol-vic-gov-au.sdp4.sdp.vic.gov.au/police-station-location
- Vic.gov.au
  - https://app.pr-1233.vic-gov-au.sdp4.sdp.vic.gov.au/completed-connectivity-projects
  - https://app.pr-1233.vic-gov-au.sdp4.sdp.vic.gov.au/find-vicfreewifi-hotspots-victoria
  - https://app.pr-1233.vic-gov-au.sdp4.sdp.vic.gov.au/find-road-safety-camera
  - https://app.pr-1233.vic-gov-au.sdp4.sdp.vic.gov.au/know-your-council

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
