### PR TITLE
[SD-1084] more primary nav tab/click fixes

### DIFF
--- a/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.cy.ts
+++ b/packages/ripple-ui-core/src/components/primary-nav/RplPrimaryNav.cy.ts
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
 // @ts-expect-error vue sfc import
+import { h } from 'vue'
 import RplPrimaryNav from './RplPrimaryNav.vue'
 import { RplPrimaryNavItems } from './fixtures/sample'
 import { bpMin } from '../../lib/breakpoints'
@@ -50,15 +51,41 @@ describe('RplPrimaryNav', () => {
       cy.get('@closeMenu').click()
       cy.get('@menu').should('not.exist')
     })
+
+    it('tabs to an action when user actions are present', () => {
+      cy.mount(RplPrimaryNav, {
+        props,
+        slots: {
+          userAction: h('a', { href: '/login' }, 'Login')
+        }
+      })
+
+      cy.get('[aria-label="Open Menu"]').focus()
+
+      cy.focused().realPress('Enter')
+      cy.realPress('Tab')
+      cy.realPress('Tab')
+
+      cy.focused().should('match', 'a').should('contain.text', 'Login')
+      cy.realPress('Tab')
+      cy.realPress('Tab')
+      cy.focused()
+        .should('match', 'button')
+        .should('contain.text', 'First level A')
+
+      cy.focused().realPress(['Shift', 'Tab']).realPress(['Shift', 'Tab'])
+      cy.focused().contains('Menu')
+    })
   })
 
   context('Desktop', () => {
     beforeEach(() => {
       cy.viewport(bpMin.l, 1000)
-      cy.mount(RplPrimaryNav, { props })
     })
 
     it('toggles the menu items submenu', () => {
+      cy.mount(RplPrimaryNav, { props })
+
       cy.get(
         '.rpl-primary-nav__nav-bar-item .rpl-primary-nav__nav-bar-action--toggle'
       )
@@ -77,6 +104,8 @@ describe('RplPrimaryNav', () => {
     })
 
     it('navigates through mega menu sub levels', () => {
+      cy.mount(RplPrimaryNav, { props })
+
       const level = (val: number) =>
         `.rpl-primary-nav__mega-menu-list--level-${val}`
       const levelToggle = (val: number) =>
@@ -102,6 +131,8 @@ describe('RplPrimaryNav', () => {
     })
 
     it('toggles the display of the search form', () => {
+      cy.mount(RplPrimaryNav, { props })
+
       cy.get('[aria-label="Open Search"]').as('openSearch')
       cy.get('@openSearch').should('contain', 'Search')
       cy.get('@openSearch').should('have.attr', 'aria-expanded', 'false')
@@ -125,6 +156,8 @@ describe('RplPrimaryNav', () => {
     })
 
     it('megamenu can be navigated with the keyboard', () => {
+      cy.mount(RplPrimaryNav, { props })
+
       cy.contains('button', 'First level A').focus()
       cy.focused().should('have.attr', 'aria-expanded', 'false')
 
@@ -185,6 +218,42 @@ describe('RplPrimaryNav', () => {
         .realPress('Tab')
 
       cy.focused().should('match', 'button').should('have.text', 'Second level')
+
+      // Switching open mega menus with clicks and tabs
+      cy.contains('button', 'First level D').as('lastItem')
+      cy.get('@lastItem').click()
+      cy.focused().realPress('Tab')
+      cy.focused().realPress('Tab')
+      cy.focused().realPress('Tab')
+      cy.focused()
+        .should('match', 'button')
+        .should('contain.text', 'Second level D')
+    })
+
+    it('tabs to menu when user actions are present', () => {
+      props.items.pop()
+      cy.mount(RplPrimaryNav, {
+        props: {
+          ...props,
+          items: props.items
+        },
+        slots: {
+          userAction: h('a', { href: '/login' }, 'Login')
+        }
+      })
+
+      cy.contains('button', 'First level A').focus()
+
+      cy.focused().realPress('Enter')
+      cy.realPress('Tab')
+      cy.realPress('Tab')
+
+      cy.focused().should('match', 'a').should('contain.text', 'First level A')
+
+      cy.focused().realPress(['Shift', 'Tab'])
+      cy.focused()
+        .should('match', 'button')
+        .should('contain.text', 'First level A')
     })
   })
 })

--- a/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuList.vue
+++ b/packages/ripple-ui-core/src/components/primary-nav/components/mega-menu/RplPrimaryNavMegaMenuList.vue
@@ -36,6 +36,7 @@ withDefaults(defineProps<Props>(), {
     <!-- Repeat of parent as a clickable link -->
     <li v-if="parent" class="rpl-primary-nav__mega-menu-item">
       <RplPrimaryNavMegaMenuAction
+        :key="`${level}:${parent.id}`"
         :item="parent"
         :level="level"
         position="first"

--- a/packages/ripple-ui-core/src/components/primary-nav/fixtures/sample.ts
+++ b/packages/ripple-ui-core/src/components/primary-nav/fixtures/sample.ts
@@ -104,7 +104,7 @@ export const RplPrimaryNavItems = [
     items: [
       {
         id: '28',
-        text: 'Second level',
+        text: 'Second level D',
         url: '#',
         items: [
           {
@@ -115,8 +115,8 @@ export const RplPrimaryNavItems = [
           }
         ]
       },
-      { id: '31', text: 'Second level', url: '#' },
-      { id: '32', text: 'Second level', url: '#' }
+      { id: '31', text: 'Second level DB', url: '#' },
+      { id: '32', text: 'Second level DC', url: '#' }
     ]
   },
   { id: '26', text: 'First level E', url: '#' }

--- a/packages/ripple-ui-core/src/composables/usePrimaryNavFocus.ts
+++ b/packages/ripple-ui-core/src/composables/usePrimaryNavFocus.ts
@@ -20,15 +20,26 @@ export function usePrimaryNavFocus(element: Ref, key: string) {
     }
   })
 
+  const isVisible = (el) => {
+    if (!el) return false
+
+    const { display, visibility } = window.getComputedStyle(el)
+
+    return (
+      display !== 'none' && visibility !== 'hidden' && el.offsetParent !== null
+    )
+  }
+
   const forceFocus = (selector: string): boolean => {
     const element = document.querySelector<HTMLInputElement>(selector)
+    const focusable = isVisible(element)
 
-    if (element) {
+    if (focusable) {
       element?.focus()
       setFocus('')
     }
 
-    return Boolean(element)
+    return focusable
   }
 
   return {


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1084

### What I did
<!-- Summary of changes made in the Pull Request -->
- Fix issue that occured when opening a top level menu via keyword, clicking on another top level menu with the mouse (so the mega menu never disapears but it's contents change) then trying to tab into the updated menu. 
  - It'll be amazing when we can delete all this tab-jacking stuff
- Fix issue where hidden user action was 'focused'

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [x] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
