### PR TITLE
[SD-1215] revert custom collection behaviour

### DIFF
--- a/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
+++ b/packages/ripple-tide-landing-page/components/global/TideLandingPage/ContentCollection.vue
@@ -48,7 +48,7 @@
 
 <script setup lang="ts">
 import { formatDate, useRuntimeConfig } from '#imports'
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { IContentCollectionDisplay } from '../../../mapping/components/content-collection/content-collection-mapping'
 import { stripMediaBaseUrl } from '@dpc-sdp/ripple-tide-api/utils'
 
@@ -107,17 +107,21 @@ const results = ref(null)
 const index = config.tide.elasticsearch.index
 const searchUrl = `${config.apiUrl}/api/tide/elasticsearch/${index}/_search`
 
-try {
-  const searchResponse = await $fetch(searchUrl, {
-    method: 'POST',
-    body: props.searchQuery
-  })
+const getCollectionItems = async () => {
+  try {
+    const searchResponse = await $fetch(searchUrl, {
+      method: 'POST',
+      body: props.searchQuery
+    })
 
-  results.value = searchResponse?.hits?.hits?.map(searchResultsMappingFn)
-} catch (e) {
-  trackError(e)
-  error.value = e
-} finally {
-  searchComplete.value = true
+    results.value = searchResponse?.hits?.hits?.map(searchResultsMappingFn)
+  } catch (e) {
+    trackError(e)
+    error.value = e
+  } finally {
+    searchComplete.value = true
+  }
 }
+
+onMounted(getCollectionItems)
 </script>


### PR DESCRIPTION
<!-- Add Jira ID Eg: SD-1234 or GitHub Issue Number eg: #123 -->

**Issue**: https://digital-vic.atlassian.net/browse/SD-1215

### What I did
<!-- Summary of changes made in the Pull Request -->
- The content collection component is rendering "Sorry! Something went wrong. Please try again later." server side, which is causing a hydration mismatch issue client side, Vue seems to be getting a little confused when dealing with this mismatch issue which results in the rpl-content class being applied to the results container which is then causing the layout issues. We need a fix for this in UAT envs today as it needs to be rolled out in tomorrows release (we'll need a `2.38.2` release). The simple solution for now is to just restore the previous behavior, i.e. previously content collection results were only fetched and displayed client side.

### How to test
<!-- Summary of how to test the changes -->
- Current develop: https://develop.vic-gov-au.sdp.delivery/testing-page-analytics#content-collection-component 
- This change: https://app.pr-1268.vic-gov-au.sdp4.sdp.vic.gov.au/testing-page-analytics#content-collection-component

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### For all PR's

- [ ] I've added relevant changes to the project Readme if needed
- [ ] I've updated the documentation site as needed
- [ ] I have added tests to cover my changes (if not applicable, please state why in a comment)

#### For new UI components only

- [ ] I have added a storybook story covering all variants
- [ ] I have checked a11y tab in storybook passes
- [ ] I have added cypress component tests (if the component is interactive)
- [ ] Any events are emitted on the event bus using `emitRplEvent`
