### PR TITLE
[SD-1134] search curations

### DIFF
--- a/examples/nuxt-app/app.config.ts
+++ b/examples/nuxt-app/app.config.ts
@@ -130,6 +130,27 @@ export default defineAppConfig({
               filter: queryFilters
             }
           }
+        },
+        exampleQueryCurationsFunction: ({ searchTerm, curations }) => {
+          return {
+            bool: {
+              should: [
+                {
+                  multi_match: {
+                    query: searchTerm?.q,
+                    fields: ['title', 'content']
+                  }
+                },
+                {
+                  terms: {
+                    [curations.key]: [...curations.items, 999],
+                    boost: 2
+                  }
+                }
+              ],
+              minimum_should_match: 1
+            }
+          }
         }
       },
       locationDSLTransformFunctions: {

--- a/examples/nuxt-app/test/features/search-listing/search-query.feature
+++ b/examples/nuxt-app/test/features/search-listing/search-query.feature
@@ -82,3 +82,44 @@ Feature: Search Queries
     And I type "The" into the search input
     And I click the search button
     Then I should not be scrolled to the search results
+
+  @mockserver
+  Example: Curations can be used to promote search results
+    Given I load the page fixture with "/search-listing/search-query/page-curations"
+    And the search network request is stubbed with fixture "/search-listing/search-query/response" and status 200
+    Then the page endpoint for path "/" returns the loaded fixture
+
+    When I visit the page "/"
+    And I type "EduPay" into the search input
+    And I click the search button
+    Then the search network request should be called with the "/search-listing/search-query/request-curation-edupay" fixture
+
+    When I clear the search input
+    And I type " police force! " into the search input
+    And I click the search button
+    Then the search network request should be called with the "/search-listing/search-query/request-curation-police" fixture
+
+  @mockserver
+  Example: The curations field key can be customized
+    Given I load the page fixture with "/search-listing/search-query/page-curations"
+    And the search listing curation "key" is set to "uid"
+    And the search listing curation "boost" is set to "5"
+    And the search network request is stubbed with fixture "/search-listing/search-query/response" and status 200
+    Then the page endpoint for path "/" returns the loaded fixture
+
+    When I visit the page "/"
+    And I type "help" into the search input
+    And I click the search button
+    Then the search network request should be called with the "/search-listing/search-query/request-curation-key" fixture
+
+  @mockserver
+  Example: Curations can be used and customized within custom query functions
+    Given I load the page fixture with "/search-listing/search-query/page-curations-custom"
+    And the search listing curation "key" is set to "id"
+    And the search network request is stubbed with fixture "/search-listing/search-query/response" and status 200
+    Then the page endpoint for path "/" returns the loaded fixture
+
+    When I visit the page "/"
+    And I type "departments" into the search input
+    And I click the search button
+    Then the search network request should be called with the "/search-listing/search-query/request-curation-custom" fixture

--- a/examples/nuxt-app/test/fixtures/search-listing/search-query/page-curations-custom.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/search-query/page-curations-custom.json
@@ -1,0 +1,51 @@
+{
+  "title": "Custom curations search query",
+  "changed": "2022-11-02T12:47:29+11:00",
+  "created": "2022-11-02T12:47:29+11:00",
+  "type": "tide_search_listing",
+  "nid": "22dede11-10c0-111e1-1100-000000000330",
+  "showTopicTags": true,
+  "summary": "...",
+  "config": {
+    "searchListingConfig": {
+      "resultsPerPage": 10
+    },
+    "customQueryConfig": {
+      "function": "exampleQueryCurationsFunction"
+    },
+    "curationConfig": {
+      "items": [
+        {
+          "queryTerms": ["departments"],
+          "promotedItems": [25]
+        }
+      ]
+    },
+    "globalFilters": [
+      {
+        "terms": {
+          "type": [
+            "landing_page"
+          ]
+        }
+      },
+      {
+        "terms": {
+          "field_node_site": [
+            8888
+          ]
+        }
+      }
+    ],
+    "resultsConfig": {
+      "layout": {
+        "component": "TideSearchResultsList"
+      },
+      "item": {
+        "*": {
+          "component": "TideSearchResult"
+        }
+      }
+    }
+  }
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/search-query/page-curations.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/search-query/page-curations.json
@@ -1,0 +1,65 @@
+{
+  "title": "Curations search query",
+  "changed": "2022-11-02T12:47:29+11:00",
+  "created": "2022-11-02T12:47:29+11:00",
+  "type": "tide_search_listing",
+  "nid": "22dede11-10c0-111e1-1100-000000000330",
+  "showTopicTags": true,
+  "summary": "...",
+  "config": {
+    "searchListingConfig": {
+      "resultsPerPage": 10
+    },
+    "queryConfig": {
+      "multi_match": {
+        "query": "{{query}}",
+        "fields": [
+          "title",
+          "body"
+        ]
+      }
+    },
+    "curationConfig": {
+      "items": [
+        {
+          "queryTerms": ["edupay", "payroll login"],
+          "promotedItems": [50, 55]
+        },
+        {
+          "queryTerms": ["vicpol", "police force"],
+          "promotedItems": [99]
+        },
+        {
+          "queryTerms": ["edupay", "help"],
+          "promotedItems": [50, 60]
+        }
+      ]
+    },
+    "globalFilters": [
+      {
+        "terms": {
+          "type": [
+            "landing_page"
+          ]
+        }
+      },
+      {
+        "terms": {
+          "field_node_site": [
+            8888
+          ]
+        }
+      }
+    ],
+    "resultsConfig": {
+      "layout": {
+        "component": "TideSearchResultsList"
+      },
+      "item": {
+        "*": {
+          "component": "TideSearchResult"
+        }
+      }
+    }
+  }
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/search-query/request-curation-custom.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/search-query/request-curation-custom.json
@@ -1,0 +1,37 @@
+{
+  "query": {
+    "bool": {
+      "should": [
+        {
+          "multi_match": {
+            "query": "departments",
+            "fields": [
+              "title",
+              "content"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "id": [
+              25,
+              999
+            ],
+            "boost": 2
+          }
+        }
+      ],
+      "minimum_should_match": 1
+    }
+  },
+  "size": 10,
+  "from": 0,
+  "sort": [
+    {
+      "_score": "desc"
+    },
+    {
+      "_doc": "desc"
+    }
+  ]
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/search-query/request-curation-edupay.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/search-query/request-curation-edupay.json
@@ -1,0 +1,54 @@
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "terms": {
+            "type": [
+              "landing_page"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [
+              8888
+            ]
+          }
+        }
+      ],
+      "should": [
+        {
+          "multi_match": {
+            "query": "EduPay",
+            "fields": [
+              "title",
+              "body"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "nid": [
+              50,
+              55,
+              60
+            ],
+            "boost": 20
+          }
+        }
+      ],
+      "minimum_should_match": 1
+    }
+  },
+  "size": 10,
+  "from": 0,
+  "sort": [
+    {
+      "_score": "desc"
+    },
+    {
+      "_doc": "desc"
+    }
+  ]
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/search-query/request-curation-key.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/search-query/request-curation-key.json
@@ -1,0 +1,53 @@
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "terms": {
+            "type": [
+              "landing_page"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [
+              8888
+            ]
+          }
+        }
+      ],
+      "should": [
+        {
+          "multi_match": {
+            "query": "help",
+            "fields": [
+              "title",
+              "body"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "uid": [
+              50,
+              60
+            ],
+            "boost": 5
+          }
+        }
+      ],
+      "minimum_should_match": 1
+    }
+  },
+  "size": 10,
+  "from": 0,
+  "sort": [
+    {
+      "_score": "desc"
+    },
+    {
+      "_doc": "desc"
+    }
+  ]
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/search-query/request-curation-police.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/search-query/request-curation-police.json
@@ -1,0 +1,52 @@
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "terms": {
+            "type": [
+              "landing_page"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "field_node_site": [
+              8888
+            ]
+          }
+        }
+      ],
+      "should": [
+        {
+          "multi_match": {
+            "query": " police force! ",
+            "fields": [
+              "title",
+              "body"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "nid": [
+              99
+            ],
+            "boost": 20
+          }
+        }
+      ],
+      "minimum_should_match": 1
+    }
+  },
+  "size": 10,
+  "from": 0,
+  "sort": [
+    {
+      "_score": "desc"
+    },
+    {
+      "_doc": "desc"
+    }
+  ]
+}

--- a/examples/nuxt-app/test/fixtures/search-listing/search-query/response.json
+++ b/examples/nuxt-app/test/fixtures/search-listing/search-query/response.json
@@ -1,7 +1,7 @@
 {
   "hits": {
     "total": {
-      "value": 2,
+      "value": 4,
       "relation": "eq"
     },
     "hits": [

--- a/packages/ripple-test-utils/step_definitions/content-types/listing.ts
+++ b/packages/ripple-test-utils/step_definitions/content-types/listing.ts
@@ -644,6 +644,19 @@ Then(
 )
 
 Then(
+  'the search listing curation {string} is set to {string}',
+  (key: string, value: string) => {
+    cy.get('@pageFixture').then((response) => {
+      set(
+        response,
+        `config.curationConfig.${key}`,
+        isNaN(Number(value)) ? value : Number(value)
+      )
+    })
+  }
+)
+
+Then(
   'the search listing config has the following excludes added to source',
   (dataTable: DataTable) => {
     const table = dataTable.hashes()

--- a/packages/ripple-tide-search/components/TideSearchListingPage.vue
+++ b/packages/ripple-tide-search/components/TideSearchListingPage.vue
@@ -39,6 +39,7 @@ interface Props {
   sortOptions?: TideSearchListingConfig['sortOptions']
   customQueryConfig?: TideSearchListingConfig['customQueryConfig']
   queryConfig?: TideSearchListingConfig['queryConfig']
+  curationConfig?: TideSearchListingConfig['curationConfig']
   globalFilters?: TideSearchListingConfig['globalFilters']
   userFilters?: TideSearchListingConfig['userFilters']
   resultsLayout: TideSearchListingResultLayout
@@ -57,6 +58,7 @@ const props = withDefaults(defineProps<Props>(), {
   introText: '',
   globalFilters: () => [],
   userFilters: () => [],
+  curationConfig: undefined,
   customQueryConfig: undefined,
   queryConfig: () => ({
     multi_match: {
@@ -167,6 +169,7 @@ const {
 } = useTideSearch({
   customQueryConfig: props.customQueryConfig,
   queryConfig: props.queryConfig,
+  curationConfig: props.curationConfig,
   userFilters: props.userFilters,
   globalFilters: props.globalFilters,
   searchResultsMappingFn: props.searchResultsMappingFn,

--- a/packages/ripple-tide-search/components/global/TideCustomCollection.vue
+++ b/packages/ripple-tide-search/components/global/TideCustomCollection.vue
@@ -28,6 +28,7 @@ interface Props {
   introText?: string
   searchListingConfig?: TideSearchListingConfig['searchListingConfig']
   sortOptions?: TideSearchListingConfig['sortOptions']
+  curationConfig?: TideSearchListingConfig['curationConfig']
   customQueryConfig?: TideSearchListingConfig['customQueryConfig']
   queryConfig?: TideSearchListingConfig['queryConfig']
   globalFilters?: TideSearchListingConfig['globalFilters']
@@ -48,6 +49,7 @@ const props = withDefaults(defineProps<Props>(), {
   index: undefined,
   globalFilters: () => [],
   userFilters: () => [],
+  curationConfig: undefined,
   customQueryConfig: undefined,
   queryConfig: () => ({
     multi_match: {
@@ -234,6 +236,7 @@ const {
 } = useTideSearch({
   customQueryConfig: props.customQueryConfig,
   queryConfig: props.queryConfig,
+  curationConfig: props.curationConfig,
   userFilters: props.userFilters,
   globalFilters: props.globalFilters,
   searchResultsMappingFn,

--- a/packages/ripple-tide-search/components/global/TideTideSearchListing.vue
+++ b/packages/ripple-tide-search/components/global/TideTideSearchListing.vue
@@ -46,6 +46,7 @@ const searchResultsMappingFn = (item: any): TideSearchListingResultItem => {
     :title="page.title"
     :introText="page.introText"
     :searchListingConfig="page.config.searchListingConfig"
+    :curationConfig="page.config.curationConfig"
     :customQueryConfig="page.config.customQueryConfig"
     :queryConfig="page.config.queryConfig"
     :globalFilters="page.config.globalFilters"

--- a/packages/ripple-tide-search/types.ts
+++ b/packages/ripple-tide-search/types.ts
@@ -196,6 +196,15 @@ export type TideSearchRangeFilterValue = {
   to: string
 }
 
+export type TideSearchListingCurationConfig = {
+  key?: string
+  boost?: number
+  items: {
+    queryTerms: string[]
+    promotedItems: string[] | number[]
+  }[]
+}
+
 export type TideSearchListingTab = {
   title: string
   key: TideSearchListingTabKey
@@ -318,6 +327,10 @@ export type TideSearchListingConfig = {
      */
     filterByCurrentSite?: boolean
   }
+  /**
+   * @description Tabs to display, key needs to be one of TideSearchListingTabKey
+   */
+  curationConfig?: TideSearchListingCurationConfig
   /**
    * @description Tabs to display, key needs to be one of TideSearchListingTabKey
    */


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1134

### What I did
<!-- Summary of changes made in the Pull Request -->
- Adds support for search curations, this allows people to promote specific results when the user enters a specific term. For example; you might want to ensure that when people search for "how do i get paid?" that the "edupay" page is the first result. (The CMS mapping will come later).

### How to test
<!-- Summary of how to test the changes -->
- Search listing
  - FE: https://app.pr-227.reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/listing
  - Config: https://github.com/dpc-sdp/reference-sdp-vic-gov-au/blob/feature/search-curations/pages/listing.vue#L138
- Custom collection
  - BE: https://app.pr-227.reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/collection
  - Config: https://github.com/dpc-sdp/reference-sdp-vic-gov-au/blob/feature/search-curations/pages/collection.vue#L67

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
