### PR TITLE
fix: move sanitize-html to regular dependencies

### DIFF
--- a/packages/nuxt-ripple/package.json
+++ b/packages/nuxt-ripple/package.json
@@ -20,9 +20,7 @@
     "@nuxtjs/robots": "^3.0.0",
     "@vueuse/core": "^9.13.0",
     "change-case": "^4.1.2",
-    "defu": "^6.1.2"
-  },
-  "devDependencies": {
+    "defu": "^6.1.2",
     "sanitize-html": "^2.17.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,7 +369,6 @@ importers:
       defu:
         specifier: ^6.1.2
         version: 6.1.4
-    devDependencies:
       sanitize-html:
         specifier: ^2.17.0
         version: 2.17.0


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

### What I did
<!-- Summary of changes made in the Pull Request -->
- The site builds are failing in lagoon right now, hoping this fixes that (move sanitize-html to regular dependencies)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
