### PR TITLE
[SD-1190] webform redirects

### DIFF
--- a/examples/nuxt-app/test/fixtures/landingpage/full-redirect.json
+++ b/examples/nuxt-app/test/fixtures/landingpage/full-redirect.json
@@ -1,0 +1,114 @@
+{
+  "title": "Redirect form",
+  "changed": "2022-12-08T12:05:35+11:00",
+  "created": "2022-12-01T11:36:44+11:00",
+  "type": "landing_page",
+  "nid": "48cc390c-3952-48b4-8b61-d6eacb10a7e6",
+  "sidebar": {
+    "contacts": [],
+    "relatedLinks": [],
+    "whatsNext": [],
+    "socialShareNetworks": ["Facebook", "X", "LinkedIn"],
+    "siteSectionNav": null
+  },
+  "topicTags": [
+    {
+      "text": "Demo Topic",
+      "url": "/topic/demo-topic"
+    }
+  ],
+  "summary": "A simple form",
+  "showHeroAcknowledgement": false,
+  "showInPageNav": false,
+  "showHeroImageCaption": false,
+  "showTopicTags": true,
+  "inPageNavHeadingLevel": "h2",
+  "background": "default",
+  "header": {
+    "title": "Redirect form",
+    "summary": "",
+    "links": {
+      "title": "",
+      "items": [],
+      "more": null
+    },
+    "backgroundImageCaption": "",
+    "theme": "default",
+    "logoImage": null,
+    "backgroundImage": null,
+    "cornerTopImage": null,
+    "cornerBottomImage": null,
+    "primaryAction": null,
+    "secondaryAction": null,
+    "secondaryActionLabel": ""
+  },
+  "primaryCampaign": null,
+  "secondaryCampaign": null,
+  "headerComponents": [],
+  "bodyComponents": [
+    {
+      "uuid": "7c8c065a-7212-4b56-9869-e8e38e762457",
+      "component": "TideLandingPageWebForm",
+      "id": 1930,
+      "title": null,
+      "props": {
+        "title": "A redirecting form",
+        "formId": "redirect_form",
+        "hideFormOnSubmit": false,
+        "redirectFormUrl": "/form-submitted",
+        "successMessageTitle": "Redirecting...",
+        "successMessageHTML": "Thank you! Your response has been submitted.",
+        "errorMessageTitle": "Form not submitted",
+        "errorMessageHTML": "We are experiencing a server error. Please try again, otherwise contact us.",
+        "schema": [
+          {
+            "$formkit": "RplFormText",
+            "key": "name",
+            "name": "name",
+            "label": "Name",
+            "id": "redirect_form_name",
+            "validation": [
+              [ "length", 0, 255 ],
+              [ "required" ]
+            ],
+            "validationMessages": {
+              "required": "What is your name?",
+              "length": "You can enter a maximum of 255 characters"
+            }
+          },
+          {
+            "$formkit": "RplFormEmail",
+            "key": "email",
+            "name": "email",
+            "label": "Email",
+            "id": "redirect_form_email",
+            "validation": [["email"], ["required"]],
+            "validationMessages": {
+              "required": "Email is required",
+              "accepted": "Email is required",
+              "email": "Email must be a valid email address"
+            }
+          },
+          {
+            "$formkit": "RplFormActions",
+            "key": "actions",
+            "name": "submit",
+            "variant": "filled",
+            "id": "redirect_form_actions",
+            "displayResetButton": false,
+            "validation": [],
+            "validationMessages": {
+              "required": "Submit is required",
+              "accepted": "Submit is required"
+            }
+          }
+        ],
+        "captchaConfig": {
+          "enabled": false,
+          "siteKey": "",
+          "siteIdentifier": ""
+        }
+      }
+    }
+  ]
+}

--- a/packages/ripple-tide-landing-page/mapping/components/webforms/webforms-mapping.ts
+++ b/packages/ripple-tide-landing-page/mapping/components/webforms/webforms-mapping.ts
@@ -15,17 +15,25 @@ const componentMapping = async (
   page: ApiPage,
   tidePageApi: TidePageApi
 ) => {
+  const redirectUrl =
+    field.field_paragraph_webform.settings?.confirmation_type === 'url' &&
+    field.field_paragraph_webform.settings?.confirmation_url
+
   return {
     title: field.field_paragraph_title,
     formId: field.field_paragraph_webform.meta.drupal_internal__target_id,
     hideFormOnSubmit:
       field.field_paragraph_webform.settings?.confirmation_type === 'inline',
+    redirectFormUrl: redirectUrl
+      ? field.field_paragraph_webform.settings?.confirmation_url
+      : null,
     successMessageTitle:
       field.field_paragraph_webform.settings?.confirmation_title ||
       'Form submitted',
-    successMessageHTML:
-      field.field_paragraph_webform.settings?.confirmation_message ||
-      'Thank you! Your response has been submitted.',
+    successMessageHTML: redirectUrl
+      ? 'Redirecting to confirmation page...'
+      : field.field_paragraph_webform.settings?.confirmation_message ||
+        'Thank you! Your response has been submitted.',
     errorMessageTitle: 'Form not submitted',
     errorMessageHTML:
       field.field_paragraph_webform.settings?.submission_exception_message ||

--- a/packages/ripple-tide-webform/types.ts
+++ b/packages/ripple-tide-webform/types.ts
@@ -33,6 +33,7 @@ export interface ApiWebForm {
   }
   settings?: {
     confirmation_type?: string
+    confirmation_url?: string
     confirmation_title?: string
     confirmation_message?: string
     submission_exception_message?: string


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1190

### What I did
<!-- Summary of changes made in the Pull Request -->
- Add support for redirecting a form upon successfull completion, this was flaged by design as a requirement for multistep forms although it just uses an exiting (non form wizard) CMS option so it works on any web form.
 
Notes: I've just implemented this the 'easy' way for now to get feedback, and by easy way I mean when you submit the form the form alert with display briefly with a notice that says "Redirecting to confirmation page...". The alternative is to not display the form alert at all, this would be a larger change though.

![wf-redirects](https://github.com/user-attachments/assets/b84e024b-4316-497f-b945-2983c41b415c)


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [x] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
