### PR TITLE
[SD-1069] privacy statement font size

### DIFF
--- a/packages/ripple-tide-webform/mapping/webforms-mapping.ts
+++ b/packages/ripple-tide-webform/mapping/webforms-mapping.ts
@@ -183,7 +183,7 @@ export const getFormSchemaFromMapping = async (
           disabled: field['#disabled'],
           // TODO: It's not clear what field we should be using for the 'label' here because it's a new requirement, setting as 'help title' for now
           label: field['#privacy_statement_heading'],
-          help: field['#privacy_statement_content'],
+          description: field['#privacy_statement_content'],
           checkboxLabel: field['#title'],
           value: field['#default_value'],
           pii: false,

--- a/packages/ripple-ui-forms/src/components/RplForm/RplForm.stories.ts
+++ b/packages/ripple-ui-forms/src/components/RplForm/RplForm.stories.ts
@@ -312,6 +312,24 @@ export const DefaultStory: Story = {
         }
       },
       {
+        $formkit: 'RplFormCheckbox',
+        key: 'privacy_statement',
+        id: 'connect_with_us_privacy_statement',
+        name: 'privacy_statement',
+        label: 'Collection notice',
+        description:
+          '<p>The Department of Government Services (the Department) collects the information that you provide with this form. The information that you provide is used to respond to your enquiry. You can request access to, and corrections of, any personal information provided in this form. Requests for access or correction should be sent to <a href="mailto:privacy@dgs.vic.gov.au">privacy@dgs.vic.gov.au</a></p>',
+        checkboxLabel:
+          'I have read and understand how the Victorian Government stores information.',
+        validation: 'required',
+        validationMessages: {
+          required:
+            'I have read and understand how the Victorian Government stores information. is required',
+          accepted:
+            'I have read and understand how the Victorian Government stores information. is required'
+        }
+      },
+      {
         $formkit: 'RplFormActions',
         label: 'Submit form',
         id: '123'

--- a/packages/ripple-ui-forms/src/components/RplFormDescription/RplFormDescription.css
+++ b/packages/ripple-ui-forms/src/components/RplFormDescription/RplFormDescription.css
@@ -1,0 +1,7 @@
+.rpl-form-description {
+  margin-bottom: var(--rpl-sp-4);
+
+  .rpl-form-label + & {
+    margin-top: calc(var(--rpl-sp-3) * -1);
+  }
+}

--- a/packages/ripple-ui-forms/src/components/RplFormDescription/RplFormDescription.vue
+++ b/packages/ripple-ui-forms/src/components/RplFormDescription/RplFormDescription.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+interface Props {
+  html: string
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <RplContent class="rpl-form-description" :html="html" />
+</template>
+
+<style src="./RplFormDescription.css"></style>

--- a/packages/ripple-ui-forms/src/inputs/checkbox.ts
+++ b/packages/ripple-ui-forms/src/inputs/checkbox.ts
@@ -15,6 +15,7 @@ export const checkbox: FormKitTypeDefinition = {
       type: 'checkbox',
       id: `$id + '__checkbox'`,
       name: '$node.name',
+      description: '$node.description',
       disabled: '$node.context.disabled',
       label: '$node.props.checkboxLabel',
       onValue: '$node.props.onValue',
@@ -44,7 +45,14 @@ export const checkbox: FormKitTypeDefinition = {
   /**
    * An array of extra props to accept for this input.
    */
-  props: ['checkboxLabel', 'variant', 'onValue', 'offValue', 'pii'],
+  props: [
+    'checkboxLabel',
+    'description',
+    'variant',
+    'onValue',
+    'offValue',
+    'pii'
+  ],
   /**
    * Forces node.props.type to be this explicit value.
    */

--- a/packages/ripple-ui-forms/src/inputs/input-utils.ts
+++ b/packages/ripple-ui-forms/src/inputs/input-utils.ts
@@ -16,6 +16,7 @@ import { rplOuter } from '../sections/rplOuter'
 import { rplLabel } from '../sections/rplLabel'
 import { rplLegend } from '../sections/rplLegend'
 import { rplHelp } from '../sections/rplHelp'
+import { rplDescription } from '../sections/rplDescription'
 import {
   isFieldRequired,
   isFieldInvalid,
@@ -35,6 +36,7 @@ import RplFormDateRange from './../components/RplFormDateRange/RplFormDateRange.
 import RplFormDateSelect from '../components/RplFormDateSelect/RplFormDateSelect.vue'
 import RplFormDateSelectRange from '../components/RplFormDateSelectRange/RplFormDateSelectRange.vue'
 import RplFormValidationError from './../components/RplFormValidationError/RplFormValidationError.vue'
+import RplFormDescription from './../components/RplFormDescription/RplFormDescription.vue'
 import RplFormHelpText from './../components/RplFormHelpText/RplFormHelpText.vue'
 import RplFormLabel from './../components/RplFormLabel/RplFormLabel.vue'
 import RplFormInputGrid from './../components/RplFormInputGrid/RplFormInputGrid.vue'
@@ -62,6 +64,7 @@ export const inputLibrary = {
   RplFormDateSelectRange: markRaw(RplFormDateSelectRange),
   RplFormValidationError: markRaw(RplFormValidationError),
   RplFormHelpText: markRaw(RplFormHelpText),
+  RplFormDescription: markRaw(RplFormDescription),
   RplFormLabel: markRaw(RplFormLabel),
   RplFormInputGrid: markRaw(RplFormInputGrid),
   RplFormFieldset: markRaw(RplFormFieldset),
@@ -124,6 +127,7 @@ export const createRplFormGroup = (
     fieldset(
       rplLegend('$label'),
       rplHelp('$help'),
+      rplDescription('$description'),
       createSection('error', () => ({
         $cmp: 'FormkitInputError',
         props: {

--- a/packages/ripple-ui-forms/src/sections/rplDescription.ts
+++ b/packages/ripple-ui-forms/src/sections/rplDescription.ts
@@ -1,0 +1,10 @@
+import { createSection } from '@formkit/inputs'
+
+export const rplDescription = createSection('description', () => ({
+  $cmp: 'RplFormDescription',
+  if: '$description',
+  props: {
+    id: `$id + '__description'`,
+    html: '$description'
+  }
+}))


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1069

### What I did
<!-- Summary of changes made in the Pull Request -->
-  Make privacy statement font size the default 16px, as always there's a few ways to do this

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
