### PR TITLE
[SD-983] add support for table orientation

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/page-components.feature
+++ b/examples/nuxt-app/test/features/landingpage/page-components.feature
@@ -185,6 +185,22 @@ Feature: Home page
       | td   | Row Three Column One | Row Three Column Two | Row Three Column Three |
 
   @mockserver
+  Scenario: Page component - Data Table column oriented
+    Given a data table with ID "1938"
+    Then it should have a heading
+    And the table should display the following
+      | Fruit  | Vegetable | Elements |
+      | Apple  | Potato    | Zinc     |
+      | Orange | Broccoli  | Copper   |
+      | Banana | Pumpkin   | Iron     |
+    When I am using a "iphone-x" device
+    Then it should have no heading
+    And the table should display the following
+      | Fruit     | Apple  | Orange   | Banana  |
+      | Vegetable | Potato | Broccoli | Pumpkin |
+      | Elements  | Zinc   | Copper   | Iron    |
+
+  @mockserver
   Scenario: Page component - Category Grid i.e. compact cards
     Then a category grid with ID "7052" should exist with the following cards
       | title    | content          | image                    | url                 |

--- a/examples/nuxt-app/test/features/search-listing/table.feature
+++ b/examples/nuxt-app/test/features/search-listing/table.feature
@@ -20,6 +20,11 @@ Feature: Table layout
 
     Given a data table with type "search-listing-layout-table"
     Then the table should not display extra content
+    And the search listing results table should display the following
+      | Recommendation | Title               | Category                       | Status      |
+      | 1              | Review and begin    | Risk assessment and management | Implemented |
+      | 2              | Amend the Family    | Information sharing            | Implemented |
+      | 3              | Develop a workforce | Risk assessment and management | Implemented |
 
   @mockserver
   Example: A custom skeleton loader can be use for table cells items
@@ -59,6 +64,7 @@ Feature: Table layout
 
     Given a data table with type "search-listing-layout-table"
     When I toggle the tables extra content row
+    Then the tables extra content should be visible
     Then the tables extra content should contain the text "African Family Services"
     Then the tables extra content should contain the label "Funded for" and text "Multicultural Service"
     And the tables extra content should contain the label "Email", value "contact@africanfamilyservices.org.au" and link "mailto:contact@africanfamilyservices.org.au"
@@ -67,6 +73,15 @@ Feature: Table layout
     And the tables extra content should contain the text "Includes statewide service"
     And the tables extra content should contain the class "rpl-tag--dark"
     And the table row with text "Department with no extra content" should not display more information
+    And the dataLayer should include the following events
+      | event          | element_text | index | label                   | component      |
+      | open_table_row | More info    | 1     | African Family Services | rpl-data-table |
+
+    When I toggle the tables extra content row
+    Then the tables extra content should be hidden
+    And the dataLayer should include the following events
+      | event           | element_text | index | label                   | component      |
+      | close_table_row | Less info    | 1     | African Family Services | rpl-data-table |
 
   @mockserver
   Example: Table renders cells using core components
@@ -76,6 +91,8 @@ Feature: Table layout
     And the search network request should be called with the "/search-listing/table/request" fixture
 
     Given a data table with type "search-listing-layout-table"
+    Then the table should have the column "Funded for", with value "Multicultural Service"
+    Then the table should have the column "RAE", with value "no"
     Then the table should have the column "Email", with value "contact@africanfamilyservices.org.au" and link "mailto:contact@africanfamilyservices.org.au"
     And the table should have the column "Phone", with value "03 9602 5046" and link "tel:03 9602 5046"
     And the table should have the column "Website", with value "http://africanfamilyservices.org.au/#contact-us" and link "http://africanfamilyservices.org.au/#contact-us"

--- a/examples/nuxt-app/test/fixtures/landingpage/home.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/home.json
@@ -948,6 +948,40 @@
       }
     },
     {
+      "component": "TideLandingPageDataTable",
+      "id": "1938",
+      "props": {
+        "caption": "My caption",
+        "headingType": {
+          "horizontal": true,
+          "vertical": false
+        },
+        "orientation": "column",
+        "columns": [
+          { "label": "Fruit", "objectKey": "col0" },
+          { "label": "Vegetable", "objectKey": "col1" },
+          { "label": "Elements", "objectKey": "col2" }
+        ],
+        "items": [
+          {
+            "col0": "Apple",
+            "col1": "Potato",
+            "col2": "Zinc"
+          },
+          {
+            "col0": "Orange",
+            "col1": "Broccoli",
+            "col2": "Copper"
+          },
+          {
+            "col0": "Banana",
+            "col1": "Pumpkin",
+            "col2": "Iron"
+          }
+        ]
+      }
+    },
+    {
       "component": "TideLandingPageCategoryGrid",
       "id": "7052",
       "title": "Category Grid",

--- a/examples/nuxt-app/test/fixtures/search-listing/table/page.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/table/page.json
@@ -34,7 +34,7 @@
           "columns": [
             {
               "label": "Recommendation",
-              "key": "field_fv_recommendation_number"
+              "objectKey": "field_fv_recommendation_number"
             },
             {
               "label": "Title",
@@ -42,11 +42,11 @@
             },
             {
               "label": "Category",
-              "key": "field_fv_recommendation_category_name"
+              "objectKey": "field_fv_recommendation_category_name"
             },
             {
               "label": "Status",
-              "key": "fv_recommendation_status"
+              "objectKey": "fv_recommendation_status"
             }
           ]
         }

--- a/examples/nuxt-app/test/fixtures/search-listing/table/response.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/table/response.json
@@ -51,7 +51,7 @@
           "field_fv_recommendation_number": [2],
           "fv_recommendation_status": ["Implemented"],
           "field_fv_recommendation_category_name": [
-            "Risk assessment and management"
+            "Information sharing"
           ],
           "title": ["Amend the Family Violence Protection Act 2008 (Vic)"],
           "field_fv_recommendation_dpt_name": ["Family Safety Victoria"],

--- a/packages/ripple-test-utils/step_definitions/components/data-table.ts
+++ b/packages/ripple-test-utils/step_definitions/components/data-table.ts
@@ -51,7 +51,9 @@ Then('it should have a heading', () => {
 
 Then('it should have no heading', () => {
   cy.get('@component').within(() => {
-    cy.get('table thead tr').should('not.exist')
+    cy.get('table thead').should('satisfy', ($el) => {
+      return !$el.length || !$el.is(':visible')
+    })
   })
 })
 
@@ -96,6 +98,15 @@ Then(
   (text: string) => {
     cy.get('@component').within(() => {
       cy.get('.rpl-data-table__details-content:visible').contains(text)
+    })
+  }
+)
+
+Then(
+  'the table should have the column {string}, with value {string}',
+  (label: string, value: string) => {
+    cy.get('@component').within(() => {
+      cy.get(`td[data-label="${label}"]`).contains(value)
     })
   }
 )
@@ -163,3 +174,17 @@ Then(
     })
   }
 )
+
+Then('the table should display the following', (dataTable: DataTable) => {
+  const table = dataTable.raw()
+
+  cy.get('@component').within(() => {
+    table.forEach((row: any, i: number) => {
+      cy.get('tr:visible').eq(i).as('row')
+
+      row.forEach((cell: any, j: number) => {
+        cy.get('@row').find('th, td').eq(j).contains(cell)
+      })
+    })
+  })
+})

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -697,3 +697,18 @@ Then(
     })
   }
 )
+
+Then(
+  'the search listing results table should display the following',
+  (dataTable: DataTable) => {
+    const table = dataTable.raw()
+
+    table.forEach((row: any, i: number) => {
+      cy.get('tr').eq(i).as('row')
+
+      row.forEach((cell: any, j: number) => {
+        cy.get('@row').find('th, td').eq(j).contains(cell)
+      })
+    })
+  }
+)

--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/DataTable.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/DataTable.vue
@@ -15,6 +15,7 @@ defineProps<{
   <RplDataTable
     :caption="caption"
     :headingType="headingType"
+    :orientation="orientation"
     :columns="columns"
     :items="items"
   />

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.cy.ts
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.cy.ts
@@ -1,8 +1,12 @@
 import RplDataTable from './RplDataTable.vue'
 import {
   RplDataTableColumns,
+  RplDataTableColumnsCustom,
   RplDataTableItems,
-  RplDataTableItemsSimple
+  RplDataTableItemsCustom,
+  RplDataTableItemsSimple,
+  RplDataTableMixedColumns,
+  RplDataTableMixedItems
 } from './fixtures/sample'
 import { bpMin } from '@dpc-sdp/ripple-ui-core'
 
@@ -11,6 +15,19 @@ const props = {
   columns: RplDataTableColumns,
   items: RplDataTableItems
 }
+
+const title = ['Time frame', 'Budget', 'Risk']
+const headings = [
+  'Design ideas',
+  'Co-design solutions',
+  'Single solution',
+  'Development'
+]
+const values = [
+  ['2-4 weeks', '8-10 weeks', '12 weeks', '16 weeks'],
+  ['$50k', '$60k', '$100k', '$125k'],
+  ['High', 'Medium', 'Low', 'High']
+]
 
 describe('RplDataTable', () => {
   it('mounts', () => {
@@ -72,5 +89,114 @@ describe('RplDataTable', () => {
     cy.get('thead th').should('have.attr', 'scope', 'col')
     cy.get('tbody th').should('have.attr', 'scope', 'row')
     cy.get('tbody td').should('not.have.attr', 'scope')
+  })
+
+  it('handles column orientation on mobile for horizontal headings', () => {
+    cy.viewport(bpMin.s, 600)
+    cy.mount(RplDataTable, {
+      props: {
+        columns: RplDataTableColumnsCustom,
+        items: RplDataTableItemsCustom,
+        headingType: {
+          vertical: false,
+          horizontal: true
+        },
+        orientation: 'column'
+      }
+    })
+
+    const expected = [
+      {
+        heading: 'Fruit',
+        content: ['Apple', 'Orange', 'Banana', 'Pear', 'Mango']
+      },
+      {
+        heading: 'Vegetable',
+        content: ['Potato', 'Broccoli', 'Pumpkin', 'Carrot', 'Mushrooms']
+      },
+      {
+        heading: 'Elements',
+        content: ['Zinc', 'Copper', 'Iron', 'Bronze', 'Slate']
+      }
+    ]
+
+    expected.forEach((item, index) => {
+      cy.get(`tbody:nth-of-type(${index + 1})`).each(($tbody) => {
+        cy.wrap($tbody).as('tbody')
+        cy.get('@tbody')
+          .find('th')
+          .should('have.attr', 'scope', 'row')
+          .should('contain.text', expected[index].heading)
+
+        item.content.forEach((content, i) => {
+          cy.get('@tbody')
+            .find(`td:nth-of-type(${i + 1})`)
+            .should('contain.text', content)
+        })
+      })
+    })
+  })
+
+  it('handles column orientation on mobile for vertical headings', () => {
+    cy.viewport(bpMin.s, 600)
+    cy.mount(RplDataTable, {
+      props: {
+        columns: RplDataTableMixedColumns,
+        items: RplDataTableMixedItems,
+        headingType: {
+          vertical: true,
+          horizontal: false
+        },
+        orientation: 'column'
+      }
+    })
+
+    values.forEach((item, index) => {
+      cy.get(`tbody:nth-of-type(${index + 1})`).each(($tbody) => {
+        cy.wrap($tbody).as('tbody')
+        cy.get('@tbody').find('th').should('not.exist')
+
+        item.forEach((content, i) => {
+          cy.get('@tbody')
+            .find(`td:nth-child(${i + 1})`)
+            .as('cell')
+          cy.get('@cell').should('contain.text', headings[i])
+          cy.get('@cell').should('contain.text', content)
+        })
+      })
+    })
+  })
+
+  it('handles column orientation on mobile for dual headings', () => {
+    cy.viewport(bpMin.s, 600)
+    cy.mount(RplDataTable, {
+      props: {
+        columns: RplDataTableMixedColumns,
+        items: RplDataTableMixedItems,
+        headingType: {
+          vertical: true,
+          horizontal: true
+        },
+        orientation: 'column'
+      }
+    })
+
+    values.forEach((item, index) => {
+      cy.get(`tbody:nth-of-type(${index + 1})`).each(($tbody) => {
+        cy.wrap($tbody).as('tbody')
+        cy.get('@tbody')
+          .find('th')
+          .should('have.attr', 'scope', 'row')
+          .should('contain.text', title[index])
+
+        item.forEach((content, i) => {
+          cy.get('@tbody')
+            .find(`td:nth-of-type(${i + 1})`)
+            .as('cell')
+          cy.get('@cell').should('contain.text', headings[i])
+          cy.get('@cell').should('contain.text', content)
+        })
+      })
+    })
   })
 })

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.stories.ts
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.stories.ts
@@ -12,7 +12,11 @@ import {
   RplDataTableStructuredColumns,
   RplDataTableStructuredItems,
   RplDataTableExtraComponents,
-  RplDataTableItemsSimple
+  RplDataTableItemsSimple,
+  RplDataTableMixedColumns,
+  RplDataTableMixedItems,
+  RplDataTableColumnsCustom,
+  RplDataTableItemsCustom
 } from './fixtures/sample'
 
 type ExtendedPDataTableProps = Partial<typeof RplDataTable> & {
@@ -21,7 +25,13 @@ type ExtendedPDataTableProps = Partial<typeof RplDataTable> & {
 
 export default {
   title: 'Core/Containers/Data table',
-  component: RplDataTable
+  component: RplDataTable,
+  argTypes: {
+    orientation: {
+      control: { type: 'radio' },
+      options: ['row', 'column']
+    }
+  }
 } satisfies Meta<ExtendedPDataTableProps>
 
 type Story = StoryObj<ExtendedPDataTableProps>
@@ -102,5 +112,85 @@ export const Simple: Story = {
   args: {
     columns: RplDataTableColumns,
     items: RplDataTableItemsSimple
+  }
+}
+
+export const NoHeadings: Story = {
+  args: {
+    columns: RplDataTableColumns,
+    items: RplDataTableItemsSimple,
+    headingType: { horizontal: false, vertical: false }
+  }
+}
+
+export const ColumnOrientedNoHeadings: Story = {
+  name: 'Column Oriented - No Headings',
+  parameters: {
+    chromatic: {
+      viewports: [bpMin.s, bpMin.l]
+    }
+  },
+  args: {
+    columns: RplDataTableColumnsCustom,
+    items: RplDataTableItemsCustom,
+    headingType: {
+      vertical: false,
+      horizontal: false
+    },
+    orientation: 'column'
+  }
+}
+
+export const ColumnOrientedHorizontalHeadings: Story = {
+  name: 'Column Oriented - Horizontal Headings',
+  parameters: {
+    chromatic: {
+      viewports: [bpMin.s, bpMin.l]
+    }
+  },
+  args: {
+    columns: RplDataTableColumnsCustom,
+    items: RplDataTableItemsCustom,
+    headingType: {
+      vertical: false,
+      horizontal: true
+    },
+    orientation: 'column'
+  }
+}
+
+export const ColumnOrientedVerticalHeadings: Story = {
+  name: 'Column Oriented - Vertical Headings',
+  parameters: {
+    chromatic: {
+      viewports: [bpMin.s, bpMin.l]
+    }
+  },
+  args: {
+    columns: RplDataTableMixedColumns,
+    items: RplDataTableMixedItems,
+    headingType: {
+      vertical: true,
+      horizontal: false
+    },
+    orientation: 'column'
+  }
+}
+
+export const ColumnOrientedDualHeadings: Story = {
+  name: 'Column Oriented - Dual Headings',
+  parameters: {
+    chromatic: {
+      viewports: [bpMin.s, bpMin.l]
+    }
+  },
+  args: {
+    columns: RplDataTableMixedColumns,
+    items: RplDataTableMixedItems,
+    headingType: {
+      vertical: true,
+      horizontal: true
+    },
+    orientation: 'column'
   }
 }

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTable.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTable.vue
@@ -2,16 +2,9 @@
 import { useBreakpoints } from '@vueuse/core'
 import { computed, type ComputedRef, ref, unref, onMounted } from 'vue'
 import { bpMin } from '../../lib/breakpoints'
-import RplDataTableRow, {
-  extraRowContent,
-  tableColumnConfig,
-  tableRow
-} from './RplDataTableRow.vue'
-
-interface HeadingType {
-  horizontal: boolean
-  vertical: boolean
-}
+import RplDataTableRow, { extraRowContent } from './RplDataTableRow.vue'
+import RplDataTableColumnOriented from './RplDataTableColumnOriented.vue'
+import type { tableColumnConfig, tableRow, HeadingType } from './types'
 
 interface Props {
   caption?: string
@@ -22,6 +15,7 @@ interface Props {
   headingType?: HeadingType
   offset?: number
   hasSidebar?: boolean
+  orientation?: 'row' | 'column'
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -34,7 +28,8 @@ const props = withDefaults(defineProps<Props>(), {
   offset: 1,
   showExtraContent: false,
   items: () => [],
-  hasSidebar: false
+  hasSidebar: false,
+  orientation: 'row'
 })
 
 const isMounted = ref(false)
@@ -92,19 +87,28 @@ const displayMobileView: ComputedRef<boolean> = computed(() => {
             </th>
           </tr>
         </thead>
-        <RplDataTableRow
-          v-for="(row, index) in items"
-          :key="row.id || index"
-          :columns="columns"
-          :row="row"
-          :extraContent="(row.__extraContent as extraRowContent) || null"
-          :showExtraContent="showExtraContent"
-          :vertical-header="headingType.vertical"
-          :horizontal-header="headingType.horizontal"
-          :offset="offset"
-          :caption="caption"
-          :index="index"
-        ></RplDataTableRow>
+        <template v-if="displayMobileView && props.orientation === 'column'">
+          <RplDataTableColumnOriented
+            :items="items"
+            :columns="columns"
+            :heading-type="headingType"
+          />
+        </template>
+        <template v-else>
+          <RplDataTableRow
+            v-for="(row, index) in items"
+            :key="row.id || index"
+            :columns="columns"
+            :row="row"
+            :extraContent="(row.__extraContent as extraRowContent) || null"
+            :showExtraContent="showExtraContent"
+            :vertical-header="headingType.vertical"
+            :horizontal-header="headingType.horizontal"
+            :offset="offset"
+            :caption="caption"
+            :index="index"
+          />
+        </template>
         <tfoot v-if="footer">
           <tr>
             <td :colspan="columns.length">{{ footer }}</td>

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTableCell.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTableCell.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { getCellText, hasComponent } from './helpers'
+import type { tableColumnConfig, tableRow } from './types'
+
+interface Props {
+  columns: tableColumnConfig[]
+  column: tableColumnConfig
+  row: tableRow
+  i: number
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <template v-if="hasComponent(column)">
+    <component
+      :is="(column as tableColumnConfig).component"
+      :item="row"
+      :column="column"
+    />
+  </template>
+  <template v-else>
+    <div v-if="column?.isHTML" v-html="getCellText(i, null, columns, row)" />
+    <template v-else>
+      {{ getCellText(i, null, columns, row) }}
+    </template>
+  </template>
+</template>

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTableColumnOriented.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTableColumnOriented.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import RplDataTableCell from './RplDataTableCell.vue'
+import type { HeadingType, tableColumnConfig, tableRow } from './types'
+
+type RplDataTableColumnOrientedRows = {
+  column: tableColumnConfig
+  items: {
+    data: tableRow
+    column: tableColumnConfig
+    label: string
+    index: number
+  }[]
+}
+
+interface Props {
+  items: tableRow[]
+  columns: tableColumnConfig[]
+  headingType: HeadingType
+}
+
+const props = defineProps<Props>()
+
+// Re-maps items so data is instead grouped by column instead of row, for example,
+// Row 1 Col 1 heading - becomes - Row 1 Col 1 heading
+// - Row 2 Col 1 value ----------- - Row 2 Col 1 value
+// Row 1 Col 2 heading ----------- - Row 3 Col 1 value
+// - Row 2 Col 2 value
+const columnOriented = computed((): RplDataTableColumnOrientedRows[] => {
+  const vertical = props.headingType.vertical
+
+  return (
+    Object.keys(props.items?.[0] || [])
+      // remove the first column if it's a vertical header
+      .filter((_, i) => !(vertical && i === 0))
+      .map((_, i) => {
+        // index, taking removed vertical header into account
+        const index = vertical ? i + 1 : i
+        return {
+          column: props.columns[index],
+          items: props.items.map((item) => {
+            const [key, val] = Object.entries(item)[index]
+            return {
+              index,
+              data: { [key]: val },
+              column: props.columns[index],
+              label: vertical ? Object.values(item)[0] : null
+            }
+          })
+        }
+      })
+  )
+})
+</script>
+
+<template>
+  <tbody
+    v-for="(row, index) in columnOriented"
+    :key="`cor-${index}`"
+    :class="`rpl-data-table__row rpl-data-table__row--${(index + 1) % 2 === 0 ? 'even' : 'odd'}`"
+  >
+    <tr>
+      <th v-if="headingType.horizontal" scope="row">
+        <span v-if="row.column.isLabelHTML" v-html="row.column.label" />
+        <span v-else>{{ row.column.label }}</span>
+      </th>
+      <td v-for="(item, i) in row.items" :key="`coi-${i}`">
+        <div v-if="headingType.vertical" class="rpl-data-table__mobile-label">
+          <span v-if="item.column.isHTML" v-html="item.label" />
+          <span v-else>{{ item.label }}</span>
+        </div>
+        <RplDataTableCell
+          :columns="columns"
+          :row="item.data"
+          :column="item.column"
+          :i="item.index"
+        />
+      </td>
+    </tr>
+  </tbody>
+</template>

--- a/packages/ripple-ui-core/src/components/data-table/fixtures/sample.ts
+++ b/packages/ripple-ui-core/src/components/data-table/fixtures/sample.ts
@@ -305,3 +305,66 @@ export const RplDataTableExtraComponents = [
     }
   }
 ]
+
+export const RplDataTableMixedColumns = [
+  { label: 'Design plan', objectKey: 'col0' },
+  {
+    label: 'Time frame',
+    component: {
+      props: {
+        item: Object
+      },
+      template: `⏰ {{ item.col1 }}`
+    }
+  },
+  { label: 'Budget <sup>$</sup>', objectKey: 'col2', isLabelHTML: true },
+  { label: 'Risk', objectKey: 'col3', isHTML: true }
+]
+
+export const RplDataTableMixedItems = [
+  {
+    col0: 'Design ideas',
+    col1: '2-4 weeks',
+    col2: '$50k',
+    col3: 'High <sup>H</sup>'
+  },
+  {
+    col0: 'Co-design solutions',
+    col1: '8-10 weeks',
+    col2: '$60k',
+    col3: 'Medium <sup>M</sup>'
+  },
+  {
+    col0: 'Single solution',
+    col1: '12 weeks',
+    col2: '$100k',
+    col3: 'Low <sup>L</sup>'
+  },
+  {
+    col0: 'Development',
+    col1: '16 weeks',
+    col2: '$125k',
+    col3: 'High <sup>H</sup>'
+  }
+]
+
+export const RplDataTableColumnsCustom = [
+  {
+    label: 'Fruit',
+    objectKey: 'col0'
+  },
+  { label: 'Vegetable', objectKey: 'col1' },
+  { label: 'Elements', objectKey: 'col2' }
+]
+
+export const RplDataTableItemsCustom = [
+  { col0: 'Apple', col1: 'Potato', col2: 'Zinc' },
+  { col0: 'Orange', col1: 'Broccoli', col2: 'Copper' },
+  {
+    col0: 'Banana',
+    col1: 'Pumpkin',
+    col2: 'Iron'
+  },
+  { col0: 'Pear', col1: 'Carrot', col2: 'Bronze' },
+  { col0: 'Mango', col1: 'Mushrooms', col2: 'Slate' }
+]

--- a/packages/ripple-ui-core/src/components/data-table/helpers.ts
+++ b/packages/ripple-ui-core/src/components/data-table/helpers.ts
@@ -1,0 +1,19 @@
+import type { tableColumnConfig, tableRow } from './types'
+
+export const hasComponent = (column: any) =>
+  typeof column === 'object' && column.hasOwnProperty('component')
+
+export const getCellText = (
+  col: number | string | undefined,
+  value: string | null | undefined,
+  columns?: tableColumnConfig[],
+  row?: tableRow
+) => {
+  if (typeof col === 'undefined') return value
+
+  const objectKey = typeof col === 'string' ? col : columns[col]?.objectKey
+
+  return typeof row === 'object' && row.hasOwnProperty(objectKey)
+    ? row[objectKey]
+    : value
+}

--- a/packages/ripple-ui-core/src/components/data-table/types.ts
+++ b/packages/ripple-ui-core/src/components/data-table/types.ts
@@ -1,0 +1,19 @@
+export type tableColumnConfig = {
+  label: string
+  objectKey?: string
+  classes?: string[]
+  component?: string
+  props?: any
+  isHTML?: boolean
+  isLabelHTML?: boolean
+}
+
+export type tableRow = {
+  id?: string
+  [key: string]: any
+}
+
+export interface HeadingType {
+  horizontal: boolean
+  vertical: boolean
+}


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-983

### What I did
<!-- Summary of changes made in the Pull Request -->
- Adds support for table orientation, not 100% sold on this approach but it keeps the orientation support issolated which is good considering it's narrow usecase.

NOTE: I need to update the PR base after the `2.36.0` release

### How to test
<!-- Summary of how to test the changes -->
- Storybook
  - https://624ac117357335003a84dac3-pulfovohup.chromatic.com/?path=/story/core-containers-data-table--column-oriented-no-headings&globals=viewport.value:mobile1
  - https://624ac117357335003a84dac3-pulfovohup.chromatic.com/?path=/story/core-containers-data-table--column-oriented-horizontal-headings&globals=viewport.value:mobile1
  - https://624ac117357335003a84dac3-pulfovohup.chromatic.com/?path=/story/core-containers-data-table--column-oriented-vertical-headings&globals=viewport.value:mobile1
  - https://624ac117357335003a84dac3-pulfovohup.chromatic.com/?path=/story/core-containers-data-table--column-oriented-dual-headings&globals=viewport.value:mobile1
- Vic.gov.au
  - https://app.pr-1251.vic-gov-au.sdp4.sdp.vic.gov.au/test-page-1 
  - https://app.pr-1251.vic-gov-au.sdp4.sdp.vic.gov.au/test-page-2
  - https://app.pr-1251.vic-gov-au.sdp4.sdp.vic.gov.au/test-page-3

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [x] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
