### PR TITLE
[SD-1058] Provide 'contextName' for data table toggle event

### DIFF
--- a/examples/nuxt-app/test/features/landingpage/custom-collection.feature
+++ b/examples/nuxt-app/test/features/landingpage/custom-collection.feature
@@ -18,6 +18,14 @@ Feature: Custom Collection
     And the "cslReq" network request should be made to the elasticsearch endpoint
     And the search listing layout should be "table"
 
+    Given a data table with type "search-listing-layout-table"
+    When I toggle the tables extra content row
+    Then the tables extra content should be visible
+    Then the tables extra content should contain the label "Offence location" and text "Alexandra Parade, at the intersection of Alexandra Parade and Smith Street, Fitzroy North"
+    And the dataLayer should include the following events
+      | event          | element_text | index | label         | name               | component      |
+      | open_table_row | More info    | 1     | Fitzroy North | Cameras save lives | rpl-data-table |
+
   @mockserver
   Scenario: Custom collection emits search related events for analytics
     Given the page endpoint for path "/custom-collection" returns fixture "/landingpage/custom-collection/page" with status 200

--- a/examples/nuxt-app/test/features/search-listing/table.feature
+++ b/examples/nuxt-app/test/features/search-listing/table.feature
@@ -74,14 +74,14 @@ Feature: Table layout
     And the tables extra content should contain the class "rpl-tag--dark"
     And the table row with text "Department with no extra content" should not display more information
     And the dataLayer should include the following events
-      | event          | element_text | index | label                   | component      |
-      | open_table_row | More info    | 1     | African Family Services | rpl-data-table |
+      | event          | element_text | index | label                   | name                            | component      |
+      | open_table_row | More info    | 1     | African Family Services | Table with structure extra data | rpl-data-table |
 
     When I toggle the tables extra content row
     Then the tables extra content should be hidden
     And the dataLayer should include the following events
-      | event           | element_text | index | label                   | component      |
-      | close_table_row | Less info    | 1     | African Family Services | rpl-data-table |
+      | event           | element_text | index | label                   | name                            | component      |
+      | close_table_row | Less info    | 1     | African Family Services | Table with structure extra data | rpl-data-table |
 
   @mockserver
   Example: Table renders cells using core components

--- a/examples/nuxt-app/test/fixtures/landingpage/custom-collection.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/custom-collection.json
@@ -102,6 +102,7 @@
       "id": "123",
       "title": "Cameras save lives",
       "props": {
+        "title": "Cameras save lives",
         "searchListingConfig": {
           "searchProvider": "elasticsearch",
           "index": "sdp_data_pipelines_scl",
@@ -127,6 +128,7 @@
           "layout": {
             "component": "TideSearchResultsTable",
             "props": {
+              "showExtraContent": true,
               "columns": [
                 {
                   "label": "Suburb",
@@ -140,7 +142,15 @@
                   "label": "Last annual test",
                   "objectKey": "last_annual_test"
                 }
-              ]
+              ],
+              "extraContent": {
+                "items": [
+                  {
+                    "label": "Offence location",
+                    "objectKey": "offence_location"
+                  }
+                ]
+              }
             }
           }
         }

--- a/packages/nuxt-ripple-analytics/lib/index.ts
+++ b/packages/nuxt-ripple-analytics/lib/index.ts
@@ -148,7 +148,7 @@ export default {
         element_id: payload?.id,
         element_text: payload?.text,
         label: payload?.label,
-        name: payload?.name,
+        name: payload?.name || payload?.contextName,
         index: payload?.index,
         component: 'rpl-data-table',
         platform_event: 'expandRow'

--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -181,6 +181,7 @@ const baseEvent = computed(() => {
   return {
     section: 'search-listing',
     contextId: props.id,
+    contextName: props.title,
     name: props.title,
     index: page.value,
     label: searchTerm.value.q,

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -253,6 +253,7 @@ const baseEvent = computed(() => {
   return {
     section: 'custom-collection',
     contextId: props.id,
+    contextName: props.title,
     name: props.title,
     index: page.value,
     label: props.locationQueryConfig?.component

--- a/packages/ripple-ui-core/src/components/data-table/RplDataTableRow.vue
+++ b/packages/ripple-ui-core/src/components/data-table/RplDataTableRow.vue
@@ -72,12 +72,14 @@ const rowClasses = computed(() => [
 const toggleLabel = computed(() => (state.enabled ? 'Less info' : 'More info'))
 
 const handleClick = () => {
+  const label = getCellText(0, null, props.columns, props.row)
+
   emitRplEvent(
     'expandRow',
     {
       action: !state.enabled ? 'open' : 'close',
       text: toggleLabel.value,
-      label: getCellText(0, null, props.columns, props.row),
+      label: Array.isArray(label) ? label[0] : label,
       name: props.caption,
       index: props.index + 1
     },


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1058

### What I did
<!-- Summary of changes made in the Pull Request -->
- Provide 'contextName' for data table toggle event, these means the data table toggle event will get `name` set to the relevant context i.e. the search listing title or custom collection title.
- Also noticed the label value can be an array so added a check for that.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
