### PR TITLE
[SD-1034] stop search event firing twice

### DIFF
--- a/examples/nuxt-app/test/features/maps/suggestions.feature
+++ b/examples/nuxt-app/test/features/maps/suggestions.feature
@@ -33,6 +33,10 @@ Feature: Suggestions
     And the URL should reflect that the location has the following:
       | key  | value           |
       | name | Bayswater North |
+    And the dataLayer should include the following events
+      | event  | element_text    | name           | type       | component              |
+      | search | Bayswater North | Test map title | suggestion | tide-custom-collection |
+    And the "search" dataLayer event should be fired once
 
   @mockserver
   Scenario: Suggestion is auto selected on enter

--- a/packages/ripple-test-utils/step_definitions/common/site/analytics.ts
+++ b/packages/ripple-test-utils/step_definitions/common/site/analytics.ts
@@ -132,3 +132,11 @@ Then(
     })
   }
 )
+
+Then('the {string} dataLayer event should be fired once', (name: string) => {
+  cy.window().then((window) => {
+    const event = window.dataLayer?.filter((i) => i.event === name)
+
+    expect(event).to.have.length(1)
+  })
+})

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -496,7 +496,7 @@ const handleTabChange = (tab: TideSearchListingTab) => {
 
 function handleLocationSearch(payload: any) {
   locationQuery.value = payload
-  handleSearchSubmit({ type: 'suggestion' })
+  handleSearchSubmit({ type: 'suggestion', text: payload?.name })
 }
 
 const rplMapRef = ref(null)

--- a/packages/ripple-tide-search/components/global/TideSearchLocationAutocomplete.vue
+++ b/packages/ripple-tide-search/components/global/TideSearchLocationAutocomplete.vue
@@ -21,6 +21,7 @@
     :showSubmitButton="showSubmitButton"
     :submitOnSuggestionOnly="submitOnSuggestionOnly"
     :analyticsName="context.name"
+    :globalEvents="false"
     @submit="submitAction"
     @update:input-value="onUpdate"
   >


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1034

### What I did
<!-- Summary of changes made in the Pull Request -->
- Stop search event fire twice when using the address lockup

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
