### PR TITLE
[SD-1083] add aria attributes to primary nav

### DIFF
--- a/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.cy.ts
+++ b/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.cy.ts
@@ -32,15 +32,23 @@ describe('RplPrimaryNav', () => {
       cy.viewport(bpMin.s, 1000)
       cy.mount(RplPrimaryNav, { props })
 
-      cy.get(
-        '.rpl-primary-nav__nav-bar-mobile-menu-toggle-container .rpl-primary-nav__nav-bar-action--toggle'
-      ).as('toggle')
+      cy.get('[aria-label="Open Menu"]').as('openMenu')
+      cy.get('@openMenu').should('have.attr', 'aria-expanded', 'false')
+      cy.get('@openMenu').click()
 
-      cy.get('@toggle').click()
-      cy.get('.rpl-primary-nav__mega-menu').should('be.visible')
+      cy.get('[aria-label="Close Menu"]').as('closeMenu')
 
-      cy.get('@toggle').click()
-      cy.get('.rpl-primary-nav__mega-menu').should('not.exist')
+      cy.get('@closeMenu')
+        .invoke('attr', 'aria-controls')
+        .then((id) => {
+          cy.get(`#${id}`).as('menu')
+        })
+
+      cy.get('@menu').should('be.visible')
+      cy.get('@closeMenu').should('have.attr', 'aria-expanded', 'true')
+
+      cy.get('@closeMenu').click()
+      cy.get('@menu').should('not.exist')
     })
   })
 
@@ -90,16 +98,26 @@ describe('RplPrimaryNav', () => {
     })
 
     it('toggles the display of the search form', () => {
-      cy.contains('.rpl-primary-nav__nav-bar-action--toggle', 'Search').click()
+      cy.get('[aria-label="Open Search"]').as('openSearch')
+      cy.get('@openSearch').should('contain', 'Search')
+      cy.get('@openSearch').should('have.attr', 'aria-expanded', 'false')
+      cy.get('@openSearch').click()
 
-      cy.get('.rpl-primary-nav__search-form').as('form')
+      cy.get('[aria-label="Close Search"]').as('closeSearch')
+      cy.get('@closeSearch').should('contain', 'Close')
 
-      cy.get('form').should('be.visible')
-      cy.get('form').find('.rpl-search-bar__input').should('have.focus')
+      cy.get('@closeSearch')
+        .invoke('attr', 'aria-controls')
+        .then((id) => {
+          cy.get(`#${id}`).as('search')
+        })
 
-      cy.contains('.rpl-primary-nav__nav-bar-action--toggle', 'Close').click()
+      cy.get('@search').should('be.visible')
+      cy.get('@closeSearch').should('have.attr', 'aria-expanded', 'true')
+      cy.get('@search').find('input').should('have.focus')
 
-      cy.get('.rpl-primary-nav__search-form').should('not.exist')
+      cy.get('@closeSearch').click()
+      cy.get('@search').should('not.exist')
     })
   })
 })

--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenu.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenu.vue
@@ -124,6 +124,7 @@ const backButtonHandler = (label: string) => {
               :items="items ? items : []"
               :active-nav-items="activeNavItems"
               :toggle-item="toggleItem"
+              aria-label="Main menu"
             />
           </div>
 
@@ -152,6 +153,7 @@ const backButtonHandler = (label: string) => {
               "
               :active-nav-items="activeNavItems"
               :toggle-item="toggleItem"
+              :aria-label="`${activeNavItems.level1.text} level 2 menu`"
             />
           </div>
 
@@ -181,6 +183,7 @@ const backButtonHandler = (label: string) => {
               "
               :active-nav-items="activeNavItems"
               :toggle-item="toggleItem"
+              :aria-label="`${activeNavItems.level2.text} level 3 menu`"
             />
           </div>
 
@@ -210,6 +213,7 @@ const backButtonHandler = (label: string) => {
               "
               :active-nav-items="activeNavItems"
               :toggle-item="toggleItem"
+              :aria-label="`${activeNavItems.level3.text} level 4 menu`"
             />
           </div>
         </div>

--- a/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/nav-bar/RplPrimaryNavBar.vue
@@ -162,6 +162,10 @@ const showMobileToggle = computed(() => {
           href="/"
           :active="isMegaNavActive"
           focusKey="menu:toggle"
+          aria-haspopup="true"
+          aria-controls="megamenu"
+          :aria-expanded="isMegaNavActive ? 'true' : 'false'"
+          :aria-label="`${isMegaNavActive ? 'Close' : 'Open'} ${mobileToggleLabel}`"
           @click="toggleMobileMenu(mobileToggleLabel)"
         >
           <span>{{ mobileToggleLabel }}</span
@@ -218,7 +222,14 @@ const showMobileToggle = computed(() => {
 
       <!-- Search toggle -->
       <li v-if="showSearch">
-        <RplPrimaryNavBarAction type="toggle" @click="toggleSearch()">
+        <RplPrimaryNavBarAction
+          type="toggle"
+          aria-haspopup="true"
+          aria-controls="search-megamenu"
+          :aria-expanded="isSearchActive ? 'true' : 'false'"
+          :aria-label="`${isSearchActive ? 'Close' : 'Open'} Search`"
+          @click="toggleSearch()"
+        >
           <template v-if="!isSearchActive">
             <span class="rpl-primary-nav__nav-bar-search-label">Search</span
             >&NoBreak;<span

--- a/packages/ripple-ui-core/src/components/primary-nav/components/search-form/RplPrimaryNavSearchForm.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/search-form/RplPrimaryNavSearchForm.vue
@@ -29,7 +29,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="rpl-primary-nav__search-form">
+  <div id="search-megamenu" class="rpl-primary-nav__search-form">
     <!-- Quick links -->
     <div v-if="showQuickExit" class="rpl-primary-nav__search-form-quick-links">
       <RplPrimaryNavQuickExit />


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1083

### What I did
<!-- Summary of changes made in the Pull Request -->
- Add aria attributes to primary nav, specifically `aria-haspopup`, `aria-controls`, `aria-expanded` and `aria-label`
- This also adds descriptive labels to the disparate 'submenus'; because there's no heirachy to our menus this tries to somewhat mimic what you would get if there was. For example, a typical nested list will tell the screen reader what level within the ul your currently at.

### How to test
<!-- Summary of how to test the changes -->
- See storybook

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
