### PR TITLE
[SD-1033] hide nav when there are no publication pages

### DIFF
--- a/examples/nuxt-app/test/features/publication/publication.feature
+++ b/examples/nuxt-app/test/features/publication/publication.feature
@@ -1,14 +1,12 @@
 Feature: Publication page
 
-  Example of mocked page
-
   Background:
-    Given the page endpoint for path "/victorian-skills-plan-2023-implementation-update" returns fixture "/publication/sample-publication" with status 200
-    And the site endpoint returns fixture "/site/vic" with status 200
+    Given the site endpoint returns fixture "/site/vic" with status 200
 
   @mockserver
   Example: Publication parent
-    Given the endpoint "/api/tide/publication-index" with query "?id=ecb799a1-a1a3-4989-89f6-1657f786e12e" returns fixture "/publication/sample-index" with status 200
+    Given the page endpoint for path "/victorian-skills-plan-2023-implementation-update" returns fixture "/publication/sample-publication" with status 200
+    And the endpoint "/api/tide/publication-index" with query "?id=ecb799a1-a1a3-4989-89f6-1657f786e12e" returns fixture "/publication/sample-index" with status 200
     When I visit the page "/victorian-skills-plan-2023-implementation-update"
     Then the title should be "Victorian Skills Plan Implementation Update"
     And the publication details should include the following items
@@ -25,6 +23,15 @@ Feature: Publication page
       | title                                                    | url                                                                               | type | size    |
       | Victorian Skills Plan Implementation Update October 2023 | /sites/default/files/2023-10/16686-VSA-Implementation-Plan-Section_FA_Digital.pdf | pdf  | 4.61 MB |
       | Print full document                                      | /victorian-skills-plan-2023-implementation-update/print-all                       |      |         |
+    And the publication nav should have 36 links
+    And the publication nav should include the following links
+      | title                                                            | url                                                                                                    |
+      | Victorian Skills Plan Implementation Update                      | /victorian-skills-plan-2023-implementation-update                                                      |
+      | The Victorian Skills Plan 2022 into 2023 actions and initiatives | /victorian-skills-plan-2023-implementation-update/2022-victorian-skills-plan-actions-and-initiatives   |
+      | Promoting post-secondary education skills and career pathways    | /victorian-skills-plan-2023-implementation-update/promoting-post-secondary-education-skills-and-career |
+      | Lifting participation in education and training                  | /victorian-skills-plan-2023-implementation-update/lifting-participation-education-and-training         |
+    And the print document link should visible
+
     When I click on the document "Victorian Skills Plan Implementation Update October 2023"
     Then the dataLayer should include the following events
       | event         | element_text                                             | file_name                                            | file_extension | file_size | component |
@@ -32,7 +39,8 @@ Feature: Publication page
 
   @mockserver
   Example: Publication child
-    Given the page endpoint for path "/victorian-skills-plan-2023-implementation-update/2022-victorian-skills-plan-actions-and-initiatives" returns fixture "/publication/sample-publication-page" with status 200
+    Given the page endpoint for path "/victorian-skills-plan-2023-implementation-update" returns fixture "/publication/sample-publication" with status 200
+    And the page endpoint for path "/victorian-skills-plan-2023-implementation-update/2022-victorian-skills-plan-actions-and-initiatives" returns fixture "/publication/sample-publication-page" with status 200
     And the page endpoint for path "/victorian-skills-plan-2023-implementation-update/promoting-post-secondary-education-skills-and-career" returns fixture "/publication/sample-publication-page" with status 200
     And the endpoint "/api/tide/publication-index" with query "?id=ecb799a1-a1a3-4989-89f6-1657f786e12e" returns fixture "/publication/sample-index" with status 200
     When I visit the page "/victorian-skills-plan-2023-implementation-update/2022-victorian-skills-plan-actions-and-initiatives"
@@ -43,6 +51,8 @@ Feature: Publication page
       | title                                                    | url                                                                               | type | size    |
       | Victorian Skills Plan Implementation Update October 2023 | /sites/default/files/2023-10/16686-VSA-Implementation-Plan-Section_FA_Digital.pdf | pdf  | 4.61 MB |
       | Print full document                                      | /victorian-skills-plan-2023-implementation-update/print-all                       |      |         |
+    And the publication nav should have 36 links
+    And the print document link should visible
 
     When I click on the "Next" page link
     Then the dataLayer should include the following events
@@ -56,7 +66,8 @@ Feature: Publication page
 
   @mockserver
   Example: Publication print all
-    Given the endpoint "/api/tide/publication-children" with query "?ids=100&ids=101&ids=102&ids=103&ids=104&ids=105&ids=106&ids=107&ids=108&ids=109&ids=110&ids=111&ids=112&ids=113&ids=114&ids=115&ids=116&ids=117&ids=118&ids=119&ids=120&ids=121&ids=122&ids=123&ids=124&ids=125&ids=126" returns fixture "/publication/sample-print-all" with status 200
+    Given the page endpoint for path "/victorian-skills-plan-2023-implementation-update" returns fixture "/publication/sample-publication" with status 200
+    And the endpoint "/api/tide/publication-children" with query "?ids=100&ids=101&ids=102&ids=103&ids=104&ids=105&ids=106&ids=107&ids=108&ids=109&ids=110&ids=111&ids=112&ids=113&ids=114&ids=115&ids=116&ids=117&ids=118&ids=119&ids=120&ids=121&ids=122&ids=123&ids=124&ids=125&ids=126" returns fixture "/publication/sample-print-all" with status 200
     And the endpoint "/api/tide/publication-index" with query "?id=ecb799a1-a1a3-4989-89f6-1657f786e12e" returns fixture "/publication/sample-index" with status 200
     When I visit the print all page "/victorian-skills-plan-2023-implementation-update/print-all"
     Then the dataLayer should include the following events
@@ -78,6 +89,15 @@ Feature: Publication page
 
   @mockserver
   Example: Hides print all button when node limit exceeded
-    Given the endpoint "/api/tide/publication-index" with query "?id=ecb799a1-a1a3-4989-89f6-1657f786e12e" returns fixture "/publication/sample-index-large" with status 200
+    Given the page endpoint for path "/victorian-skills-plan-2023-implementation-update" returns fixture "/publication/sample-publication" with status 200
+    And the endpoint "/api/tide/publication-index" with query "?id=ecb799a1-a1a3-4989-89f6-1657f786e12e" returns fixture "/publication/sample-index-large" with status 200
     When I visit the page "/victorian-skills-plan-2023-implementation-update"
     Then the print document link should be hidden
+
+  @mockserver
+  Example: Hides publication menu when there are no child pages
+    Given the page endpoint for path "/publication-no-pages" returns fixture "/publication/sample-publication-no-children" with status 200
+    And the endpoint "/api/tide/publication-index" with query "?id=cecd683a-c34b-4613-ac06-0d4147cf1a42" returns fixture "/publication/sample-index-no-children" with status 200
+    When I visit the page "/publication-no-pages"
+    Then the publication nav should not exist
+    And the print document link should visible

--- a/examples/nuxt-app/test/fixtures/publication/sample-index-no-children.json
+++ b/examples/nuxt-app/test/fixtures/publication/sample-index-no-children.json
@@ -1,0 +1,8 @@
+{
+  "publication": {
+    "text": "Publication with no pages",
+    "url": "/publication-no-pages",
+    "id": "cecd683a-c34b-4613-ac06-0d4147cf1a42",
+    "nid": "291"
+  }
+}

--- a/examples/nuxt-app/test/fixtures/publication/sample-publication-no-children.json
+++ b/examples/nuxt-app/test/fixtures/publication/sample-publication-no-children.json
@@ -1,0 +1,115 @@
+{
+  "title": "Publication with no pages",
+  "changed": "2025-06-26T11:47:06+10:00",
+  "created": "2025-06-26T11:45:33+10:00",
+  "type": "publication",
+  "nid": "cecd683a-c34b-4613-ac06-0d4147cf1a42",
+  "_sectionId": "8888",
+  "sidebar": {
+    "contacts": [],
+    "relatedLinks": [],
+    "socialShareNetworks": [
+      "Facebook",
+      "X",
+      "LinkedIn"
+    ]
+  },
+  "status": "published",
+  "topicTags": [
+    {
+      "text": "Another Demo Topic",
+      "url": "/topic/another-demo-topic"
+    }
+  ],
+  "tags": [],
+  "topic": {
+    "text": "Another Demo Topic",
+    "url": "/topic/another-demo-topic"
+  },
+  "header": {
+    "title": "Publication with no pages",
+    "summary": "",
+    "links": {
+      "title": "",
+      "items": [],
+      "more": null
+    },
+    "backgroundImageCaption": "",
+    "theme": "default",
+    "logoImage": null,
+    "backgroundImage": null,
+    "cornerTop": null,
+    "cornerBottom": null,
+    "primaryAction": null,
+    "secondaryAction": null,
+    "secondaryActionLabel": ""
+  },
+  "siteSection": {
+    "id": 8888,
+    "name": "Demo Site",
+    "siteOverrides": {
+      "showQuickExit": null,
+      "featureFlags": {}
+    }
+  },
+  "meta": {
+    "url": "/publication-no-pages",
+    "langcode": "en",
+    "description": "...",
+    "additional": [
+      {
+        "tag": "meta",
+        "attributes": {
+          "name": "title",
+          "content": "Publication with no pages | Single Digital Presence Content Management System"
+        }
+      },
+      {
+        "tag": "link",
+        "attributes": {
+          "rel": "canonical",
+          "href": "https://develop.content.reference.sdp.vic.gov.au/publication-no-pages"
+        }
+      },
+      {
+        "tag": "meta",
+        "attributes": {
+          "property": "og:locale",
+          "content": "en-AU"
+        }
+      }
+    ],
+    "keywords": "",
+    "image": null
+  },
+  "showContentRating": true,
+  "url": "/publication-no-pages",
+  "summary": "...",
+  "showTopicTags": false,
+  "showInPageNav": false,
+  "inPageNavHeadingLevel": "h2",
+  "details": {
+    "author": "Demo Organisation 1",
+    "date": "2025-06-26T10:00:00+10:00",
+    "copyright": null
+  },
+  "chapters": [],
+  "bodyComponents": [
+    {
+      "uuid": "0207a1c0-d937-4cd2-820a-f0f8795c246f",
+      "component": "TideLandingPageContent",
+      "id": "1902",
+      "internalAnchors": [],
+      "props": {
+        "html": "<p>Magna Lorem ea cupidatat proident in cillum velit ex adipisicing proident qui sit commodo nulla. Quis cupidatat aute proident. Aliqua exercitation esse tempor ullamco laborum sit. Deserunt laboris laborum laboris eiusmod non culpa qui.</p><p>Ullamco culpa nulla eiusmod proident dolor incididunt reprehenderit cupidatat ad incididunt qui commodo. Fugiat sunt est magna esse pariatur aute aliquip amet eu pariatur magna exercitation proident. Nisi qui tempor non Lorem. Pariatur cillum reprehenderit Lorem minim dolor esse. Elit nisi pariatur reprehenderit exercitation excepteur deserunt.</p>"
+      }
+    }
+  ],
+  "publication": {
+    "text": "Publication with no pages",
+    "url": "/publication-no-pages",
+    "id": "cecd683a-c34b-4613-ac06-0d4147cf1a42",
+    "documents": []
+  },
+  "showLastUpdated": true
+}

--- a/packages/ripple-test-utils/step_definitions/content-types/publication.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/publication.ts
@@ -23,6 +23,10 @@ Then('the print document link should be hidden', () => {
   cy.get('.tide-publication__actions-print').should('not.exist')
 })
 
+Then('the print document link should visible', () => {
+  cy.get('.tide-publication__actions-print').should('exist')
+})
+
 Then(
   'there should be a page link with a title of {string} and description text of {string}',
   (title: string, desc: string) => {
@@ -74,6 +78,35 @@ Then(
     })
   }
 )
+
+Then('the publication nav should have {int} links', (num: number) => {
+  cy.get(`.tide-publication__sidebar-nav li`).should('have.length', num)
+})
+
+Then(
+  'the publication nav should include the following links',
+  (dataTable: DataTable) => {
+    const table = dataTable.hashes()
+
+    cy.get(`.tide-publication__sidebar-nav li`).as('items')
+
+    table.forEach((row, i: number) => {
+      cy.get('@items')
+        .eq(i)
+        .then((item) => {
+          cy.wrap(item).as('item')
+
+          cy.get('@item').find('a').as('link')
+          cy.get('@link').contains(row.title)
+          cy.get('@link').should('have.attr', 'href', row.url)
+        })
+    })
+  }
+)
+
+Then('the publication nav should not exist', () => {
+  cy.get(`.tide-publication__sidebar-nav`).should('not.exist')
+})
 
 Then(
   'the publication should display the following documents',

--- a/packages/ripple-tide-publication/components/TidePublicationSidebar.vue
+++ b/packages/ripple-tide-publication/components/TidePublicationSidebar.vue
@@ -11,7 +11,7 @@
         v-if="navigation?.length"
         :title="publication.text"
         :items="navigation"
-        class="rpl-u-margin-b-9"
+        class="tide-publication__sidebar-nav rpl-u-margin-b-9"
       ></RplVerticalNav>
     </RplSidebarComponent>
   </div>
@@ -34,12 +34,12 @@ const props = defineProps<Props>()
 const MAX_NAV_ITEMS = 80
 
 const printUrl = computed(() => {
-  if (!props.navigation?.length) return null
+  const url = `${props.publication.url}/print-all`
+
+  if (!props.navigation?.length) return url
 
   const navItems = flattenMenu(props.navigation)
 
-  return navItems.length < MAX_NAV_ITEMS
-    ? `${props.publication.url}/print-all`
-    : null
+  return navItems.length < MAX_NAV_ITEMS ? url : null
 })
 </script>

--- a/packages/ripple-tide-publication/components/global/TidePublication.vue
+++ b/packages/ripple-tide-publication/components/global/TidePublication.vue
@@ -67,7 +67,7 @@ const menu = props.page?.publication?.id
   ? await useTidePublicationMenu(props.page.publication.id)
   : null
 
-if (menu) {
+if (menu?.publication?.items) {
   nav.value = processMenu(menu.publication, useRoute())
 }
 </script>

--- a/packages/ripple-tide-publication/composables/use-tide-publication-menu.ts
+++ b/packages/ripple-tide-publication/composables/use-tide-publication-menu.ts
@@ -1,8 +1,8 @@
-import type { indexNode } from './../types'
+import type { TidePublicationMenu } from './../types'
 
 export const useTidePublicationMenu = async (
   publicationId: string
-): Promise<indexNode[]> => {
+): Promise<TidePublicationMenu> => {
   const { public: config } = useRuntimeConfig()
   const { data: menuData } = useNuxtData(`publication-menu-${publicationId}`)
 

--- a/packages/ripple-tide-publication/types.ts
+++ b/packages/ripple-tide-publication/types.ts
@@ -34,12 +34,16 @@ export interface indexNode {
   text: string
   url: string
   id: string
-  nid: string
+  nid?: string
   items: indexNode[] | undefined
   active: boolean | undefined
 }
 
 export type flatIndexNode = Omit<indexNode, 'items'>
+
+export interface TidePublicationMenu {
+  publication: indexNode
+}
 
 export interface TidePublicationPage extends TidePageBase {
   /**


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1033

### What I did
<!-- Summary of changes made in the Pull Request -->
- Only show the publication nav menu when there are publication pages within said publication

<img width="2065" alt="Screenshot 2025-06-27 at 9 10 14 am" src="https://github.com/user-attachments/assets/12194c91-73d0-49e0-b15e-a5c646ee7b62" />


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
