### PR TITLE
[SD-981] Add config for number of topics in user filter

### DIFF
--- a/packages/ripple-tide-search/app.config.ts
+++ b/packages/ripple-tide-search/app.config.ts
@@ -14,7 +14,8 @@ export default defineAppConfig({
       ],
       suggestionsFunctions: {
         rplAddressSuggestionsFn
-      }
+      },
+      topicSize: 20
     }
   }
 })

--- a/packages/ripple-tide-search/components/TideSearchPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchPage.vue
@@ -3,7 +3,8 @@ import { ref, watch, computed } from 'vue'
 import {
   getActiveFilterURL,
   scrollToElementTopWithOffset,
-  useRuntimeConfig
+  useRuntimeConfig,
+  stripSiteId
 } from '#imports'
 import useSearchUI from './../composables/useSearchUI'
 import {

--- a/packages/ripple-tide-search/composables/useSearchUI.ts
+++ b/packages/ripple-tide-search/composables/useSearchUI.ts
@@ -37,7 +37,7 @@ export default async (
           ...result,
           [filter.field]: {
             type: 'value',
-            size: 10
+            size: filter.maxValue || 10
           }
         }
       }, {})
@@ -129,13 +129,15 @@ export default async (
   const applyFilters = () => {
     searchDriver.clearFilters()
 
-    Object.entries(filterFormValues.value).forEach(([key, val]) => {
-      if (val && val.length) {
-        const config = filterConfig.find((filter) => filter.field === key)
+    Object.entries(filterFormValues.value).forEach(
+      ([key, val]: [string, []]) => {
+        if (val && val.length) {
+          const config = filterConfig.find((filter) => filter.field === key)
 
-        searchDriver.addFilter(key, val, config.filterType)
+          searchDriver.addFilter(key, val, config.filterType)
+        }
       }
-    })
+    )
   }
 
   return {

--- a/packages/ripple-tide-search/composables/useSearchUI.ts
+++ b/packages/ripple-tide-search/composables/useSearchUI.ts
@@ -37,7 +37,7 @@ export default async (
           ...result,
           [filter.field]: {
             type: 'value',
-            size: filter.maxValue || 10
+            size: filter.topicSize
           }
         }
       }, {})

--- a/packages/ripple-tide-search/pages/search.vue
+++ b/packages/ripple-tide-search/pages/search.vue
@@ -4,7 +4,10 @@ import {
   formatDate,
   useRuntimeConfig,
   useAppConfig,
-  useTideSite
+  useTideSite,
+  useFeatureFlags,
+  useNuxtApp,
+  stripSiteId
 } from '#imports'
 
 const appConfig = useAppConfig()
@@ -37,7 +40,8 @@ const filtersConfig: AppSearchFilterConfigItem[] = [
     label: 'Select a topic',
     placeholder: 'Select',
     field: 'field_topic_name',
-    filterType: 'any'
+    filterType: 'any',
+    maxValue: 20
   }
 ]
 

--- a/packages/ripple-tide-search/pages/search.vue
+++ b/packages/ripple-tide-search/pages/search.vue
@@ -41,7 +41,7 @@ const filtersConfig: AppSearchFilterConfigItem[] = [
     placeholder: 'Select',
     field: 'field_topic_name',
     filterType: 'any',
-    maxValue: 20
+    topicSize: appConfig.ripple?.search?.topicSize
   }
 ]
 

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -19,6 +19,8 @@ export interface AppSearchFilterConfigItem {
   label: string
   field: string
   filterType: FilterType
+  placeholder?: string
+  maxValue?: number
 }
 
 export interface FilterConfigItem {

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -20,7 +20,7 @@ export interface AppSearchFilterConfigItem {
   field: string
   filterType: FilterType
   placeholder?: string
-  maxValue?: number
+  topicSize?: number
 }
 
 export interface FilterConfigItem {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "jsx": "preserve",
     "resolveJsonModule": true,
     "baseUrl": "./packages",
-    "types": ["vite/client", "@types/react"],
+    "types": ["vite/client"],
     "paths": {
       "@dpc-sdp/nuxt-ripple-preview/utils": ["nuxt-ripple-preview/utils"],
       "@dpc-sdp/ripple-tide-api/errors": ["ripple-tide-api/src/errors/errors"],


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-981

### What I did
<!-- Summary of changes made in the Pull Request -->
- Added extra prop `maxValue` to change number of topics shown, increased in the search page template to 30
- Some lint / ts / imports tidy up while I was in there

### How to test
<!-- Summary of how to test the changes -->
- nuxt-app `/search`
- 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
